### PR TITLE
feat(races): implement Half-Elf race (PHB 2014)

### DIFF
--- a/src/components/character-builder/AbilitiesStep.tsx
+++ b/src/components/character-builder/AbilitiesStep.tsx
@@ -1,10 +1,11 @@
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { RollingNumber } from '@/components/ui/rolling-number';
-import { Card, CardContent } from '@/components/ui/card';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import { ChoicePicker } from '@/components/character-builder/ChoicePicker';
 import { useCharacterContext, type CreationUpdates } from '@/hooks/useCharacterContext';
 import {
   getAbilityModifier,
@@ -18,8 +19,9 @@ import {
   DND_RACES,
 } from '@/lib/dnd-helpers';
 import type { AbilityScores } from '@/types/database';
+import type { PendingChoice } from '@/types/resolved';
 import { Check, ChevronDown, ChevronUp, Dices, TrendingDown, TrendingUp } from 'lucide-react';
-import { useCallback, useEffect, useRef, useState } from 'react';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 
 const DEFAULT_ABILITIES: AbilityScores = { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 };
@@ -262,6 +264,27 @@ export function AbilitiesStep() {
     );
   };
 
+  // Scan grant bundles for ability-choice grants (e.g. Half-Elf +1/+1)
+  const abilityChoicePending = useMemo((): readonly PendingChoice[] => {
+    if (context.bundles.length === 0) return [];
+    const result: PendingChoice[] = [];
+    for (const bundle of context.bundles) {
+      for (const grant of bundle.grants) {
+        if (grant.type === 'ability-choice') {
+          result.push({
+            type: 'ability-choice',
+            choiceKey: grant.key,
+            source: bundle.source,
+            count: grant.count,
+            bonus: grant.bonus,
+            from: grant.from,
+          });
+        }
+      }
+    }
+    return result;
+  }, [context.bundles]);
+
   const abilityKeys = Object.keys(baseAbilities) as Array<keyof AbilityScores>;
   const pointsSpent = Object.values(baseAbilities).reduce((sum, s) => sum + getPointBuyCost(s), 0);
   const pointsRemaining = POINT_BUY_TOTAL - pointsSpent;
@@ -277,6 +300,8 @@ export function AbilitiesStep() {
     setIsRolling(false);
     context.updateCreation({ ability_method: val as CreationUpdates['ability_method'] });
   };
+
+  const { build } = context;
 
   return (
     <div className="space-y-4">
@@ -454,6 +479,27 @@ export function AbilitiesStep() {
           </div>
         </TabsContent>
       </Tabs>
+
+      {abilityChoicePending.length > 0 && (
+        <Card>
+          <CardHeader className="pb-2">
+            <CardTitle className="text-sm font-semibold">
+              {tc('characterBuilder.abilities.racialAbilityChoice')}
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="space-y-4">
+            {abilityChoicePending.map((choice) => (
+              <ChoicePicker
+                key={choice.choiceKey}
+                choice={choice}
+                currentDecision={build?.choices[choice.choiceKey]}
+                onDecide={context.makeChoice}
+                onClear={context.clearChoice}
+              />
+            ))}
+          </CardContent>
+        </Card>
+      )}
     </div>
   );
 }

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -5,7 +5,14 @@ import { Card, CardContent, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { DND_LANGUAGES, DND_SKILLS, type LanguageId, type SkillId, type ToolProficiencyId } from '@/lib/dnd-helpers';
+import {
+  DND_LANGUAGES,
+  DND_SKILLS,
+  type AbilityKey,
+  type LanguageId,
+  type SkillId,
+  type ToolProficiencyId,
+} from '@/lib/dnd-helpers';
 import { getItemDef, getItemNameKey } from '@/lib/sources/items';
 import { getBundleDef, getBundleNameKey, getItemsForSlot, resolveBundleRef } from '@/lib/sources/bundles';
 import type { ChoiceDecision, ChoiceKey } from '@/types/choices';
@@ -27,6 +34,7 @@ interface ChoicePickerProps {
   readonly onClear: (key: ChoiceKey) => void;
 }
 
+const ALL_ABILITY_KEYS: readonly AbilityKey[] = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
 const ALL_SKILL_IDS: readonly SkillId[] = DND_SKILLS.map((s) => s.id);
 const ALL_LANGUAGE_IDS: readonly LanguageId[] = DND_LANGUAGES;
 
@@ -41,6 +49,54 @@ function isLanguageId(id: string): id is LanguageId {
 export function ChoicePicker({ choice, currentDecision, onDecide, onClear }: ChoicePickerProps) {
   const { t } = useTranslation('gamedata');
   const { t: tc } = useTranslation('common');
+
+  if (choice.type === 'ability-choice') {
+    const pool: readonly AbilityKey[] = choice.from ?? ALL_ABILITY_KEYS;
+    const current = currentDecision?.type === 'ability-choice' ? currentDecision.abilities : [];
+    const atMax = current.length >= choice.count;
+
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <p className="text-sm text-muted-foreground">
+            {tc('characterBuilder.pendingChoices.abilityChoice', { count: choice.count, bonus: choice.bonus })}
+          </p>
+          <Badge variant="outline" className="text-xs">
+            {current.length} / {choice.count}
+          </Badge>
+        </div>
+        <div className="space-y-1">
+          {pool.map((abilityId) => {
+            const isSelected = current.includes(abilityId);
+            const isDisabled = atMax && !isSelected;
+            return (
+              <div
+                key={abilityId}
+                className="flex items-center gap-3 px-2 py-1.5 rounded-md transition-colors hover:bg-muted/50"
+              >
+                <Checkbox
+                  id={`choice-ability-${choice.choiceKey}-${abilityId}`}
+                  checked={isSelected}
+                  disabled={isDisabled}
+                  onCheckedChange={(checked) => {
+                    const next = checked ? [...current, abilityId] : current.filter((a) => a !== abilityId);
+                    if (next.length === 0) {
+                      onClear(choice.choiceKey);
+                    } else {
+                      onDecide(choice.choiceKey, { type: 'ability-choice', abilities: next });
+                    }
+                  }}
+                />
+                <Label htmlFor={`choice-ability-${choice.choiceKey}-${abilityId}`} className="flex-1 cursor-pointer">
+                  {t(`abilities.${abilityId}`)}
+                </Label>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
 
   if (choice.type === 'skill-choice') {
     const rawPool = choice.from ?? ALL_SKILL_IDS;

--- a/src/lib/dnd-helpers.ts
+++ b/src/lib/dnd-helpers.ts
@@ -434,7 +434,7 @@ export const DND_RACES = [
     id: 'halfelf',
     size: 'medium',
     speed: 30,
-    abilityBonuses: { cha: 2, int: 1, wis: 1 },
+    abilityBonuses: { cha: 2 },
     languages: ['common', 'elvish'],
     languageChoices: 1,
   },

--- a/src/lib/sources/races.test.ts
+++ b/src/lib/sources/races.test.ts
@@ -227,3 +227,80 @@ describe('Stout Halfling race source', () => {
     expect(resistance).toEqual({ type: 'resistance', damageType: 'poison' });
   });
 });
+
+describe('Half-Elf race source', () => {
+  const source = getRaceSource('halfelf' as RaceId);
+
+  it('source is defined', () => {
+    expect(source).toBeDefined();
+  });
+
+  it('has correct defaults', () => {
+    expect(source?.defaultSize).toBe('medium');
+    expect(source?.defaultSpeed).toBe(30);
+  });
+
+  it('grants exactly one fixed ability bonus: +2 CHA', () => {
+    const abilityBonuses = source?.grants.filter((g) => g.type === 'ability-bonus');
+    expect(abilityBonuses).toHaveLength(1);
+    expect(abilityBonuses).toEqual([{ type: 'ability-bonus', ability: 'cha', bonus: 2 }]);
+  });
+
+  it('grants one ability-choice with count 2, bonus 1, from all abilities except CHA', () => {
+    const abilityChoice = source?.grants.find((g) => g.type === 'ability-choice');
+    expect(abilityChoice).toEqual({
+      type: 'ability-choice',
+      key: createChoiceKey('ability-choice', 'race', 'halfelf', 0),
+      count: 2,
+      bonus: 1,
+      from: ['str', 'dex', 'con', 'int', 'wis'],
+    });
+  });
+
+  it('grants 30 ft walk speed', () => {
+    const speed = source?.grants.find((g) => g.type === 'speed');
+    expect(speed).toEqual({ type: 'speed', mode: 'walk', value: 30 });
+  });
+
+  it('grants Common and Elvish languages as fixed proficiencies', () => {
+    const languages = source?.grants.filter((g) => g.type === 'proficiency' && g.category === 'language');
+    expect(languages).toHaveLength(2);
+    expect(languages).toEqual(
+      expect.arrayContaining([
+        { type: 'proficiency', category: 'language', id: 'common' },
+        { type: 'proficiency', category: 'language', id: 'elvish' },
+      ])
+    );
+  });
+
+  it('grants one language-choice with count 1 and from: null (any language)', () => {
+    const langChoice = source?.grants.find((g) => g.type === 'proficiency-choice' && g.category === 'language');
+    expect(langChoice).toEqual({
+      type: 'proficiency-choice',
+      category: 'language',
+      key: createChoiceKey('language-choice', 'race', 'halfelf', 0),
+      count: 1,
+      from: null,
+    });
+  });
+
+  it('grants one skill-choice with count 2 and from: null (any skill)', () => {
+    const skillChoice = source?.grants.find((g) => g.type === 'proficiency-choice' && g.category === 'skill');
+    expect(skillChoice).toEqual({
+      type: 'proficiency-choice',
+      category: 'skill',
+      key: createChoiceKey('skill-choice', 'race', 'halfelf', 0),
+      count: 2,
+      from: null,
+    });
+  });
+
+  it('grants three features: darkvision, fey ancestry, skill versatility', () => {
+    const features = source?.grants.filter((g) => g.type === 'feature');
+    expect(features).toHaveLength(3);
+    const featureIds = features?.map((g) => g.type === 'feature' && g.feature.id);
+    expect(featureIds).toEqual(
+      expect.arrayContaining(['halfelf-darkvision', 'halfelf-fey-ancestry', 'halfelf-skill-versatility'])
+    );
+  });
+});

--- a/src/lib/sources/races.ts
+++ b/src/lib/sources/races.ts
@@ -178,4 +178,48 @@ export const RACE_SOURCES: readonly RaceSource[] = [
       },
     ],
   },
+  {
+    id: 'halfelf',
+    defaultSize: 'medium',
+    defaultSpeed: 30,
+    grants: [
+      // Ability Score Increase: +2 CHA (fixed)
+      { type: 'ability-bonus', ability: 'cha', bonus: 2 },
+      // Ability Score Increase: +1 to two other abilities of player's choice (not CHA)
+      {
+        type: 'ability-choice',
+        key: createChoiceKey('ability-choice', 'race', 'halfelf', 0),
+        count: 2,
+        bonus: 1,
+        from: ['str', 'dex', 'con', 'int', 'wis'],
+      },
+      // Speed: 30 ft
+      { type: 'speed', mode: 'walk', value: 30 },
+      // Languages: Common, Elvish (fixed)
+      { type: 'proficiency', category: 'language', id: 'common' },
+      { type: 'proficiency', category: 'language', id: 'elvish' },
+      // One additional language of choice
+      {
+        type: 'proficiency-choice',
+        category: 'language',
+        key: createChoiceKey('language-choice', 'race', 'halfelf', 0),
+        count: 1,
+        from: null,
+      },
+      // Skill Versatility: proficiency in 2 skills of player's choice
+      {
+        type: 'proficiency-choice',
+        category: 'skill',
+        key: createChoiceKey('skill-choice', 'race', 'halfelf', 0),
+        count: 2,
+        from: null,
+      },
+      // Darkvision (60 ft)
+      { type: 'feature', feature: { id: 'halfelf-darkvision' } },
+      // Fey Ancestry: advantage vs charm, immune to magical sleep
+      { type: 'feature', feature: { id: 'halfelf-fey-ancestry' } },
+      // Skill Versatility
+      { type: 'feature', feature: { id: 'halfelf-skill-versatility' } },
+    ],
+  },
 ];

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -150,6 +150,7 @@
       "toolChoice": "Choose {{count}} tool(s)",
       "expertiseChoice": "Choose {{count}} expertise",
       "fightingStyleChoice": "Choose {{count}} fighting style(s)",
+      "abilityChoice": "Choose {{count}} abilities to gain +{{bonus}}",
       "unsupported": "Choice not yet supported: {{type}}",
       "remaining": "remaining",
       "fromSource": "from {{source}}"
@@ -227,7 +228,8 @@
       "increaseScore_plural": "Increase score, spend {{count}} points",
       "maximumScore": "Maximum score",
       "notEnoughPoints": "Not enough points",
-      "racialBonus": "{{race}} Racial Bonus: {{bonuses}}"
+      "racialBonus": "{{race}} Racial Bonus: {{bonuses}}",
+      "racialAbilityChoice": "Racial Ability Bonuses"
     },
     "skills": {
       "selectClassFirst": "Please select a class in the Basics step before choosing skills.",

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -362,6 +362,18 @@
       "name": "Stout Resilience",
       "description": "You have advantage on saving throws against poison, and you have resistance against poison damage."
     },
+    "halfelf-darkvision": {
+      "name": "Darkvision",
+      "description": "You can see in dim light within 60 feet as if it were bright light, and in darkness as if it were dim light."
+    },
+    "halfelf-fey-ancestry": {
+      "name": "Fey Ancestry",
+      "description": "You have advantage on saving throws against being charmed, and magic can't put you to sleep."
+    },
+    "halfelf-skill-versatility": {
+      "name": "Skill Versatility",
+      "description": "You gain proficiency in two skills of your choice."
+    },
     "rogue-sneak-attack": {
       "name": "Sneak Attack",
       "description": "Once per turn, deal extra 1d6 damage to one creature you hit with a finesse or ranged weapon attack if you have advantage or an ally is within 5 feet of the target. Scales to ceil(level/2)d6."


### PR DESCRIPTION
## Summary

Adds the PHB 2014 Half-Elf race, paired naturally with the recently shipped Druid class. Half-Elf is the first race in the project to exercise `ability-choice` and race-origin skill-category `proficiency-choice` grants — both were supported by the resolver and SkillsStep/ProficienciesStep but never used by a race. Wiring an `ability-choice` branch into `ChoicePicker` and surfacing the picker in `AbilitiesStep` unblocks every future race with similar mechanics.

## Traits

- +2 CHA (fixed)
- +1 to two other abilities of player's choice
- Darkvision 60 ft
- Fey Ancestry (advantage vs charm, immune to magical sleep)
- Skill Versatility: proficiency in 2 skills of player's choice
- One extra language of choice
- Speed 30, Size medium
- Common + Elvish fixed; 1 more language via choice

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint`
- [x] `npm run test -- --run`
- [ ] Manual: create Half-Elf → AbilitiesStep shows racial ability picker; pick 2; CHA reflects +2 and selected abilities reflect +1
- [ ] Manual: SkillsStep shows 2-skill versatility picker; ProficienciesStep shows extra-language picker
- [ ] Manual: sheet shows 3 Half-Elf features; clearing choices surfaces them in PendingChoicesPanel

🤖 Generated with [Claude Code](https://claude.com/claude-code)