### PR TITLE
[5.5e] Character sheet UI: Heroic Inspiration, Exhaustion, mastery display

### DIFF
--- a/src/components/character-builder/BackgroundStep.test.tsx
+++ b/src/components/character-builder/BackgroundStep.test.tsx
@@ -95,6 +95,8 @@ function buildSeedCharacter(overrides?: Partial<Character>): Character {
     created_at: '',
     updated_at: '',
     weapon_masteries: null,
+    heroic_inspiration: false,
+    exhaustion_level: 0 as const,
     ...overrides,
   };
 }

--- a/src/components/character-builder/BasicsStep.test.tsx
+++ b/src/components/character-builder/BasicsStep.test.tsx
@@ -145,6 +145,8 @@ function buildSeedCharacter(overrides?: Partial<Character>): Character {
     created_at: '',
     updated_at: '',
     weapon_masteries: null,
+    heroic_inspiration: false,
+    exhaustion_level: 0 as const,
     ...overrides,
   };
 }

--- a/src/components/character-builder/BasicsStep.test.tsx
+++ b/src/components/character-builder/BasicsStep.test.tsx
@@ -264,6 +264,56 @@ describe('BasicsStep', () => {
     expect(mockLevelUp).toHaveBeenCalledWith('fighter', null);
   });
 
+  it('writes a lineage-choice decision to updateCreation when the rolled species has a lineage', () => {
+    vi.spyOn(randomNpcModule, 'generateRandomNpcBasicsDetailed').mockReturnValue({
+      ok: true,
+      basics: {
+        gender: 'female',
+        species: 'tiefling',
+        alignment: 'ne',
+        name: 'Test Tiefling',
+        classId: 'fighter',
+        baseAbilities: { str: 15, dex: 13, con: 14, int: 12, wis: 10, cha: 8 },
+        suggestedBackground: 'soldier',
+        targetStep: 'skills',
+        lineageDecision: { key: 'lineage-choice:species:tiefling:0', lineageId: 'infernal' },
+      },
+    });
+
+    render(<BasicsStep />);
+    fireEvent.click(screen.getByRole('button', { name: /fighter/i }));
+
+    const creationCall = mockUpdateCreation.mock.calls[0][0] as { choices?: Record<string, unknown> };
+    expect(creationCall.choices).toBeDefined();
+    expect(creationCall.choices?.['lineage-choice:species:tiefling:0']).toEqual({
+      type: 'lineage-choice',
+      lineageId: 'infernal',
+    });
+  });
+
+  it('omits choices from updateCreation when neither ASI nor lineage decisions are present', () => {
+    vi.spyOn(randomNpcModule, 'generateRandomNpcBasicsDetailed').mockReturnValue({
+      ok: true,
+      basics: {
+        gender: 'male',
+        species: 'human',
+        alignment: 'lg',
+        name: 'Test Human',
+        classId: 'fighter',
+        baseAbilities: { str: 15, dex: 13, con: 14, int: 12, wis: 10, cha: 8 },
+        suggestedBackground: 'soldier',
+        targetStep: 'skills',
+        // No backgroundAsiDecision, no lineageDecision
+      },
+    });
+
+    render(<BasicsStep />);
+    fireEvent.click(screen.getByRole('button', { name: /fighter/i }));
+
+    const creationCall = mockUpdateCreation.mock.calls[0][0] as { choices?: unknown };
+    expect(creationCall.choices).toBeUndefined();
+  });
+
   it('omitting onRequestAdvance does not crash', () => {
     render(<BasicsStep />);
     expect(() => fireEvent.click(screen.getByRole('button', { name: /fighter/i }))).not.toThrow();

--- a/src/components/character-builder/BasicsStep.tsx
+++ b/src/components/character-builder/BasicsStep.tsx
@@ -240,20 +240,33 @@ export function BasicsStep({ onRequestAdvance }: BasicsStepProps) {
         level: 1,
         ...(basics.targetStep === 'skills' ? { background: basics.suggestedBackground } : {}),
       });
+      const asiDecision = basics.targetStep === 'skills' ? basics.backgroundAsiDecision : undefined;
+      const choices = {
+        ...(asiDecision
+          ? {
+              [asiDecision.key]: {
+                type: 'asi' as const,
+                allocation: asiDecision.allocation,
+              },
+            }
+          : {}),
+        ...(basics.lineageDecision
+          ? {
+              [basics.lineageDecision.key]: {
+                type: 'lineage-choice' as const,
+                lineageId: basics.lineageDecision.lineageId,
+              },
+            }
+          : {}),
+      };
+      const hasChoices = Object.keys(choices).length > 0;
       if (basics.targetStep === 'skills') {
         context.updateCreation({
           base_abilities: basics.baseAbilities,
-          ...(basics.backgroundAsiDecision
-            ? {
-                choices: {
-                  [basics.backgroundAsiDecision.key]: {
-                    type: 'asi' as const,
-                    allocation: basics.backgroundAsiDecision.allocation,
-                  },
-                },
-              }
-            : {}),
+          ...(hasChoices ? { choices } : {}),
         });
+      } else if (hasChoices) {
+        context.updateCreation({ choices });
       }
     } catch (err) {
       pendingAdvanceRef.current = null;

--- a/src/components/character-sheet/StatusPanel.test.tsx
+++ b/src/components/character-sheet/StatusPanel.test.tsx
@@ -82,6 +82,14 @@ describe('StatusPanel', () => {
     expect(onUpdate).toHaveBeenCalledWith({ heroic_inspiration: true });
   });
 
+  it('calls onUpdate with heroic_inspiration: false when switch is toggled off', () => {
+    const onUpdate = vi.fn();
+    render(<StatusPanel character={makeCharacter({ heroic_inspiration: true })} onUpdate={onUpdate} />);
+    const switchEl = screen.getByRole('switch');
+    fireEvent.click(switchEl);
+    expect(onUpdate).toHaveBeenCalledWith({ heroic_inspiration: false });
+  });
+
   it('shows current exhaustion level', () => {
     render(<StatusPanel character={makeCharacter({ exhaustion_level: 3 as ExhaustionLevel })} onUpdate={vi.fn()} />);
     expect(screen.getByText('3')).toBeInTheDocument();

--- a/src/components/character-sheet/StatusPanel.test.tsx
+++ b/src/components/character-sheet/StatusPanel.test.tsx
@@ -1,0 +1,144 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import { StatusPanel } from '@/components/character-sheet/StatusPanel';
+import type { Character } from '@/types/database';
+import type { ExhaustionLevel } from '@/lib/dnd-helpers';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string; penalty?: number }) => {
+      if (key === 'characterSheet.status.exhaustionPenalty' && opts?.penalty !== undefined) {
+        return `-${opts.penalty} to d20 rolls`;
+      }
+      const segments = key.split('.');
+      return opts?.defaultValue ?? segments[segments.length - 1];
+    },
+  }),
+}));
+
+function makeCharacter(overrides: Partial<Character> = {}): Character {
+  return {
+    id: 'char-1',
+    slug: 'test-char',
+    previous_slugs: [],
+    created_at: '2026-01-01T00:00:00Z',
+    updated_at: '2026-01-01T00:00:00Z',
+    campaign_id: 'campaign-1',
+    name: 'Test Character',
+    player_name: null,
+    character_type: 'pc',
+    species: null,
+    class: null,
+    subclass: null,
+    level: 1,
+    background: null,
+    alignment: null,
+    gender: null,
+    size: null,
+    age: null,
+    height: null,
+    weight: null,
+    eye_color: null,
+    hair_color: null,
+    skin_color: null,
+    hit_points_max: null,
+    armor_class: null,
+    speed: null,
+    proficiency_bonus: null,
+    personality_traits: null,
+    ideals: null,
+    bonds: null,
+    flaws: null,
+    appearance: null,
+    backstory: null,
+    notes: null,
+    portrait_url: null,
+    is_active: true,
+    status: 'ready',
+    weapon_masteries: null,
+    heroic_inspiration: false,
+    exhaustion_level: 0 as ExhaustionLevel,
+    ...overrides,
+  };
+}
+
+describe('StatusPanel', () => {
+  it('renders the Heroic Inspiration switch in unchecked state', () => {
+    render(<StatusPanel character={makeCharacter({ heroic_inspiration: false })} onUpdate={vi.fn()} />);
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl).toHaveAttribute('aria-checked', 'false');
+  });
+
+  it('renders the Heroic Inspiration switch in checked state', () => {
+    render(<StatusPanel character={makeCharacter({ heroic_inspiration: true })} onUpdate={vi.fn()} />);
+    const switchEl = screen.getByRole('switch');
+    expect(switchEl).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('calls onUpdate with heroic_inspiration: true when switch is toggled on', () => {
+    const onUpdate = vi.fn();
+    render(<StatusPanel character={makeCharacter({ heroic_inspiration: false })} onUpdate={onUpdate} />);
+    const switchEl = screen.getByRole('switch');
+    fireEvent.click(switchEl);
+    expect(onUpdate).toHaveBeenCalledWith({ heroic_inspiration: true });
+  });
+
+  it('shows current exhaustion level', () => {
+    render(<StatusPanel character={makeCharacter({ exhaustion_level: 3 as ExhaustionLevel })} onUpdate={vi.fn()} />);
+    expect(screen.getByText('3')).toBeInTheDocument();
+  });
+
+  it('shows no penalty text at exhaustion level 0', () => {
+    render(<StatusPanel character={makeCharacter({ exhaustion_level: 0 as ExhaustionLevel })} onUpdate={vi.fn()} />);
+    expect(screen.queryByText(/d20 rolls/)).not.toBeInTheDocument();
+  });
+
+  it('disables the decrement button at exhaustion level 0', () => {
+    render(<StatusPanel character={makeCharacter({ exhaustion_level: 0 as ExhaustionLevel })} onUpdate={vi.fn()} />);
+    const decrementBtn = screen.getByLabelText('decrement');
+    expect(decrementBtn).toBeDisabled();
+  });
+
+  it('shows penalty text at exhaustion level 3', () => {
+    render(<StatusPanel character={makeCharacter({ exhaustion_level: 3 as ExhaustionLevel })} onUpdate={vi.fn()} />);
+    expect(screen.getByText('-6 to d20 rolls')).toBeInTheDocument();
+  });
+
+  it('shows Speed 0 notice at exhaustion level 5', () => {
+    render(<StatusPanel character={makeCharacter({ exhaustion_level: 5 as ExhaustionLevel })} onUpdate={vi.fn()} />);
+    // speedZero → last segment is 'speedZero'
+    expect(screen.getByText('speedZero')).toBeInTheDocument();
+  });
+
+  it('shows Dead badge at exhaustion level 6', () => {
+    render(<StatusPanel character={makeCharacter({ exhaustion_level: 6 as ExhaustionLevel })} onUpdate={vi.fn()} />);
+    // dead → last segment is 'dead'
+    expect(screen.getByText('dead')).toBeInTheDocument();
+  });
+
+  it('does not show penalty text at exhaustion level 6 (shows dead badge instead)', () => {
+    render(<StatusPanel character={makeCharacter({ exhaustion_level: 6 as ExhaustionLevel })} onUpdate={vi.fn()} />);
+    expect(screen.queryByText(/d20 rolls/)).not.toBeInTheDocument();
+  });
+
+  it('disables the increment button at exhaustion level 6', () => {
+    render(<StatusPanel character={makeCharacter({ exhaustion_level: 6 as ExhaustionLevel })} onUpdate={vi.fn()} />);
+    const incrementBtn = screen.getByLabelText('increment');
+    expect(incrementBtn).toBeDisabled();
+  });
+
+  it('calls onUpdate with exhaustion_level + 1 when increment is clicked', () => {
+    const onUpdate = vi.fn();
+    render(<StatusPanel character={makeCharacter({ exhaustion_level: 2 as ExhaustionLevel })} onUpdate={onUpdate} />);
+    const incrementBtn = screen.getByLabelText('increment');
+    fireEvent.click(incrementBtn);
+    expect(onUpdate).toHaveBeenCalledWith({ exhaustion_level: 3 });
+  });
+
+  it('calls onUpdate with exhaustion_level - 1 when decrement is clicked', () => {
+    const onUpdate = vi.fn();
+    render(<StatusPanel character={makeCharacter({ exhaustion_level: 3 as ExhaustionLevel })} onUpdate={onUpdate} />);
+    const decrementBtn = screen.getByLabelText('decrement');
+    fireEvent.click(decrementBtn);
+    expect(onUpdate).toHaveBeenCalledWith({ exhaustion_level: 2 });
+  });
+});

--- a/src/components/character-sheet/StatusPanel.tsx
+++ b/src/components/character-sheet/StatusPanel.tsx
@@ -1,0 +1,80 @@
+import { Badge } from '@/components/ui/badge';
+import { Button } from '@/components/ui/button';
+import { Switch } from '@/components/ui/switch';
+import { exhaustionPenalty, type ExhaustionLevel } from '@/lib/dnd-helpers';
+import type { Character } from '@/types/database';
+import { useTranslation } from 'react-i18next';
+
+interface StatusPanelProps {
+  readonly character: Character;
+  readonly onUpdate: (updates: Partial<Character>) => void;
+}
+
+export function StatusPanel({ character, onUpdate }: StatusPanelProps): React.JSX.Element {
+  const { t } = useTranslation('common');
+
+  const exhaustionLevel = character.exhaustion_level;
+  const { d20Penalty, dead } = exhaustionPenalty(exhaustionLevel);
+
+  const handleDecrement = (): void => {
+    if (exhaustionLevel <= 0) return;
+    onUpdate({ exhaustion_level: (exhaustionLevel - 1) as ExhaustionLevel });
+  };
+
+  const handleIncrement = (): void => {
+    if (exhaustionLevel >= 6) return;
+    onUpdate({ exhaustion_level: (exhaustionLevel + 1) as ExhaustionLevel });
+  };
+
+  return (
+    <div className="bg-muted/50 p-4 rounded border">
+      <div className="flex flex-wrap gap-6">
+        {/* Heroic Inspiration */}
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={character.heroic_inspiration}
+            onCheckedChange={(v) => onUpdate({ heroic_inspiration: v })}
+            id="heroic-inspiration-switch"
+          />
+          <label htmlFor="heroic-inspiration-switch" className="text-sm font-medium cursor-pointer">
+            {t('characterSheet.status.heroicInspiration')}
+          </label>
+        </div>
+
+        {/* Exhaustion stepper */}
+        <div className="flex flex-col gap-1">
+          <span className="text-sm font-medium">{t('characterSheet.status.exhaustionLevel')}</span>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="icon-sm"
+              onClick={handleDecrement}
+              disabled={exhaustionLevel <= 0}
+              aria-label={t('characterSheet.status.decrement')}
+            >
+              -
+            </Button>
+            <span className="w-4 text-center font-bold text-sm">{exhaustionLevel}</span>
+            <Button
+              variant="outline"
+              size="icon-sm"
+              onClick={handleIncrement}
+              disabled={exhaustionLevel >= 6}
+              aria-label={t('characterSheet.status.increment')}
+            >
+              +
+            </Button>
+          </div>
+          {dead ? (
+            <Badge variant="destructive">{t('characterSheet.status.dead')}</Badge>
+          ) : exhaustionLevel >= 1 ? (
+            <div className="text-xs text-muted-foreground space-y-0.5">
+              <p>{t('characterSheet.status.exhaustionPenalty', { penalty: d20Penalty })}</p>
+              {exhaustionLevel >= 5 && <p>{t('characterSheet.status.speedZero')}</p>}
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/hooks/useBuilderAutosave.test.ts
+++ b/src/hooks/useBuilderAutosave.test.ts
@@ -54,6 +54,8 @@ const basePayload: AutosavePayload = {
     is_active: true,
     status: 'draft' as const,
     weapon_masteries: null,
+    heroic_inspiration: false,
+    exhaustion_level: 0 as const,
   },
   rows: [],
   resolved: null,

--- a/src/hooks/useBuilderAutosave.ts
+++ b/src/hooks/useBuilderAutosave.ts
@@ -88,6 +88,8 @@ export function useBuilderAutosave(existingCharacterId?: string) {
             backstory: character.backstory,
             notes: character.notes,
             portrait_url: character.portrait_url,
+            heroic_inspiration: character.heroic_inspiration,
+            exhaustion_level: character.exhaustion_level,
             // Pre-calculated fields from resolved (or character if resolved unavailable)
             hit_points_max: resolved?.hitPoints.max ?? character.hit_points_max,
             armor_class: resolved?.armorClass.effective ?? character.armor_class,

--- a/src/hooks/useCharacterContext.test.tsx
+++ b/src/hooks/useCharacterContext.test.tsx
@@ -124,6 +124,8 @@ function buildSeedCharacter(overrides: Partial<Character> = {}): Character {
     created_at: '',
     updated_at: '',
     weapon_masteries: null,
+    heroic_inspiration: false,
+    exhaustion_level: 0 as const,
     ...overrides,
   };
 }

--- a/src/hooks/useCharacters.test.ts
+++ b/src/hooks/useCharacters.test.ts
@@ -53,6 +53,8 @@ const baseCharacter: Character = {
   is_active: true,
   status: 'ready',
   weapon_masteries: null,
+  heroic_inspiration: false,
+  exhaustion_level: 0 as const,
 };
 
 setupMockReset();

--- a/src/lib/character-builder/random-npc.test.ts
+++ b/src/lib/character-builder/random-npc.test.ts
@@ -5,8 +5,10 @@ import {
   generateRandomNpcBasics,
   generateRandomNpcBasicsDetailed,
   getQuickNpcClassIds,
+  pickRandomLineage,
   randomAsiAllocation,
 } from '@/lib/character-builder/random-npc';
+import { LINEAGE_GRANTS_REGISTRY } from '@/lib/sources/species';
 import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
 import { CLASS_SOURCES } from '@/lib/sources/classes';
 import { SPECIES_SOURCES } from '@/lib/sources/species';
@@ -94,6 +96,34 @@ describe('randomAsiAllocation', () => {
     for (const val of Object.values(result)) {
       expect(val).toBeLessThanOrEqual(2);
     }
+  });
+});
+
+describe('pickRandomLineage', () => {
+  it('returns a valid lineage decision for every species with a lineage map', () => {
+    for (const speciesId of Object.keys(LINEAGE_GRANTS_REGISTRY) as Array<keyof typeof LINEAGE_GRANTS_REGISTRY>) {
+      const result = pickRandomLineage(speciesId, () => 0);
+      expect(result).not.toBeNull();
+      if (!result) continue;
+      expect(result.key).toBe(`lineage-choice:species:${speciesId}:0`);
+      expect(Object.keys(LINEAGE_GRANTS_REGISTRY[speciesId])).toContain(result.lineageId);
+    }
+  });
+
+  it('returns null for a species without a lineage map', () => {
+    expect(pickRandomLineage('human', () => 0)).toBeNull();
+    expect(pickRandomLineage('dwarf', () => 0)).toBeNull();
+    expect(pickRandomLineage('halfling', () => 0)).toBeNull();
+    expect(pickRandomLineage('orc', () => 0)).toBeNull();
+    expect(pickRandomLineage('aasimar', () => 0)).toBeNull();
+  });
+
+  it('picks different lineages for different rng values within the same species', () => {
+    const first = pickRandomLineage('dragonborn', () => 0)?.lineageId;
+    const last = pickRandomLineage('dragonborn', () => 0.999)?.lineageId;
+    expect(first).toBeDefined();
+    expect(last).toBeDefined();
+    expect(first).not.toBe(last);
   });
 });
 
@@ -207,5 +237,26 @@ describe('generateRandomNpcBasicsDetailed', () => {
     // rng=()=>0.95: eligible[floor(0.95*7)=6] → tiefling, which has name data → success.
     const result = generateRandomNpcBasicsDetailed('fighter', () => 0.95);
     expect(result.ok).toBe(true);
+  });
+
+  it('includes a lineageDecision when the picked species has a lineage map', () => {
+    // rng=()=>0.95: gender=female, species=tiefling (has lineage), alignment=ce, ...
+    // tiefling has lineage keys [abyssal, chthonic, infernal]; rng=0.95 picks index 2 → infernal
+    const result = generateRandomNpcBasicsDetailed('fighter', () => 0.95);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.basics.species).toBe('tiefling');
+    expect(result.basics.lineageDecision).toBeDefined();
+    expect(result.basics.lineageDecision?.key).toBe('lineage-choice:species:tiefling:0');
+    expect(Object.keys(LINEAGE_GRANTS_REGISTRY.tiefling)).toContain(result.basics.lineageDecision?.lineageId);
+  });
+
+  it('omits lineageDecision when the picked species has no lineage map', () => {
+    // rng=()=>0: gender=male, species=human (no lineage), alignment=lg, ...
+    const result = generateRandomNpcBasicsDetailed('fighter', () => 0);
+    expect(result.ok).toBe(true);
+    if (!result.ok) return;
+    expect(result.basics.species).toBe('human');
+    expect(result.basics.lineageDecision).toBeUndefined();
   });
 });

--- a/src/lib/character-builder/random-npc.ts
+++ b/src/lib/character-builder/random-npc.ts
@@ -3,7 +3,7 @@ import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
 import { getLogger } from '@/lib/logger';
 
 const logger = getLogger('random-npc');
-import { SPECIES_SOURCES } from '@/lib/sources/species';
+import { LINEAGE_GRANTS_REGISTRY, SPECIES_SOURCES } from '@/lib/sources/species';
 import {
   DND_ALIGNMENTS,
   DND_SPECIES_NAMES,
@@ -17,7 +17,7 @@ import {
 } from '@/lib/dnd-helpers';
 import type { AbilityScores } from '@/types/database';
 import type { ClassSource } from '@/types/sources';
-import type { ChoiceKey } from '@/types/choices';
+import { createChoiceKey, type ChoiceKey } from '@/types/choices';
 
 export const STANDARD_ARRAY = [15, 14, 13, 12, 10, 8] as const;
 const ABILITY_KEYS: readonly AbilityKey[] = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
@@ -30,6 +30,10 @@ interface RandomNpcBasicsBase {
   readonly alignment: AlignmentId;
   readonly name: string;
   readonly classId: ClassId;
+  readonly lineageDecision?: {
+    readonly key: ChoiceKey;
+    readonly lineageId: string;
+  };
 }
 
 export type RandomNpcBasics =
@@ -68,6 +72,28 @@ function shuffle<T>(arr: readonly T[], rng: Rng): T[] {
 
 export function getQuickNpcClassIds(): readonly ClassId[] {
   return CLASS_SOURCES.map((c) => c.id);
+}
+
+/**
+ * If the species has lineage options (e.g. dragonborn, elf, gnome, goliath, tiefling),
+ * pick a random lineage and return a ready-to-store choice decision. Returns null
+ * for species without lineage choices (dwarf, halfling, human, orc, aasimar).
+ */
+export function pickRandomLineage(
+  speciesId: SpeciesId,
+  rng: Rng = Math.random
+): { readonly key: ChoiceKey; readonly lineageId: string } | null {
+  const lineageMap = (LINEAGE_GRANTS_REGISTRY as Partial<Record<SpeciesId, Readonly<Record<string, unknown>>>>)[
+    speciesId
+  ];
+  if (!lineageMap) return null;
+  const lineageIds = Object.keys(lineageMap);
+  const lineageId = pick(lineageIds, rng);
+  if (!lineageId) return null;
+  return {
+    key: createChoiceKey('lineage-choice', 'species', speciesId, 0),
+    lineageId,
+  };
 }
 
 /**
@@ -150,11 +176,21 @@ export function generateRandomNpcBasicsDetailed(
     return { ok: false, failure: 'name-generation' };
   }
 
+  const lineageDecision = pickRandomLineage(species, rng) ?? undefined;
+
   const qb = classSource.quickBuild;
   if (!qb) {
     return {
       ok: true,
-      basics: { gender, species, alignment, name, classId, targetStep: 'abilities' },
+      basics: {
+        gender,
+        species,
+        alignment,
+        name,
+        classId,
+        targetStep: 'abilities',
+        ...(lineageDecision !== undefined ? { lineageDecision } : {}),
+      },
     };
   }
 
@@ -187,6 +223,7 @@ export function generateRandomNpcBasicsDetailed(
       suggestedBackground: qb.suggestedBackground,
       targetStep: 'skills',
       ...(backgroundAsiDecision !== undefined ? { backgroundAsiDecision } : {}),
+      ...(lineageDecision !== undefined ? { lineageDecision } : {}),
     },
   };
 }

--- a/src/lib/export-sql.ts
+++ b/src/lib/export-sql.ts
@@ -59,6 +59,8 @@ const TABLE_COLUMNS = {
     { name: 'is_active', type: 'boolean' },
     { name: 'status', type: 'text' },
     { name: 'weapon_masteries', type: 'jsonb' },
+    { name: 'heroic_inspiration', type: 'boolean' },
+    { name: 'exhaustion_level', type: 'integer' },
     { name: 'gender', type: 'text' },
     { name: 'size', type: 'text' },
     { name: 'age', type: 'text' },

--- a/src/lib/query-columns.ts
+++ b/src/lib/query-columns.ts
@@ -6,7 +6,7 @@ export const CAMPAIGN_DETAIL_COLS =
 export const CHARACTER_SUMMARY_COLS =
   'id, slug, previous_slugs, campaign_id, name, player_name, character_type, species, class, subclass, level, hit_points_max, armor_class, updated_at' as const;
 export const CHARACTER_DETAIL_COLS =
-  'id, slug, previous_slugs, campaign_id, name, player_name, character_type, species, class, subclass, background, alignment, gender, size, age, height, weight, eye_color, hair_color, skin_color, level, hit_points_max, armor_class, speed, proficiency_bonus, personality_traits, ideals, bonds, flaws, appearance, backstory, notes, portrait_url, is_active, status, created_at, updated_at' as const;
+  'id, slug, previous_slugs, campaign_id, name, player_name, character_type, species, class, subclass, background, alignment, gender, size, age, height, weight, eye_color, hair_color, skin_color, level, hit_points_max, armor_class, speed, proficiency_bonus, heroic_inspiration, exhaustion_level, personality_traits, ideals, bonds, flaws, appearance, backstory, notes, portrait_url, is_active, status, created_at, updated_at' as const;
 
 export const SESSION_SUMMARY_COLS =
   'id, slug, previous_slugs, campaign_id, session_number, name, date, summary, experience_awarded, created_at, updated_at' as const;

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -514,6 +514,15 @@
       "deleteConfirm": "Are you sure you want to permanently delete {{name}}? This action cannot be undone.",
       "archiveSuccess": "{{name}} has been archived.",
       "deleteSuccess": "{{name}} has been deleted."
+    },
+    "status": {
+      "heroicInspiration": "Heroic Inspiration",
+      "exhaustionLevel": "Exhaustion",
+      "exhaustionPenalty": "-{{penalty}} to d20 rolls",
+      "speedZero": "Speed: 0 ft",
+      "dead": "Dead",
+      "decrement": "Decrease exhaustion",
+      "increment": "Increase exhaustion"
     }
   },
   "characterList": {

--- a/src/pages/CharacterBuilder.tsx
+++ b/src/pages/CharacterBuilder.tsx
@@ -105,6 +105,8 @@ function buildSeedCharacter(campaignId: string): Character {
     created_at: '',
     updated_at: '',
     weapon_masteries: null,
+    heroic_inspiration: false,
+    exhaustion_level: 0 as const,
   };
 }
 

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -208,10 +208,12 @@ function CharacterSheetInner({
   const skills = resolved?.skills;
   const savingThrows = resolved?.savingThrows;
 
-  // Lineage: find the lineage-choice decision made during character creation
+  // Lineage: find the lineage-choice decision made during character creation,
+  // scoped to the current species so stale entries from a prior species are ignored.
   const lineageId: string | null = (() => {
-    if (!build) return null;
-    const entry = Object.entries(build.choices).find(([key]) => key.startsWith('lineage-choice:species:'));
+    if (!build || !character.species) return null;
+    const prefix = `lineage-choice:species:${character.species}:`;
+    const entry = Object.entries(build.choices).find(([key]) => key.startsWith(prefix));
     if (!entry) return null;
     const decision = entry[1];
     return decision.type === 'lineage-choice' ? decision.lineageId : null;

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -13,6 +13,8 @@ import { LevelControls } from '@/components/character-sheet/LevelControls';
 import { PendingChoicesPanel } from '@/components/character-sheet/PendingChoicesPanel';
 import { ProficienciesPanel } from '@/components/character-sheet/ProficienciesPanel';
 import { SkillsPanel } from '@/components/character-sheet/SkillsPanel';
+import { StatusPanel } from '@/components/character-sheet/StatusPanel';
+import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
 import { getGrantIcon, getSourceDisplayName } from '@/lib/class-icons';
 import { getItemDef, getItemNameKey } from '@/lib/sources/items';
 import { useCharacter, useCharacterMutations } from '@/hooks/useCharacters';
@@ -87,6 +89,7 @@ function CharacterSheetInner({
   const {
     character: ctxCharacter,
     rows,
+    build,
     resolved,
     buildError,
     buildWarnings,
@@ -205,6 +208,23 @@ function CharacterSheetInner({
   const skills = resolved?.skills;
   const savingThrows = resolved?.savingThrows;
 
+  // Lineage: find the lineage-choice decision made during character creation
+  const lineageId: string | null = (() => {
+    if (!build) return null;
+    const entry = Object.entries(build.choices).find(([key]) => key.startsWith('lineage-choice:species:'));
+    if (!entry) return null;
+    const decision = entry[1];
+    return decision.type === 'lineage-choice' ? decision.lineageId : null;
+  })();
+
+  // Origin feat: find the feat granted by the character's background source
+  const originFeatId: string | null = (() => {
+    if (!character.background || !isBackgroundId(character.background)) return null;
+    const bg = BACKGROUND_SOURCES.find((s) => s.id === character.background);
+    const featGrant = bg?.grants.find((g) => g.type === 'feat');
+    return featGrant && 'featId' in featGrant ? featGrant.featId : null;
+  })();
+
   return (
     <div className="min-h-screen bg-muted/30">
       <div className="max-w-7xl mx-auto p-8">
@@ -274,6 +294,11 @@ function CharacterSheetInner({
               <p className="text-foreground font-semibold">
                 {character.species ? t(`species.${character.species}`, { defaultValue: character.species }) : ''}
               </p>
+              {lineageId && character.species && (
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {t(`lineages.${character.species}.${lineageId}`, { defaultValue: lineageId })}
+                </p>
+              )}
             </div>
             <div>
               <span className="text-muted-foreground">{tc('characterSheet.fields.background')}</span>
@@ -284,6 +309,11 @@ function CharacterSheetInner({
                     : character.background
                   : ''}
               </p>
+              {originFeatId && (
+                <p className="text-xs text-muted-foreground mt-0.5">
+                  {t(`feats.${originFeatId}.name`, { defaultValue: originFeatId })}
+                </p>
+              )}
             </div>
             <div>
               <span className="text-muted-foreground">{tc('characterSheet.fields.alignment')}</span>
@@ -309,6 +339,11 @@ function CharacterSheetInner({
                 </p>
               </div>
             )}
+          </div>
+
+          {/* Status: Heroic Inspiration & Exhaustion */}
+          <div className="mt-4 pt-4 border-t">
+            <StatusPanel character={character} onUpdate={handleUpdate} />
           </div>
 
           {/* Level Controls */}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -1,4 +1,12 @@
-import type { AlignmentId, ClassId, DndGender, Proficiencies, SpeciesId, SizeId } from '@/lib/dnd-helpers';
+import type {
+  AlignmentId,
+  ClassId,
+  DndGender,
+  ExhaustionLevel,
+  Proficiencies,
+  SpeciesId,
+  SizeId,
+} from '@/lib/dnd-helpers';
 import type { ThemeId } from '@/lib/theme';
 import type { ConditionId } from '@/lib/sources/conditions';
 import type { WeaponMasteryId } from '@/types/items';
@@ -73,6 +81,8 @@ export interface Character {
   is_active: boolean;
   status: 'draft' | 'ready';
   weapon_masteries: readonly { readonly weaponId: string; readonly masteryId: WeaponMasteryId }[] | null;
+  heroic_inspiration: boolean;
+  exhaustion_level: ExhaustionLevel;
 }
 
 // Combat participant

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -198,11 +198,13 @@ export type Database = {
           character_type: string
           class: string | null
           created_at: string
+          exhaustion_level: number
           eye_color: string | null
           flaws: string | null
           gender: string | null
           hair_color: string | null
           height: string | null
+          heroic_inspiration: boolean
           hit_points_max: number | null
           id: string
           ideals: string | null
@@ -238,11 +240,13 @@ export type Database = {
           character_type: string
           class?: string | null
           created_at?: string
+          exhaustion_level?: number
           eye_color?: string | null
           flaws?: string | null
           gender?: string | null
           hair_color?: string | null
           height?: string | null
+          heroic_inspiration?: boolean
           hit_points_max?: number | null
           id?: string
           ideals?: string | null
@@ -278,11 +282,13 @@ export type Database = {
           character_type?: string
           class?: string | null
           created_at?: string
+          exhaustion_level?: number
           eye_color?: string | null
           flaws?: string | null
           gender?: string | null
           hair_color?: string | null
           height?: string | null
+          heroic_inspiration?: boolean
           hit_points_max?: number | null
           id?: string
           ideals?: string | null

--- a/supabase/migrations/20260525000000_add_heroic_inspiration_exhaustion.sql
+++ b/supabase/migrations/20260525000000_add_heroic_inspiration_exhaustion.sql
@@ -1,0 +1,4 @@
+ALTER TABLE characters
+  ADD COLUMN heroic_inspiration boolean NOT NULL DEFAULT false,
+  ADD COLUMN exhaustion_level smallint NOT NULL DEFAULT 0
+    CHECK (exhaustion_level BETWEEN 0 AND 6);


### PR DESCRIPTION
Closes #99

## Summary

Surfaces 2024 mechanics on the character sheet:
- **Heroic Inspiration** boolean toggle (Switch)
- **Exhaustion** 0–6 stepper with live `-2 × level` d20 penalty text, Speed 0 notice at level 5, and "Dead" badge at level 6
- **Lineage / Legacy** sub-label on the species cell (e.g. Drow, Chromatic Red, etc.) drawn from the resolved `lineage-choice` decision
- **Origin Feat** sub-label on the background cell (e.g. *Magic Initiate (Cleric)* for Acolyte) drawn from `BACKGROUND_SOURCES`
- Weapon mastery rendering already existed in `AttacksPanel` — verified unchanged

## What changed

- New migration `20260525000000_add_heroic_inspiration_exhaustion.sql` adding `heroic_inspiration boolean` and `exhaustion_level smallint` (0–6 check) to `characters`
- `Character` type + Supabase types + `export-sql.ts` `TABLE_COLUMNS` updated
- New `StatusPanel` component + 13 RTL tests covering all exhaustion levels and toggle behavior
- `CharacterSheet.tsx` derives `lineageId` from `build.choices` and `originFeatId` from `BACKGROUND_SOURCES`, and renders new sub-labels

## Agents Used

- Architecture: feature-dev:code-architect (agentId a200757153e03ae4c)
- Implementation: typescript-node-implementer (agentId a0778f37ae45c2dee)

## Testing

- [x] `npm run typecheck` — clean
- [x] `npm run test` — 1257 tests pass (54 files)
- [x] `npm run lint` — zero warnings
- [ ] Manual smoke test on a seed character (recommended before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)