### PR TITLE
[5.5e] Translations: rename races to species (data + UI labels)

### DIFF
--- a/src/components/character-builder/BasicsStep.tsx
+++ b/src/components/character-builder/BasicsStep.tsx
@@ -364,7 +364,7 @@ export function BasicsStep({ onRequestAdvance }: BasicsStepProps) {
             <Select
               value={race || null}
               onValueChange={(value) => value && handleRaceChange(value as SpeciesId)}
-              items={DND_SPECIES.map((s) => ({ value: s.id, label: t(`races.${s.id}`) }))}
+              items={DND_SPECIES.map((s) => ({ value: s.id, label: t(`species.${s.id}`) }))}
             >
               <SelectTrigger className="w-full">
                 <SelectValue placeholder={tc('characterBuilder.placeholders.chooseRace')} />
@@ -372,7 +372,7 @@ export function BasicsStep({ onRequestAdvance }: BasicsStepProps) {
               <SelectContent>
                 {DND_SPECIES.map((s) => (
                   <SelectItem key={s.id} value={s.id}>
-                    {t(`races.${s.id}`)}
+                    {t(`species.${s.id}`)}
                   </SelectItem>
                 ))}
               </SelectContent>

--- a/src/components/character-builder/BasicsStep.tsx
+++ b/src/components/character-builder/BasicsStep.tsx
@@ -323,7 +323,7 @@ export function BasicsStep({ onRequestAdvance }: BasicsStepProps) {
               disabled={!race || !gender}
               title={
                 !race || !gender
-                  ? tc('characterBuilder.hints.selectRaceAndGender')
+                  ? tc('characterBuilder.hints.selectSpeciesAndGender')
                   : tc('characterBuilder.hints.generateRandomName')
               }
               onClick={() => {
@@ -367,7 +367,7 @@ export function BasicsStep({ onRequestAdvance }: BasicsStepProps) {
               items={DND_SPECIES.map((s) => ({ value: s.id, label: t(`species.${s.id}`) }))}
             >
               <SelectTrigger className="w-full">
-                <SelectValue placeholder={tc('characterBuilder.placeholders.chooseRace')} />
+                <SelectValue placeholder={tc('characterBuilder.placeholders.chooseSpecies')} />
               </SelectTrigger>
               <SelectContent>
                 {DND_SPECIES.map((s) => (

--- a/src/components/character-builder/BasicsStep.tsx
+++ b/src/components/character-builder/BasicsStep.tsx
@@ -358,7 +358,7 @@ export function BasicsStep({ onRequestAdvance }: BasicsStepProps) {
         <div className="space-y-4">
           <div className="space-y-2">
             <Label>
-              {tc('characterBuilder.fields.race')}
+              {tc('characterBuilder.fields.species')}
               <span className="text-destructive">*</span>
             </Label>
             <Select

--- a/src/components/character-builder/PhysicalCharacteristics.test.tsx
+++ b/src/components/character-builder/PhysicalCharacteristics.test.tsx
@@ -17,9 +17,9 @@ vi.mock('react-i18next', () => ({
 }));
 
 describe('PhysicalCharacteristics', () => {
-  it('renders noRace message when speciesId is null', () => {
+  it('renders noSpecies message when speciesId is null', () => {
     render(<PhysicalCharacteristics speciesId={null} height={null} weight={null} onChange={vi.fn()} />);
-    expect(screen.getByText(/noRace/i)).toBeInTheDocument();
+    expect(screen.getByText(/noSpecies/i)).toBeInTheDocument();
     expect(screen.queryByRole('spinbutton')).toBeNull();
   });
 

--- a/src/components/character-builder/PhysicalCharacteristics.tsx
+++ b/src/components/character-builder/PhysicalCharacteristics.tsx
@@ -80,7 +80,7 @@ export function PhysicalCharacteristics({
   if (!physicals) {
     return (
       <div className={`rounded-md border p-4 text-sm text-muted-foreground${className ? ` ${className}` : ''}`}>
-        {t('characterBuilder.backstory.physicals.noRace')}
+        {t('characterBuilder.backstory.physicals.noSpecies')}
       </div>
     );
   }

--- a/src/components/character-builder/ProficienciesStep.tsx
+++ b/src/components/character-builder/ProficienciesStep.tsx
@@ -106,7 +106,7 @@ export function ProficienciesStep() {
     if (isGranted) {
       checkbox = (
         <BadgeCheckIcon
-          aria-label={tc('characterBuilder.proficiencies.grantedByRace')}
+          aria-label={tc('characterBuilder.proficiencies.grantedBySpecies')}
           className="flex size-4 shrink-0 text-primary"
         />
       );
@@ -362,7 +362,7 @@ export function ProficienciesStep() {
             </tbody>
           </table>
         ) : (
-          <p className="text-muted-foreground text-sm">{tc('characterBuilder.proficiencies.selectRaceFirst')}</p>
+          <p className="text-muted-foreground text-sm">{tc('characterBuilder.proficiencies.selectSpeciesFirst')}</p>
         )}
       </div>
     </div>

--- a/src/lib/character-builder/choice-source-name.ts
+++ b/src/lib/character-builder/choice-source-name.ts
@@ -6,7 +6,7 @@ export function getChoiceSourceName(choiceKey: ChoiceKey, t: TFunction<'gamedata
   const { origin, id } = parseChoiceKey(choiceKey);
   switch (origin) {
     case 'species':
-      return t(`races.${id as SpeciesId}`);
+      return t(`species.${id as SpeciesId}`);
     case 'background':
       return t(`backgrounds.${id as BackgroundId}`);
     case 'class':

--- a/src/lib/class-icons.ts
+++ b/src/lib/class-icons.ts
@@ -62,7 +62,7 @@ const BUNDLE_TO_CLASS: ReadonlyMap<string, ClassId> = (() => {
 export function getSourceDisplayName(source: SourceTag, tGamedata: TFunction<'gamedata'>): string {
   switch (source.origin) {
     case 'species':
-      return tGamedata(`races.${source.id}`, { defaultValue: source.id });
+      return tGamedata(`species.${source.id}`, { defaultValue: source.id });
     case 'class':
       return tGamedata(`classes.${source.id}`, { defaultValue: source.id });
     case 'subclass':

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -105,7 +105,7 @@
     },
     "fields": {
       "characterName": "Character Name",
-      "race": "Race",
+      "species": "Species",
       "class": "Class",
       "gender": "Gender",
       "playerName": "Player Name",
@@ -159,7 +159,7 @@
     "finalizeBlockers": {
       "title": "Before you can finalize:",
       "missingName": "Character name is required",
-      "missingRace": "Race is required",
+      "missingSpecies": "Species is required",
       "missingClass": "Class is required",
       "missingBackground": "Background is required",
       "pendingChoice": "Pending {{type}} ({{key}})"
@@ -347,7 +347,7 @@
     "fields": {
       "class": "Class",
       "level": "Level",
-      "race": "Race",
+      "species": "Species",
       "background": "Background",
       "alignment": "Alignment",
       "player": "Player",
@@ -512,7 +512,7 @@
     "loading": "Loading characters...",
     "noCharactersFound": "No characters found",
     "player": "Player: {{name}}",
-    "race": "Race",
+    "species": "Species",
     "background": "Background",
     "class": "Class",
     "level": "Level",
@@ -690,7 +690,7 @@
     "restoreHint": "The exported file can be restored with:"
   },
   "provenance": {
-    "race": "Race",
+    "species": "Species",
     "class": "Class",
     "background": "Background"
   },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -140,7 +140,7 @@
         "finalWeight": "Weight",
         "formula": "{{base}} + {{dice}}",
         "weightFormula": "{{base}} lbs + (height mod × {{dice}}) lbs",
-        "noRace": "Pick a species on the Basics step to set height and weight."
+        "noSpecies": "Pick a species on the Basics step to set height and weight."
       }
     },
     "pendingChoices": {
@@ -177,7 +177,7 @@
     "placeholders": {
       "enterCharacterName": "Enter character name",
       "enterPlayerName": "Enter player name",
-      "chooseRace": "Choose a race",
+      "chooseSpecies": "Choose a species",
       "chooseClass": "Choose a class",
       "chooseBackground": "Choose a background",
       "describeBackground": "Describe your background briefly",
@@ -197,12 +197,12 @@
       "cantrips": "e.g., Fire Bolt, Mage Hand"
     },
     "hints": {
-      "selectRaceAndGender": "Select race and gender first",
+      "selectSpeciesAndGender": "Select species and gender first",
       "generateRandomName": "Generate random name",
       "couldNotLoadPlayerNames": "Could not load player name suggestions",
       "quickNpcDescription": "Create a random NPC of this class and jump ahead in the wizard",
       "quickNpcButton": "Random {{class}} NPC",
-      "quickNpcFailed": "Could not generate NPC — name data missing for selected race",
+      "quickNpcFailed": "Could not generate NPC — name data missing for selected species",
       "quickNpcUnknownClass": "Could not generate NPC — unknown class",
       "quickNpcEmptyDataSource": "Could not generate NPC — required data is missing",
       "quickNpcCommitFailed": "Could not apply NPC — please try again",
@@ -228,7 +228,7 @@
       "increaseScore_plural": "Increase score, spend {{count}} points",
       "maximumScore": "Maximum score",
       "notEnoughPoints": "Not enough points",
-      "racialBonus": "{{race}} Racial Bonus: {{bonuses}}",
+      "speciesBonus": "{{species}} Species Bonus: {{bonuses}}",
       "backgroundAsi": "Background bonus",
       "backgroundBonus": "{{background}} bonus",
       "anyAbility": "any ability",
@@ -246,7 +246,7 @@
     },
     "proficiencies": {
       "selectClassFirst": "Please select a class in the Basics step before viewing proficiencies.",
-      "selectRaceFirst": "Please select a race in the Basics step before viewing languages.",
+      "selectSpeciesFirst": "Please select a species in the Basics step before viewing languages.",
       "armorProficiencies": "Armor Proficiencies",
       "weaponProficiencies": "Weapon Proficiencies",
       "toolProficiencies": "Tool Proficiencies",
@@ -256,7 +256,7 @@
       "languageName": "Language",
       "typicalSpeakers": "Typical Speakers",
       "script": "Script",
-      "grantedByRace": "Granted",
+      "grantedBySpecies": "Granted",
       "chooseTools": "Choose {{count}} tool proficiency from the list below.",
       "chooseTools_plural": "Choose {{count}} tool proficiencies from the list below.",
       "randomizeLanguage": "Roll random language (d12)",
@@ -265,7 +265,7 @@
       "selected": "{{count}} / {{max}} selected",
       "noProficiencies": "None",
       "fromClass": "From class",
-      "fromRace": "From race"
+      "fromSpecies": "From species"
     },
     "classFeatures": {
       "fightingStyles": "Fighting Styles",
@@ -501,7 +501,7 @@
     "subtitle": "{{count}} total",
     "pcCount": "{{count}} PCs",
     "npcCount": "{{count}} NPCs",
-    "searchPlaceholder": "Search by name, player, race, or class...",
+    "searchPlaceholder": "Search by name, player, species, or class...",
     "allCharacters": "All Characters",
     "playerCharacters": "Player Characters",
     "npcs": "NPCs",
@@ -620,7 +620,7 @@
       "viewAllCharacters": "View all {{count}} characters →",
       "failedToLoadCharacters": "Failed to load characters",
       "playedBy": "Played by {{name}}",
-      "charSummary": "{{race}} {{class}} • Level {{level}}"
+      "charSummary": "{{species}} {{class}} • Level {{level}}"
     },
     "toolkit": {
       "title": "Campaign Toolkit"

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1,5 +1,5 @@
 {
-  "races": {
+  "species": {
     "aasimar": "Aasimar",
     "dragonborn": "Dragonborn",
     "dwarf": "Dwarf",

--- a/src/pages/CampaignDashboard.tsx
+++ b/src/pages/CampaignDashboard.tsx
@@ -455,7 +455,9 @@ export default function CampaignDashboard() {
                           </p>
                           <p className="text-muted-foreground text-sm">
                             {t('campaign.party.charSummary', {
-                              race: char.species ? tg(`species.${char.species}`, { defaultValue: char.species }) : '',
+                              species: char.species
+                                ? tg(`species.${char.species}`, { defaultValue: char.species })
+                                : '',
                               class: char.class ? tg(`classes.${char.class}`, { defaultValue: char.class }) : '',
                               level: char.level,
                             })}

--- a/src/pages/CampaignDashboard.tsx
+++ b/src/pages/CampaignDashboard.tsx
@@ -455,7 +455,7 @@ export default function CampaignDashboard() {
                           </p>
                           <p className="text-muted-foreground text-sm">
                             {t('campaign.party.charSummary', {
-                              race: char.species ? tg(`races.${char.species}`, { defaultValue: char.species }) : '',
+                              race: char.species ? tg(`species.${char.species}`, { defaultValue: char.species }) : '',
                               class: char.class ? tg(`classes.${char.class}`, { defaultValue: char.class }) : '',
                               level: char.level,
                             })}

--- a/src/pages/CharacterBuilder.tsx
+++ b/src/pages/CharacterBuilder.tsx
@@ -296,7 +296,7 @@ function CharacterBuilderInner() {
             <>
               <span className="font-semibold text-foreground">{character.name}</span>
               {' · '}
-              {tg(`races.${selectedRace.id}`)}
+              {tg(`species.${selectedRace.id}`)}
               {' · '}
               {tg(`classes.${selectedClass.id}`)}
               {character.background && isBackgroundId(character.background) && (

--- a/src/pages/CharacterBuilder.tsx
+++ b/src/pages/CharacterBuilder.tsx
@@ -170,7 +170,7 @@ function CharacterBuilderInner() {
   const finalizeBlockers: readonly string[] = (() => {
     const reasons: string[] = [];
     if (!character.name) reasons.push(t('characterBuilder.finalizeBlockers.missingName'));
-    if (!character.species) reasons.push(t('characterBuilder.finalizeBlockers.missingRace'));
+    if (!character.species) reasons.push(t('characterBuilder.finalizeBlockers.missingSpecies'));
     if (!character.class) reasons.push(t('characterBuilder.finalizeBlockers.missingClass'));
     if (!character.background) reasons.push(t('characterBuilder.finalizeBlockers.missingBackground'));
     for (const pending of resolved?.pendingChoices ?? []) {

--- a/src/pages/CharacterList.tsx
+++ b/src/pages/CharacterList.tsx
@@ -205,7 +205,7 @@ export default function CharacterList() {
 
                 <div className="space-y-2 mb-4">
                   <div className="flex justify-between text-sm">
-                    <span className="text-muted-foreground">{t('characterList.race')}</span>
+                    <span className="text-muted-foreground">{t('characterList.species')}</span>
                     <span className="text-foreground">
                       {character.species ? tg(`species.${character.species}`, { defaultValue: character.species }) : ''}
                     </span>

--- a/src/pages/CharacterList.tsx
+++ b/src/pages/CharacterList.tsx
@@ -207,7 +207,7 @@ export default function CharacterList() {
                   <div className="flex justify-between text-sm">
                     <span className="text-muted-foreground">{t('characterList.race')}</span>
                     <span className="text-foreground">
-                      {character.species ? tg(`races.${character.species}`, { defaultValue: character.species }) : ''}
+                      {character.species ? tg(`species.${character.species}`, { defaultValue: character.species }) : ''}
                     </span>
                   </div>
                   {character.background && isBackgroundId(character.background) && (

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -270,7 +270,7 @@ function CharacterSheetInner({
               <p className="text-foreground font-semibold">{resolvedLevel}</p>
             </div>
             <div>
-              <span className="text-muted-foreground">{tc('characterSheet.fields.race')}</span>
+              <span className="text-muted-foreground">{tc('characterSheet.fields.species')}</span>
               <p className="text-foreground font-semibold">
                 {character.species ? t(`species.${character.species}`, { defaultValue: character.species }) : ''}
               </p>

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -272,7 +272,7 @@ function CharacterSheetInner({
             <div>
               <span className="text-muted-foreground">{tc('characterSheet.fields.race')}</span>
               <p className="text-foreground font-semibold">
-                {character.species ? t(`races.${character.species}`, { defaultValue: character.species }) : ''}
+                {character.species ? t(`species.${character.species}`, { defaultValue: character.species }) : ''}
               </p>
             </div>
             <div>
@@ -490,7 +490,7 @@ function CharacterSheetInner({
                                 : resolvedFeature.source.origin === 'subclass'
                                   ? t(`subclasses.${resolvedFeature.source.id}.name`)
                                   : resolvedFeature.source.origin === 'species'
-                                    ? t(`races.${resolvedFeature.source.id}`)
+                                    ? t(`species.${resolvedFeature.source.id}`)
                                     : resolvedFeature.source.origin === 'background'
                                       ? t(`backgrounds.${resolvedFeature.source.id}`)
                                       : resolvedFeature.source.origin === 'loot'


### PR DESCRIPTION
Closes #97

## Summary

Renames `races` → `species` throughout the i18n stack to match the 2024 data model. Three commits:

1. **`feat(i18n): rename gamedata races to species for 5.5e`** — top-level `races` key in `gamedata.json` renamed to `species`; updates all 9 `t('races.…')` data-namespace consumers.
2. **`refactor(i18n): rename UI label race to species`** — renames the user-facing "Race" labels in `common.json` (5 keys) and updates the 4 consumers. Eliminates the inconsistency where the storage column was `species` but the UI still said "Race".
3. **`refactor(i18n): scrub remaining race copy in helper text`** — surfaced by a Playwright UI smoke test: 5 remaining "race" strings in placeholders, tooltips, and toast/error copy (`Choose a race`, `Select race and gender first`, `…name data missing for selected race`, `Please select a race in the Basics step…`, `Search by name, player, race, or class…`), plus consistency renames of related keys (`noRace`, `racialBonus`, `grantedByRace`, `fromRace`) and the `charSummary` interpolation token `{{race}}` → `{{species}}`.

## What changed

- `src/locales/en/gamedata.json` — top-level `races` → `species`
- `src/locales/en/common.json` — 15 key/value changes across `characterBuilder.placeholders`, `.hints`, `.fields`, `.finalizeBlockers`, `.abilities`, `.backstory.physicals`, `.proficiencies`; `characterSheet.fields`; `characterList`; `provenance`; `campaign.party.charSummary`
- 8 TS/TSX consumers updated to new key paths and the `charSummary` interpolation property
- `PhysicalCharacteristics.test.tsx` — test name + matcher updated to reflect `noRace` → `noSpecies` rename

## Notes

The issue description called for adding species (aasimar, goliath, orc), backgrounds (artisan, farmer, guard, guide, merchant, scribe, wayfarer), the feat catalog, weapon mastery properties, conditions, and Common Sign Language. Architect's review confirmed all of these are already present in `gamedata.json` from prior 5.5e PRs (#88, #89, #90, #94, #95, #109, #124, #125, plus the conditions catalog). No obsolete top-level keys (halfelf, halforc, dwarf-hill, etc.) exist in the JSON — those legacy IDs appear only inside compound feature IDs (e.g., `elf-high-elf-cantrip`) that remain in use.

`src/@types/i18next.d.ts` needs no changes — it derives its resource map from `typeof gamedata` / `typeof common`, so the renames propagate automatically.

## Testing

- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run test` — 1234 tests across 53 files, all passing
- [x] Playwright UI smoke test of all 4 species-displaying screens (builder, list, sheet, dashboard) — display names render correctly, "Species" label everywhere, no missing-key warnings in browser console

🤖 Generated with [Claude Code](https://claude.com/claude-code)
