### PR TITLE
feat(barbarian): implement PHB 2014 barbarian class, levels 1-10

### DIFF
--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -264,9 +264,9 @@ describe('ChoicePicker totem-animal-choice', () => {
   it('selecting bear calls onDecide with totem-animal-choice decision', () => {
     const onDecide = vi.fn();
     render(<ChoicePicker choice={TOTEM_CHOICE} currentDecision={undefined} onDecide={onDecide} onClear={vi.fn()} />);
-    const radios = screen.getAllByRole('radio');
-    // bear is the first animal in TOTEM_ANIMALS
-    fireEvent.click(radios[0]);
+    const bearRadio = screen.getAllByRole('radio').find((r) => (r as HTMLInputElement).value === 'bear');
+    expect(bearRadio).toBeDefined();
+    fireEvent.click(bearRadio!);
     expect(onDecide).toHaveBeenCalledWith(TOTEM_CHOICE.choiceKey, {
       type: 'totem-animal-choice',
       animal: 'bear',
@@ -276,8 +276,9 @@ describe('ChoicePicker totem-animal-choice', () => {
   it('selecting eagle calls onDecide with eagle animal', () => {
     const onDecide = vi.fn();
     render(<ChoicePicker choice={TOTEM_CHOICE} currentDecision={undefined} onDecide={onDecide} onClear={vi.fn()} />);
-    const radios = screen.getAllByRole('radio');
-    fireEvent.click(radios[1]);
+    const eagleRadio = screen.getAllByRole('radio').find((r) => (r as HTMLInputElement).value === 'eagle');
+    expect(eagleRadio).toBeDefined();
+    fireEvent.click(eagleRadio!);
     expect(onDecide).toHaveBeenCalledWith(TOTEM_CHOICE.choiceKey, {
       type: 'totem-animal-choice',
       animal: 'eagle',
@@ -290,9 +291,12 @@ describe('ChoicePicker totem-animal-choice', () => {
       <ChoicePicker choice={TOTEM_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={vi.fn()} />
     );
     const radios = screen.getAllByRole('radio') as HTMLInputElement[];
-    expect(radios[0].checked).toBe(true); // bear
-    expect(radios[1].checked).toBe(false); // eagle
-    expect(radios[2].checked).toBe(false); // wolf
+    const bearRadio = radios.find((r) => r.value === 'bear');
+    const eagleRadio = radios.find((r) => r.value === 'eagle');
+    const wolfRadio = radios.find((r) => r.value === 'wolf');
+    expect(bearRadio?.checked).toBe(true);
+    expect(eagleRadio?.checked).toBe(false);
+    expect(wolfRadio?.checked).toBe(false);
   });
 
   it('persisted wolf decision renders wolf radio as checked', () => {
@@ -301,13 +305,14 @@ describe('ChoicePicker totem-animal-choice', () => {
       <ChoicePicker choice={TOTEM_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={vi.fn()} />
     );
     const radios = screen.getAllByRole('radio') as HTMLInputElement[];
-    expect(radios[2].checked).toBe(true); // wolf
+    const wolfRadio = radios.find((r) => r.value === 'wolf');
+    expect(wolfRadio?.checked).toBe(true);
   });
 
   it('renders animal name labels from translation keys', () => {
     render(<ChoicePicker choice={TOTEM_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />);
-    // mock t() returns last segment: 'totemAnimals.bear.name' → 'name'
-    // All three labels will have 'name' text since mock returns last segment
+    // The mock t() returns the last key segment; all three animal name keys share the same
+    // last segment ('name'), so three elements with that text appear.
     const labels = screen.getAllByText('name');
     expect(labels).toHaveLength(3);
   });

--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -4,6 +4,7 @@ import { ChoicePicker } from '@/components/character-builder/ChoicePicker';
 import type { PendingChoice } from '@/types/resolved';
 import type { ChoiceKey, ChoiceDecision } from '@/types/choices';
 import type { BundleCategory } from '@/types/items';
+import type { SourceTag } from '@/types/sources';
 
 vi.mock('react-i18next', () => ({
   useTranslation: () => ({
@@ -231,5 +232,83 @@ describe('ChoicePicker bundle-choice', () => {
       <ChoicePicker choice={SLOTTED_CHOICE} currentDecision={twoWeaponDecision} onDecide={vi.fn()} onClear={vi.fn()} />
     );
     expect(container.querySelectorAll('[data-slot="select-trigger"]').length).toBe(2);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ChoicePicker — totem-animal-choice branch
+// ---------------------------------------------------------------------------
+
+const TOTEM_SOURCE: SourceTag = { origin: 'subclass', id: 'totemwarrior', classId: 'barbarian', level: 3 };
+
+const TOTEM_CHOICE: PendingChoice & { type: 'totem-animal-choice' } = {
+  type: 'totem-animal-choice',
+  choiceKey: 'totem-animal-choice:class:barbarian:0' as ChoiceKey,
+  source: TOTEM_SOURCE,
+  featureIdPrefix: 'totemwarrior-totem-spirit',
+};
+
+describe('ChoicePicker totem-animal-choice', () => {
+  it('renders three radio options (bear, eagle, wolf)', () => {
+    render(<ChoicePicker choice={TOTEM_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />);
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(3);
+  });
+
+  it('no radio is checked when currentDecision is undefined', () => {
+    render(<ChoicePicker choice={TOTEM_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />);
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios.every((r) => !r.checked)).toBe(true);
+  });
+
+  it('selecting bear calls onDecide with totem-animal-choice decision', () => {
+    const onDecide = vi.fn();
+    render(<ChoicePicker choice={TOTEM_CHOICE} currentDecision={undefined} onDecide={onDecide} onClear={vi.fn()} />);
+    const radios = screen.getAllByRole('radio');
+    // bear is the first animal in TOTEM_ANIMALS
+    fireEvent.click(radios[0]);
+    expect(onDecide).toHaveBeenCalledWith(TOTEM_CHOICE.choiceKey, {
+      type: 'totem-animal-choice',
+      animal: 'bear',
+    });
+  });
+
+  it('selecting eagle calls onDecide with eagle animal', () => {
+    const onDecide = vi.fn();
+    render(<ChoicePicker choice={TOTEM_CHOICE} currentDecision={undefined} onDecide={onDecide} onClear={vi.fn()} />);
+    const radios = screen.getAllByRole('radio');
+    fireEvent.click(radios[1]);
+    expect(onDecide).toHaveBeenCalledWith(TOTEM_CHOICE.choiceKey, {
+      type: 'totem-animal-choice',
+      animal: 'eagle',
+    });
+  });
+
+  it('persisted bear decision renders the bear radio as checked', () => {
+    const currentDecision: ChoiceDecision = { type: 'totem-animal-choice', animal: 'bear' };
+    render(
+      <ChoicePicker choice={TOTEM_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios[0].checked).toBe(true); // bear
+    expect(radios[1].checked).toBe(false); // eagle
+    expect(radios[2].checked).toBe(false); // wolf
+  });
+
+  it('persisted wolf decision renders wolf radio as checked', () => {
+    const currentDecision: ChoiceDecision = { type: 'totem-animal-choice', animal: 'wolf' };
+    render(
+      <ChoicePicker choice={TOTEM_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios[2].checked).toBe(true); // wolf
+  });
+
+  it('renders animal name labels from translation keys', () => {
+    render(<ChoicePicker choice={TOTEM_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />);
+    // mock t() returns last segment: 'totemAnimals.bear.name' → 'name'
+    // All three labels will have 'name' text since mock returns last segment
+    const labels = screen.getAllByText('name');
+    expect(labels).toHaveLength(3);
   });
 });

--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -245,7 +245,6 @@ const TOTEM_CHOICE: PendingChoice & { type: 'totem-animal-choice' } = {
   type: 'totem-animal-choice',
   choiceKey: 'totem-animal-choice:class:barbarian:0' as ChoiceKey,
   source: TOTEM_SOURCE,
-  featureIdPrefix: 'totemwarrior-totem-spirit',
 };
 
 describe('ChoicePicker totem-animal-choice', () => {

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -212,6 +212,7 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear }: Cho
                   type="radio"
                   id={radioId}
                   name={`choice-totem-${choice.choiceKey}`}
+                  value={animal}
                   checked={isSelected}
                   onChange={() => onDecide(choice.choiceKey, { type: 'totem-animal-choice', animal })}
                   className="mt-0.5 size-4 text-primary"

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -11,6 +11,7 @@ import { getBundleDef, getBundleNameKey, getItemsForSlot, resolveBundleRef } fro
 import type { ChoiceDecision, ChoiceKey } from '@/types/choices';
 import type { BundleSlot, ItemDef, SlotFilter } from '@/types/items';
 import type { PendingChoice } from '@/types/resolved';
+import { TOTEM_ANIMALS, type TotemAnimalId } from '@/types/grants';
 import { getGrantIcon } from '@/lib/class-icons';
 import type { TFunction } from 'i18next';
 import type { LucideIcon } from 'lucide-react';
@@ -181,6 +182,45 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear }: Cho
                 />
                 <Label htmlFor={`choice-tool-${choice.choiceKey}-${toolId}`} className="flex-1 cursor-pointer">
                   {t(`tools.${toolId}`)}
+                </Label>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  if (choice.type === 'totem-animal-choice') {
+    const currentAnimal = currentDecision?.type === 'totem-animal-choice' ? currentDecision.animal : undefined;
+
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">{tc('characterBuilder.pendingChoices.totemAnimalChoice')}</p>
+        <div className="space-y-2">
+          {TOTEM_ANIMALS.map((animal: TotemAnimalId) => {
+            const isSelected = currentAnimal === animal;
+            const radioId = `choice-totem-${choice.choiceKey}-${animal}`;
+            return (
+              <div
+                key={animal}
+                className={`flex items-start gap-3 rounded-md border p-3 transition-colors hover:bg-muted/50 ${
+                  isSelected ? 'border-primary bg-primary/5' : 'border-border'
+                }`}
+              >
+                <input
+                  type="radio"
+                  id={radioId}
+                  name={`choice-totem-${choice.choiceKey}`}
+                  checked={isSelected}
+                  onChange={() => onDecide(choice.choiceKey, { type: 'totem-animal-choice', animal })}
+                  className="mt-0.5 size-4 text-primary"
+                />
+                <Label htmlFor={radioId} className="flex-1 cursor-pointer">
+                  <div className={`text-sm ${isSelected ? 'font-semibold' : ''}`}>
+                    {t(`totemAnimals.${animal}.name`)}
+                  </div>
+                  <p className="text-xs text-muted-foreground mt-1">{t(`totemAnimals.${animal}.description`)}</p>
                 </Label>
               </div>
             );

--- a/src/components/character-sheet/PendingChoicesPanel.tsx
+++ b/src/components/character-sheet/PendingChoicesPanel.tsx
@@ -121,6 +121,16 @@ function useAllChoiceGrants() {
       }
     }
 
+    // totem-animal-choice grants
+    for (const { grant, source } of collectGrantsByType(bundles, 'totem-animal-choice')) {
+      allGrants.push({
+        type: 'totem-animal-choice',
+        choiceKey: grant.key,
+        source,
+        featureIdPrefix: grant.featureIdPrefix,
+      });
+    }
+
     return allGrants;
   }, [bundles, buildChoices]);
 }

--- a/src/components/character-sheet/PendingChoicesPanel.tsx
+++ b/src/components/character-sheet/PendingChoicesPanel.tsx
@@ -127,7 +127,6 @@ function useAllChoiceGrants() {
         type: 'totem-animal-choice',
         choiceKey: grant.key,
         source,
-        featureIdPrefix: grant.featureIdPrefix,
       });
     }
 

--- a/src/lib/resolver/combat.test.ts
+++ b/src/lib/resolver/combat.test.ts
@@ -124,7 +124,7 @@ describe('resolveSpeed', () => {
 
 describe('resolveAc', () => {
   it('returns default AC 10 + DEX modifier when no grants', () => {
-    const result = resolveAc(NO_BUNDLES, 2);
+    const result = resolveAc(NO_BUNDLES, 2, 0, 0);
     expect(result.effective).toBe(12);
     expect(result.calculations).toHaveLength(0);
     expect(result.bonuses).toHaveLength(0);
@@ -138,7 +138,7 @@ describe('resolveAc', () => {
       },
     ];
     // DEX 14 → mod +2, armored AC = 10 + 2 = 12
-    const result = resolveAc(bundles, 2);
+    const result = resolveAc(bundles, 2, 0, 0);
     expect(result.calculations).toHaveLength(1);
     expect(result.calculations[0].mode).toBe('armored');
     expect(result.calculations[0].baseValue).toBe(12);
@@ -152,7 +152,7 @@ describe('resolveAc', () => {
         grants: [{ type: 'armor-class', calculation: { mode: 'natural', baseAc: 14 } }],
       },
     ];
-    const result = resolveAc(bundles, 0);
+    const result = resolveAc(bundles, 0, 0, 0);
     expect(result.calculations[0].mode).toBe('natural');
     expect(result.calculations[0].baseValue).toBe(14);
     expect(result.effective).toBe(14);
@@ -169,24 +169,52 @@ describe('resolveAc', () => {
       },
     ];
     // armored: 10 + 0 = 10, bonus +2 = 12
-    const result = resolveAc(bundles, 0);
+    const result = resolveAc(bundles, 0, 0, 0);
     expect(result.effective).toBe(12);
     expect(result.bonuses).toHaveLength(1);
   });
 
-  it('unarmored mode: 10 + DEX modifier', () => {
+  it('unarmored barbarian formula: 10 + DEX + CON modifier', () => {
     const bundles: GrantBundle[] = [
       {
-        source: { origin: 'class', id: 'fighter', level: 1 },
+        source: { origin: 'class', id: 'barbarian', level: 1 },
         grants: [{ type: 'armor-class', calculation: { mode: 'unarmored', formula: 'barbarian' } }],
       },
     ];
-    // DEX 16 → mod +3, unarmored AC = 10 + 3 = 13
-    const result = resolveAc(bundles, 3);
+    // DEX 16 → mod +3, CON 14 → mod +2, unarmored AC = 10 + 3 + 2 = 15
+    const result = resolveAc(bundles, 3, 2, 0);
     expect(result.calculations).toHaveLength(1);
     expect(result.calculations[0].mode).toBe('unarmored');
+    expect(result.calculations[0].baseValue).toBe(15);
+    expect(result.effective).toBe(15);
+  });
+
+  it('unarmored barbarian formula with zero CON: 10 + DEX only', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'barbarian', level: 1 },
+        grants: [{ type: 'armor-class', calculation: { mode: 'unarmored', formula: 'barbarian' } }],
+      },
+    ];
+    // DEX 16 → mod +3, CON 10 → mod 0, AC = 13
+    const result = resolveAc(bundles, 3, 0, 0);
     expect(result.calculations[0].baseValue).toBe(13);
     expect(result.effective).toBe(13);
+  });
+
+  it('unarmored monk formula: 10 + DEX + WIS modifier', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'monk', level: 1 },
+        grants: [{ type: 'armor-class', calculation: { mode: 'unarmored', formula: 'monk' } }],
+      },
+    ];
+    // DEX 14 → mod +2, WIS 16 → mod +3, unarmored AC = 10 + 2 + 3 = 15
+    const result = resolveAc(bundles, 2, 0, 3);
+    expect(result.calculations).toHaveLength(1);
+    expect(result.calculations[0].mode).toBe('unarmored');
+    expect(result.calculations[0].baseValue).toBe(15);
+    expect(result.effective).toBe(15);
   });
 
   it('equipped chain mail returns effective AC 16 (ignores DEX)', () => {
@@ -197,7 +225,7 @@ describe('resolveAc', () => {
       },
     ];
     // DEX 16 → mod +3, but chain mail ignores DEX (maxDexBonus 0, baseAc 16)
-    const result = resolveAc(bundles, 3, { totalBase: 16, shieldBonus: 0 });
+    const result = resolveAc(bundles, 3, 0, 0, { totalBase: 16, shieldBonus: 0 });
     expect(result.effective).toBe(16);
     expect(result.calculations[0].baseValue).toBe(16);
   });
@@ -212,7 +240,7 @@ describe('resolveAc', () => {
         ],
       },
     ];
-    const result = resolveAc(bundles, 3, { totalBase: 16, shieldBonus: 0 });
+    const result = resolveAc(bundles, 3, 0, 0, { totalBase: 16, shieldBonus: 0 });
     expect(result.effective).toBe(17);
   });
 
@@ -223,7 +251,7 @@ describe('resolveAc', () => {
         grants: [{ type: 'armor-class', calculation: { mode: 'armored' } }],
       },
     ];
-    const result = resolveAc(bundles, 3, { totalBase: 16, shieldBonus: 2 });
+    const result = resolveAc(bundles, 3, 0, 0, { totalBase: 16, shieldBonus: 2 });
     expect(result.effective).toBe(18);
     expect(result.bonuses).toHaveLength(1);
     expect(result.bonuses[0].value).toBe(2);
@@ -241,7 +269,7 @@ describe('resolveAc', () => {
         grants: [{ type: 'armor-class', calculation: { mode: 'natural', baseAc: 15 } }],
       },
     ];
-    const result = resolveAc(bundles, 2);
+    const result = resolveAc(bundles, 2, 0, 0);
     expect(result.calculations).toHaveLength(2);
     expect(result.effective).toBe(15);
   });

--- a/src/lib/resolver/combat.test.ts
+++ b/src/lib/resolver/combat.test.ts
@@ -71,6 +71,52 @@ describe('resolveHp', () => {
     // Level 2: 7 + (roll 4 + (-1)) = 7 + 3 = 10
     expect(resolveHp(bundles, [null, 4], -1, 2).max).toBe(10);
   });
+
+  it('hp-bonus grant adds perLevel * level on top of base HP', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'barbarian', level: 1 },
+        grants: [{ type: 'hit-die', die: 12 }],
+      },
+      {
+        source: { origin: 'race', id: 'dwarf-hill' },
+        grants: [{ type: 'hp-bonus', perLevel: 1 }],
+      },
+    ];
+    // Level 1: die 12 + CON 0 = 12, plus 1×1 = 13
+    expect(resolveHp(bundles, [], 0, 1).max).toBe(13);
+    // Level 5 with null rolls: 12 + 4×(avg 7 + 0) = 12 + 28 = 40, plus 1×5 = 45
+    expect(resolveHp(bundles, [null, null, null, null, null], 0, 5).max).toBe(45);
+  });
+
+  it('hp-bonus stacks when multiple grants present', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'fighter', level: 1 },
+        grants: [{ type: 'hit-die', die: 10 }],
+      },
+      {
+        source: { origin: 'race', id: 'dwarf-hill' },
+        grants: [{ type: 'hp-bonus', perLevel: 1 }],
+      },
+      {
+        source: { origin: 'feat', id: 'tough' },
+        grants: [{ type: 'hp-bonus', perLevel: 2 }],
+      },
+    ];
+    // Level 3 with rolled 6, 6: 10 + 6 + 6 = 22, plus (1+2)×3 = 9 → 31
+    expect(resolveHp(bundles, [null, 6, 6], 0, 3).max).toBe(31);
+  });
+
+  it('hp-bonus does not apply when level is 0', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'race', id: 'dwarf-hill' },
+        grants: [{ type: 'hp-bonus', perLevel: 1 }],
+      },
+    ];
+    expect(resolveHp(bundles, [], 0, 0).max).toBe(0);
+  });
 });
 
 describe('resolveSpeed', () => {

--- a/src/lib/resolver/combat.ts
+++ b/src/lib/resolver/combat.ts
@@ -60,6 +60,8 @@ export function resolveSpeed(bundles: readonly GrantBundle[]): Readonly<Partial<
 export function resolveAc(
   bundles: readonly GrantBundle[],
   dexModifier: number,
+  conModifier: number,
+  wisModifier: number,
   equippedArmor?: { readonly totalBase: number | null; readonly shieldBonus: number } | null
 ): ResolvedArmorClass {
   const acGrants = collectGrantsByType(bundles, 'armor-class');
@@ -83,10 +85,23 @@ export function resolveAc(
       case 'natural':
         calculations.push({ mode: 'natural', baseValue: calc.baseAc, source });
         break;
-      case 'unarmored':
-        // Unarmored: 10 + DEX modifier. TODO: barbarian formula should add CON modifier, monk should add WIS modifier.
-        calculations.push({ mode: 'unarmored', baseValue: 10 + dexModifier, source });
+      case 'unarmored': {
+        let baseValue: number;
+        switch (calc.formula) {
+          case 'barbarian':
+            baseValue = 10 + dexModifier + conModifier;
+            break;
+          case 'monk':
+            baseValue = 10 + dexModifier + wisModifier;
+            break;
+          default: {
+            const _exhaustiveFormula: never = calc.formula;
+            throw new Error(`Unhandled unarmored formula: ${JSON.stringify(_exhaustiveFormula)}`);
+          }
+        }
+        calculations.push({ mode: 'unarmored', baseValue, source });
         break;
+      }
       default: {
         const _exhaustive: never = calc;
         throw new Error(`Unhandled AC calculation mode: ${JSON.stringify(_exhaustive)}`);

--- a/src/lib/resolver/combat.ts
+++ b/src/lib/resolver/combat.ts
@@ -30,6 +30,11 @@ export function resolveHp(
     max += value + conModifier;
   }
 
+  const hpBonusGrants = collectGrantsByType(bundles, 'hp-bonus');
+  for (const { grant } of hpBonusGrants) {
+    max += grant.perLevel * level;
+  }
+
   return { max };
 }
 

--- a/src/lib/resolver/features.test.ts
+++ b/src/lib/resolver/features.test.ts
@@ -73,7 +73,7 @@ describe('resolveFeatures', () => {
     expect(result[0].source.origin).toBe('class');
   });
 
-  it('non-class source wins if it appears after a class entry with the same id when ranks are equal (rank 0 vs 0)', () => {
+  it('first entry wins when ranks are equal (first-writer-wins tiebreaker)', () => {
     const bundles: readonly GrantBundle[] = [
       {
         source: { origin: 'background', id: 'soldier' },
@@ -85,9 +85,27 @@ describe('resolveFeatures', () => {
       },
     ];
     const result = resolveFeatures(bundles);
-    // Both rank 0, second one wins via `rank >= existing.rank`
+    // Both rank 0 — first entry wins (strict > comparison, not >=)
     expect(result).toHaveLength(1);
-    expect(result[0].feature.usesCount).toBe(2);
+    expect(result[0].feature.usesCount).toBe(1);
+    expect(result[0].source).toMatchObject({ origin: 'background', id: 'soldier' });
+  });
+
+  it('first-writer-wins on ties: same rank from two class sources keeps the first emission', () => {
+    // Same class level (rank 3) from two distinct class entries — first one wins
+    const bundles: readonly GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'barbarian', level: 3 },
+        grants: [{ type: 'feature', feature: { id: 'contested-feature', usesCount: 10 } }],
+      },
+      {
+        source: { origin: 'class', id: 'barbarian', level: 3 },
+        grants: [{ type: 'feature', feature: { id: 'contested-feature', usesCount: 99 } }],
+      },
+    ];
+    const result = resolveFeatures(bundles);
+    expect(result).toHaveLength(1);
+    expect(result[0].feature.usesCount).toBe(10);
   });
 
   it('higher subclass level beats lower class level for same feature id', () => {

--- a/src/lib/resolver/features.test.ts
+++ b/src/lib/resolver/features.test.ts
@@ -1,0 +1,109 @@
+import { describe, it, expect } from 'vitest';
+import { resolveFeatures } from '@/lib/resolver/features';
+import type { GrantBundle } from '@/types/sources';
+
+describe('resolveFeatures', () => {
+  it('returns empty array when no bundles have feature grants', () => {
+    const result = resolveFeatures([]);
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns a single entry for a single feature grant', () => {
+    const bundles: readonly GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'barbarian', level: 1 },
+        grants: [{ type: 'feature', feature: { id: 'barbarian-rage', usesCount: 2 } }],
+      },
+    ];
+    const result = resolveFeatures(bundles);
+    expect(result).toHaveLength(1);
+    expect(result[0].feature.id).toBe('barbarian-rage');
+    expect(result[0].feature.usesCount).toBe(2);
+  });
+
+  it('dedupes duplicate ids, keeping the higher-level class entry', () => {
+    const bundles: readonly GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'barbarian', level: 1 },
+        grants: [{ type: 'feature', feature: { id: 'barbarian-rage', usesCount: 2 } }],
+      },
+      {
+        source: { origin: 'class', id: 'barbarian', level: 3 },
+        grants: [{ type: 'feature', feature: { id: 'barbarian-rage', usesCount: 3 } }],
+      },
+    ];
+    const result = resolveFeatures(bundles);
+    expect(result).toHaveLength(1);
+    expect(result[0].feature.usesCount).toBe(3);
+    expect(result[0].source).toMatchObject({ origin: 'class', level: 3 });
+  });
+
+  it('keeps both entries when feature ids are distinct', () => {
+    const bundles: readonly GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'barbarian', level: 1 },
+        grants: [
+          { type: 'feature', feature: { id: 'barbarian-rage' } },
+          { type: 'feature', feature: { id: 'barbarian-unarmored-defense' } },
+        ],
+      },
+    ];
+    const result = resolveFeatures(bundles);
+    expect(result).toHaveLength(2);
+    const ids = result.map((r) => r.feature.id);
+    expect(ids).toContain('barbarian-rage');
+    expect(ids).toContain('barbarian-unarmored-defense');
+  });
+
+  it('non-class sources (origin !== class/subclass) rank as 0 and are overridden by any class entry', () => {
+    const bundles: readonly GrantBundle[] = [
+      {
+        source: { origin: 'race', id: 'human' },
+        grants: [{ type: 'feature', feature: { id: 'shared-feature', usesCount: 0 } }],
+      },
+      {
+        source: { origin: 'class', id: 'fighter', level: 1 },
+        grants: [{ type: 'feature', feature: { id: 'shared-feature', usesCount: 1 } }],
+      },
+    ];
+    const result = resolveFeatures(bundles);
+    expect(result).toHaveLength(1);
+    // class entry (level 1, rank 1) beats race entry (rank 0)
+    expect(result[0].feature.usesCount).toBe(1);
+    expect(result[0].source.origin).toBe('class');
+  });
+
+  it('non-class source wins if it appears after a class entry with the same id when ranks are equal (rank 0 vs 0)', () => {
+    const bundles: readonly GrantBundle[] = [
+      {
+        source: { origin: 'background', id: 'soldier' },
+        grants: [{ type: 'feature', feature: { id: 'shared-feature', usesCount: 1 } }],
+      },
+      {
+        source: { origin: 'race', id: 'human' },
+        grants: [{ type: 'feature', feature: { id: 'shared-feature', usesCount: 2 } }],
+      },
+    ];
+    const result = resolveFeatures(bundles);
+    // Both rank 0, second one wins via `rank >= existing.rank`
+    expect(result).toHaveLength(1);
+    expect(result[0].feature.usesCount).toBe(2);
+  });
+
+  it('higher subclass level beats lower class level for same feature id', () => {
+    const bundles: readonly GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'barbarian', level: 1 },
+        grants: [{ type: 'feature', feature: { id: 'barbarian-rage', usesCount: 2 } }],
+      },
+      {
+        source: { origin: 'subclass', id: 'berserker', classId: 'barbarian', level: 6 },
+        grants: [{ type: 'feature', feature: { id: 'barbarian-rage', usesCount: 4 } }],
+      },
+    ];
+    const result = resolveFeatures(bundles);
+    expect(result).toHaveLength(1);
+    expect(result[0].feature.usesCount).toBe(4);
+    expect(result[0].source.origin).toBe('subclass');
+  });
+});

--- a/src/lib/resolver/features.ts
+++ b/src/lib/resolver/features.ts
@@ -3,8 +3,13 @@ import type { ResolvedFeature } from '@/types/resolved';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
 
 export function resolveFeatures(bundles: readonly GrantBundle[]): readonly ResolvedFeature[] {
-  return collectGrantsByType(bundles, 'feature').map(({ grant, source }) => ({
-    feature: grant.feature,
-    source,
-  }));
+  const byId = new Map<string, { entry: ResolvedFeature; rank: number }>();
+  for (const { grant, source } of collectGrantsByType(bundles, 'feature')) {
+    const rank = source.origin === 'class' || source.origin === 'subclass' ? source.level : 0;
+    const existing = byId.get(grant.feature.id);
+    if (!existing || rank >= existing.rank) {
+      byId.set(grant.feature.id, { entry: { feature: grant.feature, source }, rank });
+    }
+  }
+  return Array.from(byId.values()).map((v) => v.entry);
 }

--- a/src/lib/resolver/features.ts
+++ b/src/lib/resolver/features.ts
@@ -7,7 +7,7 @@ export function resolveFeatures(bundles: readonly GrantBundle[]): readonly Resol
   for (const { grant, source } of collectGrantsByType(bundles, 'feature')) {
     const rank = source.origin === 'class' || source.origin === 'subclass' ? source.level : 0;
     const existing = byId.get(grant.feature.id);
-    if (!existing || rank >= existing.rank) {
+    if (!existing || rank > existing.rank) {
       byId.set(grant.feature.id, { entry: { feature: grant.feature, source }, rank });
     }
   }

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -6,6 +6,7 @@ import { DND_SKILLS } from '@/lib/dnd-helpers';
 import { collectBundles } from '@/lib/sources';
 import type { CharacterBuild } from '@/types/choices';
 import { createChoiceKey } from '@/types/choices';
+import type { ChoiceDecision } from '@/types/choices';
 import type { GrantBundle, SubclassId } from '@/types/sources';
 
 const baseInput: ResolverInput = {
@@ -568,5 +569,284 @@ describe('Human Fighter L5 integration', () => {
     const pendingTypes = result.pendingChoices.map((c) => c.type);
     expect(pendingTypes).toContain('asi');
     expect(pendingTypes).toContain('subclass');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Barbarian integration tests
+// ---------------------------------------------------------------------------
+
+describe('Human Barbarian L1 integration', () => {
+  // STR 15, DEX 14, CON 16 → after human +1 each: STR 16, DEX 15, CON 17
+  // DEX modifier = 2, CON modifier = 3
+  // Unarmored AC = 10 + 2 + 3 = 15
+  // HP max = 12 (hit die) + 3 (CON mod) = 15
+  const barbarianL1Build: CharacterBuild = {
+    raceId: 'human',
+    backgroundId: 'soldier',
+    baseAbilities: { str: 15, dex: 14, con: 16, int: 8, wis: 10, cha: 12 },
+    abilityMethod: 'standard-array',
+    choices: {
+      'skill-choice:class:barbarian:0': { type: 'skill-choice', skills: ['athletics', 'intimidation'] },
+      'language-choice:race:human:0': { type: 'language-choice', languages: ['elvish'] },
+      'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+      'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      // Leave both bundle-choice grants unresolved to test pending choices
+    },
+    levels: [{ classId: 'barbarian' as ClassId, classLevel: 1, hpRoll: null }],
+    feats: [],
+    activeItems: [],
+  };
+
+  const { bundles } = collectBundles(barbarianL1Build);
+
+  const input: ResolverInput = {
+    baseAbilities: barbarianL1Build.baseAbilities,
+    level: 1,
+    bundles,
+    choices: barbarianL1Build.choices,
+    levels: barbarianL1Build.levels,
+  };
+
+  it('unarmored AC = 10 + DEX modifier (2) + CON modifier (3) = 15', () => {
+    const result = resolveCharacter(input);
+    expect(result.armorClass.effective).toBe(15);
+  });
+
+  it('features contain barbarian-rage with usesCount: 2', () => {
+    const result = resolveCharacter(input);
+    const rageFeature = result.features.find((f) => f.feature.id === 'barbarian-rage');
+    expect(rageFeature).toBeDefined();
+    expect(rageFeature!.feature.usesCount).toBe(2);
+  });
+
+  it('features contain barbarian-unarmored-defense', () => {
+    const result = resolveCharacter(input);
+    const featureIds = result.features.map((f) => f.feature.id);
+    expect(featureIds).toContain('barbarian-unarmored-defense');
+  });
+
+  it('HP max = 12 (barbarian hit die) + 3 (CON mod) = 15', () => {
+    const result = resolveCharacter(input);
+    expect(result.hitDie[0].die).toBe(12);
+    expect(result.hitPoints.max).toBe(15);
+  });
+
+  it('two bundle-choice grants appear in pendingChoices when not resolved', () => {
+    const result = resolveCharacter(input);
+    const bundlePending = result.pendingChoices.filter((c) => c.type === 'bundle-choice');
+    expect(bundlePending).toHaveLength(2);
+  });
+});
+
+describe('Human Barbarian L3 + Totem Warrior + Bear integration', () => {
+  const subclassKey = createChoiceKey('subclass', 'class', 'barbarian', 0);
+  const totemL3Key = createChoiceKey('totem-animal-choice', 'class', 'barbarian', 0);
+
+  const barbarianL3Build: CharacterBuild = {
+    raceId: 'human',
+    backgroundId: 'soldier',
+    baseAbilities: { str: 15, dex: 14, con: 16, int: 8, wis: 10, cha: 12 },
+    abilityMethod: 'standard-array',
+    choices: {
+      'skill-choice:class:barbarian:0': { type: 'skill-choice', skills: ['athletics', 'intimidation'] },
+      'language-choice:race:human:0': { type: 'language-choice', languages: ['elvish'] },
+      'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+      'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      [subclassKey]: { type: 'subclass' as const, subclassId: 'totemwarrior' as SubclassId },
+      [totemL3Key]: { type: 'totem-animal-choice' as const, animal: 'bear' as const },
+      'bundle-choice:class:barbarian:0': {
+        type: 'bundle-choice' as const,
+        bundleId: 'barbarian-greataxe',
+        slotPicks: {},
+      },
+      'bundle-choice:class:barbarian:1': {
+        type: 'bundle-choice' as const,
+        bundleId: 'two-handaxes',
+        slotPicks: {},
+      },
+    },
+    levels: [
+      { classId: 'barbarian' as ClassId, classLevel: 1, hpRoll: null },
+      { classId: 'barbarian' as ClassId, classLevel: 2, hpRoll: 8 },
+      { classId: 'barbarian' as ClassId, classLevel: 3, hpRoll: 7 },
+    ],
+    feats: [],
+    activeItems: [],
+  };
+
+  const { bundles } = collectBundles(barbarianL3Build);
+
+  const input: ResolverInput = {
+    baseAbilities: barbarianL3Build.baseAbilities,
+    level: 3,
+    bundles,
+    choices: barbarianL3Build.choices,
+    levels: barbarianL3Build.levels,
+  };
+
+  it('features contain totemwarrior-totem-spirit-bear', () => {
+    const result = resolveCharacter(input);
+    const featureIds = result.features.map((f) => f.feature.id);
+    expect(featureIds).toContain('totemwarrior-totem-spirit-bear');
+  });
+
+  it('pendingChoices does NOT contain an entry for the L3 totem choiceKey', () => {
+    const result = resolveCharacter(input);
+    const totemPending = result.pendingChoices.filter(
+      (c) => c.type === 'totem-animal-choice' && c.choiceKey === totemL3Key
+    );
+    expect(totemPending).toHaveLength(0);
+  });
+
+  it('barbarian-rage has usesCount: 3 (dedupe keeps L3 re-emission over L1)', () => {
+    const result = resolveCharacter(input);
+    const rageFeature = result.features.find((f) => f.feature.id === 'barbarian-rage');
+    expect(rageFeature).toBeDefined();
+    expect(rageFeature!.feature.usesCount).toBe(3);
+  });
+
+  it('no pending choices remain when all choices resolved', () => {
+    const result = resolveCharacter(input);
+    expect(result.pendingChoices).toHaveLength(0);
+  });
+});
+
+describe('Human Barbarian L6 + Totem Warrior (no totem decisions) integration', () => {
+  const subclassKey = createChoiceKey('subclass', 'class', 'barbarian', 0);
+  const totemL3Key = createChoiceKey('totem-animal-choice', 'class', 'barbarian', 0);
+  const totemL6Key = createChoiceKey('totem-animal-choice', 'class', 'barbarian', 1);
+
+  const barbarianL6Build: CharacterBuild = {
+    raceId: 'human',
+    backgroundId: 'soldier',
+    baseAbilities: { str: 15, dex: 14, con: 16, int: 8, wis: 10, cha: 12 },
+    abilityMethod: 'standard-array',
+    choices: {
+      'skill-choice:class:barbarian:0': { type: 'skill-choice', skills: ['athletics', 'intimidation'] },
+      'language-choice:race:human:0': { type: 'language-choice', languages: ['elvish'] },
+      'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+      'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      [subclassKey]: { type: 'subclass' as const, subclassId: 'totemwarrior' as SubclassId },
+      'bundle-choice:class:barbarian:0': {
+        type: 'bundle-choice' as const,
+        bundleId: 'barbarian-greataxe',
+        slotPicks: {},
+      },
+      'bundle-choice:class:barbarian:1': {
+        type: 'bundle-choice' as const,
+        bundleId: 'two-handaxes',
+        slotPicks: {},
+      },
+      // Intentionally omit both totem-animal-choice decisions
+    },
+    levels: [
+      { classId: 'barbarian' as ClassId, classLevel: 1, hpRoll: null },
+      { classId: 'barbarian' as ClassId, classLevel: 2, hpRoll: 8 },
+      { classId: 'barbarian' as ClassId, classLevel: 3, hpRoll: 7 },
+      { classId: 'barbarian' as ClassId, classLevel: 4, hpRoll: 6 },
+      { classId: 'barbarian' as ClassId, classLevel: 5, hpRoll: 9 },
+      { classId: 'barbarian' as ClassId, classLevel: 6, hpRoll: 8 },
+    ],
+    feats: [],
+    activeItems: [],
+  };
+
+  const { bundles } = collectBundles(barbarianL6Build);
+
+  const input: ResolverInput = {
+    baseAbilities: barbarianL6Build.baseAbilities,
+    level: 6,
+    bundles,
+    choices: barbarianL6Build.choices,
+    levels: barbarianL6Build.levels,
+  };
+
+  it('pendingChoices contains TWO totem-animal-choice entries', () => {
+    const result = resolveCharacter(input);
+    const totemPending = result.pendingChoices.filter((c) => c.type === 'totem-animal-choice');
+    expect(totemPending).toHaveLength(2);
+  });
+
+  it('the two totem-animal-choice pending entries have distinct choiceKeys', () => {
+    const result = resolveCharacter(input);
+    const totemPending = result.pendingChoices.filter((c) => c.type === 'totem-animal-choice');
+    const keys = totemPending.map((c) => c.choiceKey);
+    expect(keys).toContain(totemL3Key);
+    expect(keys).toContain(totemL6Key);
+  });
+
+  it('the two totem-animal-choice pending entries have distinct featureIdPrefixes', () => {
+    const result = resolveCharacter(input);
+    const totemPending = result.pendingChoices.filter(
+      (c): c is Extract<(typeof result.pendingChoices)[number], { type: 'totem-animal-choice' }> =>
+        c.type === 'totem-animal-choice'
+    );
+    const prefixes = totemPending.map((c) => c.featureIdPrefix);
+    expect(prefixes).toContain('totemwarrior-totem-spirit');
+    expect(prefixes).toContain('totemwarrior-aspect-of-the-beast');
+  });
+});
+
+describe('Totem Warrior — invalid totem decision falls through to pending', () => {
+  const subclassKey = createChoiceKey('subclass', 'class', 'barbarian', 0);
+  const totemL3Key = createChoiceKey('totem-animal-choice', 'class', 'barbarian', 0);
+
+  const invalidDecision = { type: 'totem-animal-choice', animal: 'cat' } as unknown as ChoiceDecision;
+
+  const barbarianL3Build: CharacterBuild = {
+    raceId: 'human',
+    backgroundId: 'soldier',
+    baseAbilities: { str: 15, dex: 14, con: 16, int: 8, wis: 10, cha: 12 },
+    abilityMethod: 'standard-array',
+    choices: {
+      'skill-choice:class:barbarian:0': { type: 'skill-choice', skills: ['athletics', 'intimidation'] },
+      'language-choice:race:human:0': { type: 'language-choice', languages: ['elvish'] },
+      'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+      'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      [subclassKey]: { type: 'subclass' as const, subclassId: 'totemwarrior' as SubclassId },
+      [totemL3Key]: invalidDecision,
+      'bundle-choice:class:barbarian:0': {
+        type: 'bundle-choice' as const,
+        bundleId: 'barbarian-greataxe',
+        slotPicks: {},
+      },
+      'bundle-choice:class:barbarian:1': {
+        type: 'bundle-choice' as const,
+        bundleId: 'two-handaxes',
+        slotPicks: {},
+      },
+    },
+    levels: [
+      { classId: 'barbarian' as ClassId, classLevel: 1, hpRoll: null },
+      { classId: 'barbarian' as ClassId, classLevel: 2, hpRoll: 8 },
+      { classId: 'barbarian' as ClassId, classLevel: 3, hpRoll: 7 },
+    ],
+    feats: [],
+    activeItems: [],
+  };
+
+  const { bundles } = collectBundles(barbarianL3Build);
+
+  const input: ResolverInput = {
+    baseAbilities: barbarianL3Build.baseAbilities,
+    level: 3,
+    bundles,
+    choices: barbarianL3Build.choices,
+    levels: barbarianL3Build.levels,
+  };
+
+  it('does NOT synthesize totemwarrior-totem-spirit-cat feature', () => {
+    const result = resolveCharacter(input);
+    const featureIds = result.features.map((f) => f.feature.id);
+    expect(featureIds).not.toContain('totemwarrior-totem-spirit-cat');
+  });
+
+  it('emits a pending totem-animal-choice entry for the invalid decision key', () => {
+    const result = resolveCharacter(input);
+    const totemPending = result.pendingChoices.filter(
+      (c) => c.type === 'totem-animal-choice' && c.choiceKey === totemL3Key
+    );
+    expect(totemPending).toHaveLength(1);
   });
 });

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -776,15 +776,12 @@ describe('Human Barbarian L6 + Totem Warrior (no totem decisions) integration', 
     expect(keys).toContain(totemL6Key);
   });
 
-  it('the two totem-animal-choice pending entries have distinct featureIdPrefixes', () => {
+  it('the two totem-animal-choice pending entries have distinct choiceKeys (one per grant)', () => {
     const result = resolveCharacter(input);
-    const totemPending = result.pendingChoices.filter(
-      (c): c is Extract<(typeof result.pendingChoices)[number], { type: 'totem-animal-choice' }> =>
-        c.type === 'totem-animal-choice'
-    );
-    const prefixes = totemPending.map((c) => c.featureIdPrefix);
-    expect(prefixes).toContain('totemwarrior-totem-spirit');
-    expect(prefixes).toContain('totemwarrior-aspect-of-the-beast');
+    const totemPending = result.pendingChoices.filter((c) => c.type === 'totem-animal-choice');
+    // Each grant emits its own pending entry identified by its unique choiceKey
+    expect(totemPending.map((c) => c.choiceKey)).toContain(totemL3Key);
+    expect(totemPending.map((c) => c.choiceKey)).toContain(totemL6Key);
   });
 });
 

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -847,3 +847,107 @@ describe('Totem Warrior — invalid totem decision falls through to pending', ()
     expect(totemPending).toHaveLength(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Hill Dwarf integration tests
+// ---------------------------------------------------------------------------
+
+describe('Hill Dwarf Barbarian L3 integration', () => {
+  const subclassKey = createChoiceKey('subclass', 'class', 'barbarian', 0);
+  const dwarfToolKey = createChoiceKey('tool-choice', 'race', 'dwarf-hill', 0);
+
+  // Base abilities chosen so Hill Dwarf's +2 CON and +1 WIS are observable over defaults
+  const hillDwarfL3Build: CharacterBuild = {
+    raceId: 'dwarf-hill',
+    backgroundId: 'soldier',
+    baseAbilities: { str: 15, dex: 14, con: 16, int: 8, wis: 10, cha: 12 },
+    abilityMethod: 'standard-array',
+    choices: {
+      'skill-choice:class:barbarian:0': { type: 'skill-choice', skills: ['athletics', 'intimidation'] },
+      'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+      'language-choice:background:soldier:0': { type: 'language-choice', languages: ['elvish'] },
+      [subclassKey]: { type: 'subclass' as const, subclassId: 'berserker' as SubclassId },
+      'bundle-choice:class:barbarian:0': {
+        type: 'bundle-choice' as const,
+        bundleId: 'barbarian-greataxe',
+        slotPicks: {},
+      },
+      'bundle-choice:class:barbarian:1': {
+        type: 'bundle-choice' as const,
+        bundleId: 'two-handaxes',
+        slotPicks: {},
+      },
+      // Intentionally leave dwarf tool-choice unresolved to verify it surfaces as pending
+    },
+    levels: [
+      { classId: 'barbarian' as ClassId, classLevel: 1, hpRoll: null },
+      { classId: 'barbarian' as ClassId, classLevel: 2, hpRoll: 8 },
+      { classId: 'barbarian' as ClassId, classLevel: 3, hpRoll: 7 },
+    ],
+    feats: [],
+    activeItems: [],
+  };
+
+  const { bundles } = collectBundles(hillDwarfL3Build);
+
+  const input: ResolverInput = {
+    baseAbilities: hillDwarfL3Build.baseAbilities,
+    level: 3,
+    bundles,
+    choices: hillDwarfL3Build.choices,
+    levels: hillDwarfL3Build.levels,
+  };
+
+  it('CON total = 18 (base 16 + dwarf +2)', () => {
+    const result = resolveCharacter(input);
+    expect(result.abilities.con.total).toBe(18);
+    expect(result.abilities.con.modifier).toBe(4);
+  });
+
+  it('WIS total = 11 (base 10 + hill subrace +1)', () => {
+    const result = resolveCharacter(input);
+    expect(result.abilities.wis.total).toBe(11);
+  });
+
+  // HP = L1 max die (12) + CON mod (4) = 16
+  //    + L2 roll 8 + CON mod 4 = 12 → 28
+  //    + L3 roll 7 + CON mod 4 = 11 → 39
+  //    + Dwarven Toughness 1 × 3 levels = 3 → 42
+  it('HP max = 42 (hit die + CON mods + Dwarven Toughness)', () => {
+    const result = resolveCharacter(input);
+    expect(result.hitPoints.max).toBe(42);
+  });
+
+  it('features include darkvision, dwarven resilience, stonecunning, and dwarven toughness', () => {
+    const result = resolveCharacter(input);
+    const featureIds = result.features.map((f) => f.feature.id);
+    expect(featureIds).toEqual(
+      expect.arrayContaining([
+        'dwarf-darkvision',
+        'dwarf-dwarven-resilience',
+        'dwarf-stonecunning',
+        'dwarf-dwarven-toughness',
+      ])
+    );
+  });
+
+  it('resistances include poison with race source', () => {
+    const result = resolveCharacter(input);
+    const poisonResistance = result.resistances.find((r) => r.value === 'poison');
+    expect(poisonResistance).toBeDefined();
+    expect(poisonResistance!.sources).toContainEqual({ origin: 'race', id: 'dwarf-hill' });
+  });
+
+  it('walk speed is 25 (dwarf)', () => {
+    const result = resolveCharacter(input);
+    expect(result.speed.walk?.value).toBe(25);
+  });
+
+  it('pendingChoices contains the unresolved dwarf tool-choice', () => {
+    const result = resolveCharacter(input);
+    const dwarfToolPending = result.pendingChoices.filter(
+      (c) => c.type === 'tool-choice' && c.choiceKey === dwarfToolKey
+    );
+    expect(dwarfToolPending).toHaveLength(1);
+  });
+});

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -203,7 +203,6 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
         type: 'totem-animal-choice',
         choiceKey: grant.key,
         source,
-        featureIdPrefix: grant.featureIdPrefix,
       });
     }
   }

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -8,6 +8,7 @@ import type { GrantBundle, SourceTag } from '@/types/sources';
 import type { ChoiceKey, ChoiceDecision } from '@/types/choices';
 import type { ResolvedCharacter, PendingChoice } from '@/types/resolved';
 import type { HitDie } from '@/types/grants';
+import { TOTEM_ANIMALS } from '@/types/grants';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
 import { resolveAbilities } from '@/lib/resolver/abilities';
 import { resolveSavingThrows, resolveSkills, resolveProficiencies } from '@/lib/resolver/proficiencies';
@@ -45,11 +46,12 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
   const abilities = resolveAbilities(baseAbilities, bundles, choices);
   const conModifier = abilities.con.modifier;
   const dexModifier = abilities.dex.modifier;
+  const wisModifier = abilities.wis.modifier;
 
   const savingThrows = resolveSavingThrows(abilities, bundles, proficiencyBonus);
   const skills = resolveSkills(abilities, bundles, proficiencyBonus, choices);
   const proficiencies = resolveProficiencies(bundles, choices);
-  const features = resolveFeatures(bundles);
+  const resolvedFeatures = resolveFeatures(bundles);
   const hitPoints = resolveHp(bundles, hpRolls, conModifier, level);
   const speed = resolveSpeed(bundles);
   const spellcasting = resolveSpellcasting(bundles);
@@ -60,7 +62,7 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
       ? resolveEquipmentFromPersisted(input.persistedItems)
       : resolveEquipment(bundles, choices, equippedItemIds);
   const equippedArmorAc = resolveEquippedArmorAc(equipmentResult.items, dexModifier);
-  const armorClass = resolveAc(bundles, dexModifier, equippedArmorAc);
+  const armorClass = resolveAc(bundles, dexModifier, conModifier, wisModifier, equippedArmorAc);
 
   // Extract chosen fighting style IDs for attack resolver, validating against each grant's from list.
   // Stale persisted decisions containing removed style IDs are filtered out and re-prompted.
@@ -186,6 +188,27 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
       });
     }
   }
+
+  // Totem animal choices — either synthesize a resolved feature or emit a pending choice
+  const totemFeatures: import('@/types/resolved').ResolvedFeature[] = [];
+  for (const { grant, source } of collectGrantsByType(bundles, 'totem-animal-choice')) {
+    const decision = choices[grant.key];
+    if (decision?.type === 'totem-animal-choice' && (TOTEM_ANIMALS as readonly string[]).includes(decision.animal)) {
+      totemFeatures.push({
+        feature: { id: `${grant.featureIdPrefix}-${decision.animal}` },
+        source,
+      });
+    } else {
+      pendingChoices.push({
+        type: 'totem-animal-choice',
+        choiceKey: grant.key,
+        source,
+        featureIdPrefix: grant.featureIdPrefix,
+      });
+    }
+  }
+
+  const features = [...resolvedFeatures, ...totemFeatures];
 
   return {
     abilities,

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -193,7 +193,7 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
   const totemFeatures: import('@/types/resolved').ResolvedFeature[] = [];
   for (const { grant, source } of collectGrantsByType(bundles, 'totem-animal-choice')) {
     const decision = choices[grant.key];
-    if (decision?.type === 'totem-animal-choice' && (TOTEM_ANIMALS as readonly string[]).includes(decision.animal)) {
+    if (decision?.type === 'totem-animal-choice' && TOTEM_ANIMALS.includes(decision.animal)) {
       totemFeatures.push({
         feature: { id: `${grant.featureIdPrefix}-${decision.animal}` },
         source,

--- a/src/lib/sources/bundles.ts
+++ b/src/lib/sources/bundles.ts
@@ -67,6 +67,36 @@ export const BUNDLE_CATALOG: readonly BundleDef[] = [
     contents: [{ itemId: 'handaxe', quantity: 2 }],
     slots: [],
   },
+  {
+    id: 'barbarian-greataxe',
+    category: 'melee-weapon',
+    contents: [{ itemId: 'greataxe', quantity: 1 }],
+    slots: [],
+  },
+  {
+    id: 'any-martial-melee',
+    category: 'melee-weapon',
+    contents: [],
+    slots: [
+      {
+        slotKey: 'weapon',
+        quantity: 1,
+        filter: { kind: 'weapon', category: 'martial', range: 'melee' },
+      },
+    ],
+  },
+  {
+    id: 'any-simple-weapon',
+    category: 'ranged-weapon',
+    contents: [],
+    slots: [
+      {
+        slotKey: 'weapon',
+        quantity: 1,
+        filter: { kind: 'weapon', category: 'simple' },
+      },
+    ],
+  },
 ];
 
 export function getBundleDef(id: string): BundleDef | undefined {

--- a/src/lib/sources/classes.test.ts
+++ b/src/lib/sources/classes.test.ts
@@ -3,6 +3,85 @@ import { getClassSource } from '@/lib/sources';
 import { createChoiceKey } from '@/types/choices';
 import type { ClassId } from '@/lib/dnd-helpers';
 
+describe('Barbarian class source', () => {
+  const source = getClassSource('barbarian' as ClassId);
+
+  it('source is defined', () => {
+    expect(source).toBeDefined();
+  });
+
+  it('has exactly 20 levels', () => {
+    expect(source?.levels).toHaveLength(20);
+  });
+
+  it('level 1 grants hit-die d12', () => {
+    const level1 = source?.levels[0];
+    const hitDie = level1?.grants.find((g) => g.type === 'hit-die');
+    expect(hitDie).toBeDefined();
+    if (hitDie?.type === 'hit-die') {
+      expect(hitDie.die).toBe(12);
+    }
+  });
+
+  it('level 1 grants unarmored AC with barbarian formula', () => {
+    const level1 = source?.levels[0];
+    const acGrant = level1?.grants.find((g) => g.type === 'armor-class');
+    expect(acGrant).toBeDefined();
+    if (acGrant?.type === 'armor-class') {
+      expect(acGrant.calculation.mode).toBe('unarmored');
+      if (acGrant.calculation.mode === 'unarmored') {
+        expect(acGrant.calculation.formula).toBe('barbarian');
+      }
+    }
+  });
+
+  it('level 1 rage has usesCount 2', () => {
+    const level1 = source?.levels[0];
+    const rageGrant = level1?.grants.find((g) => g.type === 'feature' && g.feature.id === 'barbarian-rage');
+    expect(rageGrant).toBeDefined();
+    if (rageGrant?.type === 'feature') {
+      expect(rageGrant.feature.usesCount).toBe(2);
+    }
+  });
+
+  it('level 3 grants a subclass choice for barbarian', () => {
+    const level3 = source?.levels[2];
+    const subclassGrant = level3?.grants.find((g) => g.type === 'subclass');
+    expect(subclassGrant).toBeDefined();
+    if (subclassGrant?.type === 'subclass') {
+      expect(subclassGrant.classId).toBe('barbarian');
+      expect(subclassGrant.key).toBe(createChoiceKey('subclass', 'class', 'barbarian', 0));
+    }
+  });
+
+  it('level 3 rage re-emit has usesCount 3', () => {
+    const level3 = source?.levels[2];
+    const rageGrant = level3?.grants.find((g) => g.type === 'feature' && g.feature.id === 'barbarian-rage');
+    expect(rageGrant).toBeDefined();
+    if (rageGrant?.type === 'feature') {
+      expect(rageGrant.feature.usesCount).toBe(3);
+    }
+  });
+
+  it('level 5 grants barbarian-fast-movement and walk speed 40', () => {
+    const level5 = source?.levels[4];
+    const fastMovement = level5?.grants.find((g) => g.type === 'feature' && g.feature.id === 'barbarian-fast-movement');
+    expect(fastMovement).toBeDefined();
+    const speedGrant = level5?.grants.find((g) => g.type === 'speed');
+    expect(speedGrant).toBeDefined();
+    if (speedGrant?.type === 'speed') {
+      expect(speedGrant.mode).toBe('walk');
+      expect(speedGrant.value).toBe(40);
+    }
+  });
+
+  it('levels 11-20 are all empty', () => {
+    for (let i = 10; i < 20; i++) {
+      expect(source?.levels[i]?.grants).toHaveLength(0);
+    }
+  });
+});
+
 describe('Fighter class levels 2–10 grant structures', () => {
   const source = getClassSource('fighter' as ClassId);
 

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -5,6 +5,11 @@ import { FIGHTING_STYLE_IDS } from '@/lib/dnd-helpers';
 const EMPTY_LEVEL = { grants: [] } as const;
 
 export const CLASS_SOURCES: readonly ClassSource[] = [
+  /**
+   * Rage is re-emitted at L1/L3/L6/L9 with scaling usesCount; resolveFeatures
+   * in src/lib/resolver/features.ts dedupes by feature id, keeping the
+   * highest-rank (latest level) source.
+   */
   {
     id: 'barbarian',
     primaryAbility: 'str',
@@ -14,7 +19,6 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       suggestedBackground: 'outlander',
     }),
     levels: [
-      // Level 1
       {
         grants: [
           { type: 'hit-die', die: 12 },
@@ -51,23 +55,19 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
           { type: 'equipment', itemId: 'explorers-pack', quantity: 1 },
         ],
       },
-      // Level 2
       {
         grants: [
           { type: 'feature', feature: { id: 'barbarian-reckless-attack' } },
           { type: 'feature', feature: { id: 'barbarian-danger-sense' } },
         ],
       },
-      // Level 3 — subclass + rage scaling (dedupe keeps this usesCount: 3 over L1's 2)
       {
         grants: [
           { type: 'subclass', classId: 'barbarian', key: createChoiceKey('subclass', 'class', 'barbarian', 0) },
           { type: 'feature', feature: { id: 'barbarian-rage', usesPerRest: 'long', usesCount: 3 } },
         ],
       },
-      // Level 4 — ASI
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'barbarian', 0), points: 2 }] },
-      // Level 5 — Extra Attack + Fast Movement
       {
         grants: [
           { type: 'feature', feature: { id: 'barbarian-extra-attack' } },
@@ -75,15 +75,11 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
           { type: 'speed', mode: 'walk', value: 40 },
         ],
       },
-      // Level 6 — rage uses up (dedupe keeps usesCount: 4 over L3's 3)
       {
         grants: [{ type: 'feature', feature: { id: 'barbarian-rage', usesPerRest: 'long', usesCount: 4 } }],
       },
-      // Level 7 — Feral Instinct
       { grants: [{ type: 'feature', feature: { id: 'barbarian-feral-instinct' } }] },
-      // Level 8 — ASI
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'barbarian', 1), points: 2 }] },
-      // Level 9 — Brutal Critical + rage re-emit (usesCount: 4, same as L6)
       {
         grants: [
           { type: 'feature', feature: { id: 'barbarian-brutal-critical-1' } },
@@ -92,7 +88,6 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       },
       // Level 10 — path feature handled by subclass entries
       EMPTY_LEVEL,
-      // Levels 11-20
       EMPTY_LEVEL,
       EMPTY_LEVEL,
       EMPTY_LEVEL,

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -6,6 +6,106 @@ const EMPTY_LEVEL = { grants: [] } as const;
 
 export const CLASS_SOURCES: readonly ClassSource[] = [
   {
+    id: 'barbarian',
+    primaryAbility: 'str',
+    quickBuild: makeQuickBuild({
+      highestAbility: ['str'],
+      secondaryAbility: 'con',
+      suggestedBackground: 'outlander',
+    }),
+    levels: [
+      // Level 1
+      {
+        grants: [
+          { type: 'hit-die', die: 12 },
+          { type: 'proficiency', category: 'armor', id: 'light' },
+          { type: 'proficiency', category: 'armor', id: 'medium' },
+          { type: 'proficiency', category: 'armor', id: 'shields' },
+          { type: 'proficiency', category: 'weapon', id: 'simple' },
+          { type: 'proficiency', category: 'weapon', id: 'martial' },
+          { type: 'proficiency', category: 'saving-throw', id: 'str' },
+          { type: 'proficiency', category: 'saving-throw', id: 'con' },
+          {
+            type: 'proficiency-choice',
+            category: 'skill',
+            key: createChoiceKey('skill-choice', 'class', 'barbarian', 0),
+            count: 2,
+            from: ['animalhandling', 'athletics', 'intimidation', 'nature', 'perception', 'survival'],
+          },
+          { type: 'armor-class', calculation: { mode: 'unarmored', formula: 'barbarian' } },
+          { type: 'feature', feature: { id: 'barbarian-rage', usesPerRest: 'long', usesCount: 2 } },
+          { type: 'feature', feature: { id: 'barbarian-unarmored-defense' } },
+          {
+            type: 'bundle-choice',
+            key: createChoiceKey('bundle-choice', 'class', 'barbarian', 0),
+            category: 'melee-weapon',
+            bundleIds: ['barbarian-greataxe', 'any-martial-melee'],
+          },
+          {
+            type: 'bundle-choice',
+            key: createChoiceKey('bundle-choice', 'class', 'barbarian', 1),
+            category: 'ranged-weapon',
+            bundleIds: ['two-handaxes', 'any-simple-weapon'],
+          },
+          { type: 'equipment', itemId: 'javelin', quantity: 4 },
+          { type: 'equipment', itemId: 'explorers-pack', quantity: 1 },
+        ],
+      },
+      // Level 2
+      {
+        grants: [
+          { type: 'feature', feature: { id: 'barbarian-reckless-attack' } },
+          { type: 'feature', feature: { id: 'barbarian-danger-sense' } },
+        ],
+      },
+      // Level 3 — subclass + rage scaling (dedupe keeps this usesCount: 3 over L1's 2)
+      {
+        grants: [
+          { type: 'subclass', classId: 'barbarian', key: createChoiceKey('subclass', 'class', 'barbarian', 0) },
+          { type: 'feature', feature: { id: 'barbarian-rage', usesPerRest: 'long', usesCount: 3 } },
+        ],
+      },
+      // Level 4 — ASI
+      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'barbarian', 0), points: 2 }] },
+      // Level 5 — Extra Attack + Fast Movement
+      {
+        grants: [
+          { type: 'feature', feature: { id: 'barbarian-extra-attack' } },
+          { type: 'feature', feature: { id: 'barbarian-fast-movement' } },
+          { type: 'speed', mode: 'walk', value: 40 },
+        ],
+      },
+      // Level 6 — rage uses up (dedupe keeps usesCount: 4 over L3's 3)
+      {
+        grants: [{ type: 'feature', feature: { id: 'barbarian-rage', usesPerRest: 'long', usesCount: 4 } }],
+      },
+      // Level 7 — Feral Instinct
+      { grants: [{ type: 'feature', feature: { id: 'barbarian-feral-instinct' } }] },
+      // Level 8 — ASI
+      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'barbarian', 1), points: 2 }] },
+      // Level 9 — Brutal Critical + rage re-emit (usesCount: 4, same as L6)
+      {
+        grants: [
+          { type: 'feature', feature: { id: 'barbarian-brutal-critical-1' } },
+          { type: 'feature', feature: { id: 'barbarian-rage', usesPerRest: 'long', usesCount: 4 } },
+        ],
+      },
+      // Level 10 — path feature handled by subclass entries
+      EMPTY_LEVEL,
+      // Levels 11-20
+      EMPTY_LEVEL,
+      EMPTY_LEVEL,
+      EMPTY_LEVEL,
+      EMPTY_LEVEL,
+      EMPTY_LEVEL,
+      EMPTY_LEVEL,
+      EMPTY_LEVEL,
+      EMPTY_LEVEL,
+      EMPTY_LEVEL,
+      EMPTY_LEVEL,
+    ],
+  },
+  {
     id: 'fighter',
     primaryAbility: 'str',
     quickBuild: makeQuickBuild({

--- a/src/lib/sources/races.test.ts
+++ b/src/lib/sources/races.test.ts
@@ -91,3 +91,96 @@ describe('Mountain Dwarf race source', () => {
     expect(resistance).toEqual({ type: 'resistance', damageType: 'poison' });
   });
 });
+
+describe('Hill Dwarf race source', () => {
+  const source = getRaceSource('dwarf-hill' as RaceId);
+
+  it('source is defined', () => {
+    expect(source).toBeDefined();
+  });
+
+  it('has correct defaults', () => {
+    expect(source?.defaultSize).toBe('medium');
+    expect(source?.defaultSpeed).toBe(25);
+  });
+
+  it('grants +2 CON and +1 WIS', () => {
+    const abilityBonuses = source?.grants.filter((g) => g.type === 'ability-bonus');
+    expect(abilityBonuses).toEqual(
+      expect.arrayContaining([
+        { type: 'ability-bonus', ability: 'con', bonus: 2 },
+        { type: 'ability-bonus', ability: 'wis', bonus: 1 },
+      ])
+    );
+    expect(abilityBonuses).toHaveLength(2);
+  });
+
+  it('grants 25 ft walk speed', () => {
+    const speed = source?.grants.find((g) => g.type === 'speed');
+    expect(speed).toEqual({ type: 'speed', mode: 'walk', value: 25 });
+  });
+
+  it('grants Common and Dwarvish languages', () => {
+    const languages = source?.grants.filter((g) => g.type === 'proficiency' && g.category === 'language');
+    expect(languages).toHaveLength(2);
+    expect(languages).toEqual(
+      expect.arrayContaining([
+        { type: 'proficiency', category: 'language', id: 'common' },
+        { type: 'proficiency', category: 'language', id: 'dwarvish' },
+      ])
+    );
+  });
+
+  it('does not grant armor proficiency (Mountain-only)', () => {
+    const armor = source?.grants.filter((g) => g.type === 'proficiency' && g.category === 'armor');
+    expect(armor).toHaveLength(0);
+  });
+
+  it('grants dwarven weapon proficiencies', () => {
+    const weapons = source?.grants.filter((g) => g.type === 'proficiency' && g.category === 'weapon');
+    expect(weapons).toEqual(
+      expect.arrayContaining([
+        { type: 'proficiency', category: 'weapon', id: 'battleaxe' },
+        { type: 'proficiency', category: 'weapon', id: 'handaxe' },
+        { type: 'proficiency', category: 'weapon', id: 'lighthammer' },
+        { type: 'proficiency', category: 'weapon', id: 'warhammer' },
+      ])
+    );
+    expect(weapons).toHaveLength(4);
+  });
+
+  it('grants tool proficiency choice from artisan tools', () => {
+    const toolChoice = source?.grants.find((g) => g.type === 'proficiency-choice');
+    expect(toolChoice).toEqual({
+      type: 'proficiency-choice',
+      category: 'tool',
+      key: createChoiceKey('tool-choice', 'race', 'dwarf-hill', 0),
+      count: 1,
+      from: ['smithstools', 'brewersupplies', 'masonstools'],
+    });
+  });
+
+  it('grants darkvision, dwarven resilience, stonecunning, and dwarven toughness features', () => {
+    const features = source?.grants.filter((g) => g.type === 'feature');
+    expect(features).toHaveLength(4);
+    const featureIds = features?.map((g) => g.type === 'feature' && g.feature.id);
+    expect(featureIds).toEqual(
+      expect.arrayContaining([
+        'dwarf-darkvision',
+        'dwarf-dwarven-resilience',
+        'dwarf-stonecunning',
+        'dwarf-dwarven-toughness',
+      ])
+    );
+  });
+
+  it('grants poison resistance', () => {
+    const resistance = source?.grants.find((g) => g.type === 'resistance');
+    expect(resistance).toEqual({ type: 'resistance', damageType: 'poison' });
+  });
+
+  it('grants Dwarven Toughness hp-bonus of 1 per level', () => {
+    const hpBonus = source?.grants.find((g) => g.type === 'hp-bonus');
+    expect(hpBonus).toEqual({ type: 'hp-bonus', perLevel: 1 });
+  });
+});

--- a/src/lib/sources/races.ts
+++ b/src/lib/sources/races.ts
@@ -70,7 +70,8 @@ export const RACE_SOURCES: readonly RaceSource[] = [
         feature: {
           id: 'dwarf-dwarven-resilience',
           name: 'Dwarven Resilience',
-          description: 'You have advantage on saving throws against poison.',
+          description:
+            'You have advantage on saving throws against poison, and you have resistance against poison damage.',
         },
       },
       // Stonecunning
@@ -81,6 +82,75 @@ export const RACE_SOURCES: readonly RaceSource[] = [
           name: 'Stonecunning',
           description:
             'Whenever you make an Intelligence (History) check related to the origin of stonework, you are considered proficient in the History skill and add double your proficiency bonus.',
+        },
+      },
+    ],
+  },
+  {
+    id: 'dwarf-hill',
+    defaultSize: 'medium',
+    defaultSpeed: 25,
+    grants: [
+      // Ability Score Increase: +2 CON (base dwarf), +1 WIS (hill subrace)
+      { type: 'ability-bonus', ability: 'con', bonus: 2 },
+      { type: 'ability-bonus', ability: 'wis', bonus: 1 },
+      // Speed: 25 ft (not reduced by heavy armor)
+      { type: 'speed', mode: 'walk', value: 25 },
+      // Languages: Common, Dwarvish
+      { type: 'proficiency', category: 'language', id: 'common' },
+      { type: 'proficiency', category: 'language', id: 'dwarvish' },
+      // Dwarven Combat Training: battleaxe, handaxe, lighthammer, warhammer
+      { type: 'proficiency', category: 'weapon', id: 'battleaxe' },
+      { type: 'proficiency', category: 'weapon', id: 'handaxe' },
+      { type: 'proficiency', category: 'weapon', id: 'lighthammer' },
+      { type: 'proficiency', category: 'weapon', id: 'warhammer' },
+      // Tool Proficiency: choose one from smith's tools, brewer's supplies, mason's tools
+      {
+        type: 'proficiency-choice',
+        category: 'tool',
+        key: createChoiceKey('tool-choice', 'race', 'dwarf-hill', 0),
+        count: 1,
+        from: ['smithstools', 'brewersupplies', 'masonstools'],
+      },
+      // Darkvision (60 ft)
+      {
+        type: 'feature',
+        feature: {
+          id: 'dwarf-darkvision',
+          name: 'Darkvision',
+          description:
+            'You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light.',
+        },
+      },
+      // Dwarven Resilience: advantage on saves vs. poison, resistance to poison damage
+      { type: 'resistance', damageType: 'poison' },
+      {
+        type: 'feature',
+        feature: {
+          id: 'dwarf-dwarven-resilience',
+          name: 'Dwarven Resilience',
+          description:
+            'You have advantage on saving throws against poison, and you have resistance against poison damage.',
+        },
+      },
+      // Stonecunning
+      {
+        type: 'feature',
+        feature: {
+          id: 'dwarf-stonecunning',
+          name: 'Stonecunning',
+          description:
+            'Whenever you make an Intelligence (History) check related to the origin of stonework, you are considered proficient in the History skill and add double your proficiency bonus.',
+        },
+      },
+      // Dwarven Toughness (hill subrace): +1 HP per level
+      { type: 'hp-bonus', perLevel: 1 },
+      {
+        type: 'feature',
+        feature: {
+          id: 'dwarf-dwarven-toughness',
+          name: 'Dwarven Toughness',
+          description: 'Your hit point maximum increases by 1, and it increases by 1 whenever you gain a level.',
         },
       },
     ],

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { getSubclassSource } from '@/lib/sources';
 import type { SubclassId } from '@/types/sources';
+import { createChoiceKey } from '@/types/choices';
 
 describe('getSubclassSource — Champion', () => {
   it('returns defined for champion', () => {
@@ -63,5 +64,120 @@ describe('getSubclassSource — Champion', () => {
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();
+  });
+});
+
+describe('getSubclassSource — Berserker', () => {
+  it('returns defined for berserker', () => {
+    expect(getSubclassSource('berserker')).toBeDefined();
+  });
+
+  it('berserker has classId barbarian', () => {
+    expect(getSubclassSource('berserker')?.classId).toBe('barbarian');
+  });
+
+  it('berserker has 3 features at levels 3, 6, 10', () => {
+    const source = getSubclassSource('berserker');
+    expect(source?.features).toHaveLength(3);
+    const levels = source?.features.map((f) => f.classLevel);
+    expect(levels).toEqual([3, 6, 10]);
+  });
+
+  it('berserker level 3 grants berserker-frenzy', () => {
+    const level3 = getSubclassSource('berserker')?.features.find((f) => f.classLevel === 3);
+    expect(level3?.grants).toHaveLength(1);
+    const grant = level3?.grants[0];
+    expect(grant?.type).toBe('feature');
+    if (grant?.type === 'feature') {
+      expect(grant.feature.id).toBe('berserker-frenzy');
+    }
+  });
+
+  it('berserker level 6 grants berserker-mindless-rage', () => {
+    const level6 = getSubclassSource('berserker')?.features.find((f) => f.classLevel === 6);
+    const grant = level6?.grants[0];
+    expect(grant?.type).toBe('feature');
+    if (grant?.type === 'feature') {
+      expect(grant.feature.id).toBe('berserker-mindless-rage');
+    }
+  });
+
+  it('berserker level 10 grants berserker-intimidating-presence', () => {
+    const level10 = getSubclassSource('berserker')?.features.find((f) => f.classLevel === 10);
+    const grant = level10?.grants[0];
+    expect(grant?.type).toBe('feature');
+    if (grant?.type === 'feature') {
+      expect(grant.feature.id).toBe('berserker-intimidating-presence');
+    }
+  });
+});
+
+describe('getSubclassSource — Totem Warrior', () => {
+  it('returns defined for totemwarrior', () => {
+    expect(getSubclassSource('totemwarrior')).toBeDefined();
+  });
+
+  it('totemwarrior has classId barbarian', () => {
+    expect(getSubclassSource('totemwarrior')?.classId).toBe('barbarian');
+  });
+
+  it('totemwarrior has 3 features at levels 3, 6, 10', () => {
+    const source = getSubclassSource('totemwarrior');
+    expect(source?.features).toHaveLength(3);
+    const levels = source?.features.map((f) => f.classLevel);
+    expect(levels).toEqual([3, 6, 10]);
+  });
+
+  it('totemwarrior level 3 includes spirit-seeker feature AND totem-animal-choice at index 0', () => {
+    const level3 = getSubclassSource('totemwarrior')?.features.find((f) => f.classLevel === 3);
+    expect(level3?.grants).toHaveLength(2);
+
+    const featureGrant = level3?.grants.find((g) => g.type === 'feature');
+    expect(featureGrant?.type).toBe('feature');
+    if (featureGrant?.type === 'feature') {
+      expect(featureGrant.feature.id).toBe('totemwarrior-spirit-seeker');
+    }
+
+    const totemGrant = level3?.grants.find((g) => g.type === 'totem-animal-choice');
+    expect(totemGrant?.type).toBe('totem-animal-choice');
+    if (totemGrant?.type === 'totem-animal-choice') {
+      expect(totemGrant.featureIdPrefix).toBe('totemwarrior-totem-spirit');
+      expect(totemGrant.key).toBe(createChoiceKey('totem-animal-choice', 'class', 'barbarian', 0));
+    }
+  });
+
+  it('totemwarrior level 6 has totem-animal-choice at index 1 with distinct prefix', () => {
+    const level6 = getSubclassSource('totemwarrior')?.features.find((f) => f.classLevel === 6);
+    expect(level6?.grants).toHaveLength(1);
+
+    const totemGrant = level6?.grants[0];
+    expect(totemGrant?.type).toBe('totem-animal-choice');
+    if (totemGrant?.type === 'totem-animal-choice') {
+      expect(totemGrant.featureIdPrefix).toBe('totemwarrior-aspect-of-the-beast');
+      expect(totemGrant.key).toBe(createChoiceKey('totem-animal-choice', 'class', 'barbarian', 1));
+    }
+  });
+
+  it('totemwarrior level 6 choice key index (1) is distinct from level 3 index (0)', () => {
+    const level3Grant = getSubclassSource('totemwarrior')
+      ?.features.find((f) => f.classLevel === 3)
+      ?.grants.find((g) => g.type === 'totem-animal-choice');
+    const level6Grant = getSubclassSource('totemwarrior')
+      ?.features.find((f) => f.classLevel === 6)
+      ?.grants.find((g) => g.type === 'totem-animal-choice');
+
+    expect(level3Grant?.type === 'totem-animal-choice' && level3Grant.key).not.toBe(
+      level6Grant?.type === 'totem-animal-choice' && level6Grant.key
+    );
+  });
+
+  it('totemwarrior level 10 grants totemwarrior-spirit-walker', () => {
+    const level10 = getSubclassSource('totemwarrior')?.features.find((f) => f.classLevel === 10);
+    expect(level10?.grants).toHaveLength(1);
+    const grant = level10?.grants[0];
+    expect(grant?.type).toBe('feature');
+    if (grant?.type === 'feature') {
+      expect(grant.feature.id).toBe('totemwarrior-spirit-walker');
+    }
   });
 });

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -58,4 +58,41 @@ export const SUBCLASS_SOURCES: readonly SubclassSource[] = [
       { classLevel: 18, grants: [{ type: 'feature', feature: { id: 'eldritchknight-improved-war-magic' } }] },
     ],
   },
+  {
+    id: 'berserker',
+    classId: 'barbarian',
+    features: [
+      { classLevel: 3, grants: [{ type: 'feature', feature: { id: 'berserker-frenzy' } }] },
+      { classLevel: 6, grants: [{ type: 'feature', feature: { id: 'berserker-mindless-rage' } }] },
+      { classLevel: 10, grants: [{ type: 'feature', feature: { id: 'berserker-intimidating-presence' } }] },
+    ],
+  },
+  {
+    id: 'totemwarrior',
+    classId: 'barbarian',
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          { type: 'feature', feature: { id: 'totemwarrior-spirit-seeker' } },
+          {
+            type: 'totem-animal-choice',
+            key: createChoiceKey('totem-animal-choice', 'class', 'barbarian', 0),
+            featureIdPrefix: 'totemwarrior-totem-spirit',
+          },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          {
+            type: 'totem-animal-choice',
+            key: createChoiceKey('totem-animal-choice', 'class', 'barbarian', 1),
+            featureIdPrefix: 'totemwarrior-aspect-of-the-beast',
+          },
+        ],
+      },
+      { classLevel: 10, grants: [{ type: 'feature', feature: { id: 'totemwarrior-spirit-walker' } }] },
+    ],
+  },
 ];

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -149,6 +149,7 @@
       "languageChoice": "Choose {{count}} language(s)",
       "toolChoice": "Choose {{count}} tool(s)",
       "fightingStyleChoice": "Choose {{count}} fighting style(s)",
+      "totemAnimalChoice": "Choose your totem animal",
       "unsupported": "Choice not yet supported: {{type}}",
       "remaining": "remaining",
       "fromSource": "from {{source}}"

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -415,6 +415,10 @@
     "dwarf-stonecunning": {
       "name": "Stonecunning",
       "description": "Whenever you make an Intelligence (History) check related to the origin of stonework, you are considered proficient in the History skill and add double your proficiency bonus."
+    },
+    "dwarf-dwarven-toughness": {
+      "name": "Dwarven Toughness",
+      "description": "Your hit point maximum increases by 1, and it increases by 1 whenever you gain a level."
     }
   },
   "subclasses": {

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -224,6 +224,50 @@
     "masonstools": "Mason's Tools"
   },
   "features": {
+    "barbarian-brutal-critical-1": {
+      "name": "Brutal Critical",
+      "description": "You can roll one additional weapon damage die when determining the extra damage for a critical hit with a melee attack."
+    },
+    "barbarian-danger-sense": {
+      "name": "Danger Sense",
+      "description": "You have an uncanny sense of when things nearby are not as they should be. You have advantage on Dexterity saving throws against effects that you can see."
+    },
+    "barbarian-extra-attack": {
+      "name": "Extra Attack",
+      "description": "You can attack twice, instead of once, whenever you take the Attack action on your turn."
+    },
+    "barbarian-fast-movement": {
+      "name": "Fast Movement",
+      "description": "Your speed increases by 10 feet while you aren't wearing heavy armor."
+    },
+    "barbarian-feral-instinct": {
+      "name": "Feral Instinct",
+      "description": "Your instincts are so honed that you have advantage on initiative rolls. Additionally, if you are surprised at the beginning of combat and aren't incapacitated, you can act normally on your first turn if you enter a rage."
+    },
+    "barbarian-rage": {
+      "name": "Rage",
+      "description": "On your turn, you can enter a rage as a bonus action. While raging, you have advantage on STR checks and saving throws, bonus to melee damage, and resistance to bludgeoning, piercing, and slashing damage."
+    },
+    "barbarian-reckless-attack": {
+      "name": "Reckless Attack",
+      "description": "When you make your first attack on your turn, you can decide to attack recklessly. Doing so gives you advantage on melee weapon attack rolls using STR during this turn, but attack rolls against you have advantage until your next turn."
+    },
+    "barbarian-unarmored-defense": {
+      "name": "Unarmored Defense",
+      "description": "While you are not wearing any armor, your Armor Class equals 10 + your Dexterity modifier + your Constitution modifier. You can use a shield and still gain this benefit."
+    },
+    "berserker-frenzy": {
+      "name": "Frenzy",
+      "description": "When you rage, you can go into a frenzy. For the duration of your rage, you can make a single melee weapon attack as a bonus action on each of your turns. When your rage ends, you suffer one level of exhaustion."
+    },
+    "berserker-intimidating-presence": {
+      "name": "Intimidating Presence",
+      "description": "You can use your action to frighten someone with your menacing presence. When you do so, choose one creature that you can see within 30 feet of you. If the creature can see or hear you, it must succeed on a Wisdom saving throw or be frightened of you until the end of your next turn."
+    },
+    "berserker-mindless-rage": {
+      "name": "Mindless Rage",
+      "description": "You can't be charmed or frightened while raging. If you are charmed or frightened when you enter your rage, the effect is suspended for the duration of the rage."
+    },
     "fighter-fighting-style": {
       "name": "Fighting Style",
       "description": "You adopt a particular style of fighting as your specialty."
@@ -328,6 +372,38 @@
       "name": "Fighting Style: Two-Weapon Fighting",
       "description": "When you engage in two-weapon fighting, you can add your ability modifier to the damage of the second attack."
     },
+    "totemwarrior-aspect-of-the-beast-bear": {
+      "name": "Aspect of the Beast (Bear)",
+      "description": "Bear: You gain the might of a bear. Your carrying capacity (including maximum load and maximum lift) is doubled, and you have advantage on Strength checks made to push, pull, lift, or break things."
+    },
+    "totemwarrior-aspect-of-the-beast-eagle": {
+      "name": "Aspect of the Beast (Eagle)",
+      "description": "Eagle: You gain the eyesight of an eagle. You can see up to 1 mile away with no difficulty, able to discern even fine details as though looking at something no more than 100 feet away from you."
+    },
+    "totemwarrior-aspect-of-the-beast-wolf": {
+      "name": "Aspect of the Beast (Wolf)",
+      "description": "Wolf: You gain the hunting sensibilities of a wolf. You can track other creatures while traveling at a fast pace, and you can move stealthily while traveling at a normal pace."
+    },
+    "totemwarrior-spirit-seeker": {
+      "name": "Spirit Seeker",
+      "description": "Yours is a path that seeks attunement with the natural world. You gain the ability to cast the Beast Sense and Speak with Animals spells, but only as rituals."
+    },
+    "totemwarrior-spirit-walker": {
+      "name": "Spirit Walker",
+      "description": "You can cast the Commune with Nature spell, but only as a ritual. When you do so, a spiritual version of one of the animals you chose for Totem Spirit or Aspect of the Beast appears to you to convey the information you seek."
+    },
+    "totemwarrior-totem-spirit-bear": {
+      "name": "Totem Spirit (Bear)",
+      "description": "Bear: While raging, you have resistance to all damage except psychic damage. The spirit of the bear makes you tough enough to stand up to any punishment."
+    },
+    "totemwarrior-totem-spirit-eagle": {
+      "name": "Totem Spirit (Eagle)",
+      "description": "Eagle: While you're raging and aren't wearing heavy armor, other creatures have disadvantage on opportunity attack rolls against you, and you can use the Dash action as a bonus action on your turn."
+    },
+    "totemwarrior-totem-spirit-wolf": {
+      "name": "Totem Spirit (Wolf)",
+      "description": "Wolf: While you're raging, your friends have advantage on melee attack rolls against any creature within 5 feet of you that is hostile to you."
+    },
     "dwarf-darkvision": {
       "name": "Darkvision",
       "description": "You can see in dim light within 60 feet of you as if it were bright light, and in darkness as if it were dim light."
@@ -342,6 +418,10 @@
     }
   },
   "subclasses": {
+    "berserker": {
+      "name": "Berserker",
+      "description": "For some barbarians, rage is a means to an end — that end being violence. The Path of the Berserker is a path of untrammeled fury, slick with blood. As you enter the berserker's rage, you thrill in the chaos of battle, heedless of your own health or well-being."
+    },
     "champion": {
       "name": "Champion",
       "description": "The archetypal Champion focuses on the development of raw physical power honed to deadly perfection. Those who model themselves on this archetype combine rigorous training with physical excellence to deal devastating blows."
@@ -353,6 +433,10 @@
     "eldritchknight": {
       "name": "Eldritch Knight",
       "description": "The Eldritch Knight combines martial prowess with careful study of magic. These fighters learn to cast spells from the wizard spell list, weaving magic into their weapon strikes and defenses."
+    },
+    "totemwarrior": {
+      "name": "Path of the Totem Warrior",
+      "description": "The Path of the Totem Warrior is a spiritual journey, as the barbarian accepts a spirit animal as guide, protector, and inspiration. In battle, your totem spirit fills you with supernatural might, adding magical fuel to your barbarian rage."
     }
   },
   "fightingStyles": {
@@ -491,12 +575,15 @@
     }
   },
   "bundles": {
+    "any-martial-melee": { "name": "Any martial melee weapon" },
+    "any-simple-weapon": { "name": "Any simple weapon" },
+    "barbarian-greataxe": { "name": "Greataxe" },
     "fighter-chainmail": { "name": "Chain Mail" },
     "fighter-archer-kit": { "name": "Leather Armor + Longbow + Arrows (20)" },
-    "martial-weapon-and-shield": { "name": "A martial weapon and a shield" },
-    "two-martial-weapons": { "name": "Two martial weapons" },
     "light-crossbow-kit": { "name": "Light Crossbow + Bolts (20)" },
-    "two-handaxes": { "name": "Two Handaxes" }
+    "martial-weapon-and-shield": { "name": "A martial weapon and a shield" },
+    "two-handaxes": { "name": "Two Handaxes" },
+    "two-martial-weapons": { "name": "Two martial weapons" }
   },
   "bundleCategories": {
     "loadout": "Loadout",
@@ -518,5 +605,19 @@
     "large": "Large",
     "huge": "Huge",
     "gargantuan": "Gargantuan"
+  },
+  "totemAnimals": {
+    "bear": {
+      "name": "Bear",
+      "description": "The bear's endurance and resilience make it a powerful totem. Bear totems grant resistance to damage while raging and supernatural strength."
+    },
+    "eagle": {
+      "name": "Eagle",
+      "description": "The eagle's keen sight and speed make it a swift and watchful totem. Eagle totems grant agility and awareness in battle."
+    },
+    "wolf": {
+      "name": "Wolf",
+      "description": "The wolf's pack instincts make it a cooperative totem. Wolf totems help your allies coordinate attacks against your foes."
+    }
   }
 }

--- a/src/types/choices.ts
+++ b/src/types/choices.ts
@@ -10,6 +10,7 @@ import type {
 } from '@/lib/dnd-helpers';
 import type { SubclassId } from '@/types/sources';
 import type { AbilityScores } from '@/types/database';
+import type { TotemAnimalId } from '@/types/grants';
 
 /**
  * Choice key format: `category:origin:id:index`
@@ -30,6 +31,7 @@ const CHOICE_CATEGORIES = [
   'subclass',
   'fighting-style-choice',
   'bundle-choice',
+  'totem-animal-choice',
 ] as const;
 export type ChoiceCategory = (typeof CHOICE_CATEGORIES)[number];
 
@@ -88,7 +90,8 @@ export type ChoiceDecision =
       readonly bundleId: string;
       /** Map of slotKey → chosen itemId. Empty object when the bundle has no slots. */
       readonly slotPicks: Readonly<Record<string, string>>;
-    };
+    }
+  | { readonly type: 'totem-animal-choice'; readonly animal: TotemAnimalId };
 
 export interface BuildLevel {
   readonly classId: ClassId;

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -120,11 +120,14 @@ export interface FeatureGrant {
 export const TOTEM_ANIMALS = ['bear', 'eagle', 'wolf'] as const;
 export type TotemAnimalId = (typeof TOTEM_ANIMALS)[number];
 
+/** Literal union of all feature-id prefixes that a totem-animal-choice grant can produce. */
+export type TotemFeatureIdPrefix = 'totemwarrior-totem-spirit' | 'totemwarrior-aspect-of-the-beast';
+
 export interface TotemAnimalChoiceGrant {
   readonly type: 'totem-animal-choice';
   readonly key: ChoiceKey;
   /** Resolver appends `-bear` / `-eagle` / `-wolf` to form the resolved feature id. */
-  readonly featureIdPrefix: string;
+  readonly featureIdPrefix: TotemFeatureIdPrefix;
 }
 
 export type SpeedMode = 'walk' | 'fly' | 'swim' | 'climb' | 'burrow';

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -117,6 +117,16 @@ export interface FeatureGrant {
   readonly feature: FeatureDef;
 }
 
+export const TOTEM_ANIMALS = ['bear', 'eagle', 'wolf'] as const;
+export type TotemAnimalId = (typeof TOTEM_ANIMALS)[number];
+
+export interface TotemAnimalChoiceGrant {
+  readonly type: 'totem-animal-choice';
+  readonly key: ChoiceKey;
+  /** Resolver appends `-bear` / `-eagle` / `-wolf` to form the resolved feature id. */
+  readonly featureIdPrefix: string;
+}
+
 export type SpeedMode = 'walk' | 'fly' | 'swim' | 'climb' | 'burrow';
 
 export interface SpeedGrant {
@@ -224,4 +234,5 @@ export type Grant =
   | AbilityCheckBonusGrant
   | FightingStyleChoiceGrant
   | EquipmentGrant
-  | BundleChoiceGrant;
+  | BundleChoiceGrant
+  | TotemAnimalChoiceGrant;

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -154,6 +154,12 @@ export type PendingChoice =
       readonly source: SourceTag;
       readonly category: BundleCategory;
       readonly bundleIds: readonly string[];
+    }
+  | {
+      readonly type: 'totem-animal-choice';
+      readonly choiceKey: ChoiceKey;
+      readonly source: SourceTag;
+      readonly featureIdPrefix: string;
     };
 
 export interface ResolvedCharacter {

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -8,7 +8,7 @@ import type {
   LanguageId,
   ClassId,
 } from '@/lib/dnd-helpers';
-import type { FeatureDef, DamageTypeId, HitDie, SpeedMode } from '@/types/grants';
+import type { FeatureDef, DamageTypeId, HitDie, SpeedMode, TotemFeatureIdPrefix } from '@/types/grants';
 import type { SourceTag } from '@/types/sources';
 import type { ChoiceKey } from '@/types/choices';
 import type {
@@ -159,7 +159,7 @@ export type PendingChoice =
       readonly type: 'totem-animal-choice';
       readonly choiceKey: ChoiceKey;
       readonly source: SourceTag;
-      readonly featureIdPrefix: string;
+      readonly featureIdPrefix: TotemFeatureIdPrefix;
     };
 
 export interface ResolvedCharacter {

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -8,7 +8,7 @@ import type {
   LanguageId,
   ClassId,
 } from '@/lib/dnd-helpers';
-import type { FeatureDef, DamageTypeId, HitDie, SpeedMode, TotemFeatureIdPrefix } from '@/types/grants';
+import type { FeatureDef, DamageTypeId, HitDie, SpeedMode } from '@/types/grants';
 import type { SourceTag } from '@/types/sources';
 import type { ChoiceKey } from '@/types/choices';
 import type {
@@ -159,7 +159,6 @@ export type PendingChoice =
       readonly type: 'totem-animal-choice';
       readonly choiceKey: ChoiceKey;
       readonly source: SourceTag;
-      readonly featureIdPrefix: TotemFeatureIdPrefix;
     };
 
 export interface ResolvedCharacter {

--- a/src/types/sources.ts
+++ b/src/types/sources.ts
@@ -1,7 +1,7 @@
 import type { RaceId, ClassId, BackgroundId, SizeId, AbilityKey } from '@/lib/dnd-helpers';
 import type { Grant } from '@/types/grants';
 
-export const SUBCLASS_IDS = ['champion', 'battlemaster', 'eldritchknight'] as const;
+export const SUBCLASS_IDS = ['champion', 'battlemaster', 'eldritchknight', 'berserker', 'totemwarrior'] as const;
 export type SubclassId = (typeof SUBCLASS_IDS)[number];
 
 export function isSubclassId(s: string): s is SubclassId {


### PR DESCRIPTION
Closes #81

## Summary

Implements the PHB 2014 Barbarian class for character levels 1-10, including Rage, Unarmored Defense, both Primal Paths (Berserker and Path of the Totem Warrior), and full starting-equipment bundles. Adds a structural fix to the resolver so scaling features (re-emitted at level thresholds) dedupe to a single sheet entry, and implements the `'barbarian'`/`'monk'` unarmored-defense formulas the AC type already declared but the resolver previously ignored.

## What Changed

- **Types**: new `TotemAnimalChoiceGrant` grant and `TOTEM_ANIMALS` tuple; `'totem-animal-choice'` added to `CHOICE_CATEGORIES` and `ChoiceDecision`; `'berserker'` and `'totemwarrior'` added to `SUBCLASS_IDS`; totem variant added to `PendingChoice`.
- **Resolver**:
  - `resolveFeatures` now dedupes by `feature.id`, keeping the highest class/subclass-level emission — this is what makes Rage display once per sheet while letting later-level emissions override `usesCount`.
  - `resolveAc` now takes `conModifier` and `wisModifier` and implements both `'barbarian'` (`10 + DEX + CON`) and `'monk'` (`10 + DEX + WIS`) unarmored formulas; the existing monk TODO is retired.
  - `resolver/index.ts` resolves `totem-animal-choice` grants, synthesizing `${prefix}-${animal}` features on decision or emitting pending choices otherwise.
- **Sources**: Barbarian class (L1-10 detailed, 11-20 empty), Berserker and Path of the Totem Warrior subclasses, and three new equipment bundles (`barbarian-greataxe`, `any-martial-melee`, `any-simple-weapon`).
- **UI**: `ChoicePicker` renders a three-chip selector for totem animals; `PendingChoicesPanel` surfaces the new pending-choice variant.
- **i18n**: barbarian/berserker/totem-warrior feature, subclass, bundle, and totem-animal strings added to `gamedata.json`.
- **Tests**: new `resolver/features.test.ts` (dedupe), new `sources/subclasses.test.ts`, plus added coverage in `combat.test.ts` and `classes.test.ts` for both unarmored formulas and the barbarian class source. `ChoicePicker.test.tsx` extended for the totem-animal branch.

19 files changed, 820 insertions(+), 27 deletions(-).

## Agents Used

- **Architecture validation**: `feature-dev:code-architect` (agent `ae0d9056f182c8ae7`) — validated the issue's embedded implementation guide against the current codebase and surfaced 10 concrete discrepancies (signature break in `resolveAc`, type-ordering dependencies, pending-choice routing investigation, etc.).
- **Implementation**: `typescript-node-implementer` (agent `a2821ee0a82d43758`) — executed the 17-step ordering, made 8 atomic commits, pushed to origin.

## Testing

- `npm run typecheck` ✅ passes
- `npm run lint` ✅ passes (`--max-warnings 0`, no untranslated literals)
- `npm run test` — 823/826 passing. The 3 failures (`PhysicalCharacteristics.test.tsx`, `supabase.test.ts`) are pre-existing on `main` and untouched by this branch.

### Manual verification checklist (from issue)

- [ ] Create a new Barbarian character at L1: AC reflects `10 + DEX + CON`, Rage appears once with `uses=2`, equipment step shows greataxe-or-martial and handaxes-or-simple.
- [ ] Level to 3, choose Totem Warrior → Bear: totem-spirit-bear feature on sheet; Rage shows `uses=3`.
- [ ] Level to 6: Aspect of the Beast prompts again independently of the L3 pick.
- [ ] Level to 9: Brutal Critical present; Rage description reflects +3 damage.
- [ ] Spot-check Fighter unaffected by resolver dedupe and AC signature changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)