### PR TITLE
[5.5e] Documentation refresh

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## What This Is
 
-D&D 5th Edition Campaign Manager — a React SPA for managing campaigns, characters, sessions, encounters, and DM notes. No auth is implemented yet (RLS is enabled but no policies are defined).
+D&D 5.5e (2024 PHB) Campaign Manager — a React SPA for managing campaigns, characters, sessions, encounters, and DM notes. The target ruleset is the 2024 D&D Player's Handbook. No auth is implemented yet (RLS is enabled but no policies are defined).
 
 ## Commands
 
@@ -64,19 +64,21 @@ All user-facing strings must use `react-i18next` translation keys — never hard
 - **Translation files**: `src/locales/en/common.json` and `src/locales/en/gamedata.json`.
 - **Type safety**: `src/@types/i18next.d.ts` maps `resources` to the JSON files, giving compile-time key checking. Invalid `t('nonexistent.key')` calls fail typecheck.
 - **Usage pattern**: `const { t } = useTranslation('common')` for UI strings, `const { t } = useTranslation('gamedata')` for game data. When both are needed in one component, alias one: `const { t: tc } = useTranslation('common')`.
-- **Dynamic keys**: Domain ID types (`RaceId`, `ClassId`, `AlignmentId`) are narrow enough that template literals like ``t(`races.${raceId}`)`` typecheck without casts. If a variable is wider than the key union (e.g., `string` from `Object.entries()`), narrow it first rather than using `as never`.
-- **ID-based data model**: Race, class, background, alignment, and skill values are stored as lowercase IDs in the database (e.g., `dwarf-hill`, `wizard`, `folkhero`). Always translate IDs to display names via `t()` from the `gamedata` namespace — never display raw IDs to users.
+- **Dynamic keys**: Domain ID types (`SpeciesId`, `ClassId`, `AlignmentId`) are narrow enough that template literals like ``t(`species.${speciesId}`)`` typecheck without casts. If a variable is wider than the key union (e.g., `string` from `Object.entries()`), narrow it first rather than using `as never`.
+- **ID-based data model**: Species, class, background, alignment, and skill values are stored as lowercase IDs in the database (e.g., `dwarf`, `wizard`, `acolyte`). Always translate IDs to display names via `t()` from the `gamedata` namespace — never display raw IDs to users.
 
 ### D&D Game Data
 
-`src/lib/dnd-helpers.ts` contains D&D 5e reference data (races, classes, skills, backgrounds, alignments) and utility functions (ability modifier calculation, proficiency bonus, spell slot tables). Race/class/background data uses ID-based keys that correspond to translation keys in `gamedata.json`.
+`src/lib/dnd-helpers.ts` contains D&D 5.5e (2024) reference data (species, classes, skills, backgrounds, alignments, conditions) and utility functions (ability modifier calculation, proficiency bonus, spell slot tables). Species/class/background data uses ID-based keys that correspond to translation keys in `gamedata.json`. See `docs/dnd-2024.md` for the contributor data-shape reference.
 
 `src/lib/sources/` implements the **Source → Grant → Resolver pipeline**:
 
 - `classes.ts` / `subclasses.ts` / `species.ts` / `backgrounds.ts` / `feats.ts` — define `*Source` objects with per-level `Grant[]` arrays
 - `index.ts` — `collectBundles(build)` assembles `GrantBundle[]` from all active sources for a character build
 - `src/lib/resolver/` — `resolveCharacter(bundles, choices)` resolves bundles into a `ResolvedCharacter` (proficiencies, features, pending choices, etc.)
-- All 12 classes have `ClassSource` entries; Fighter and Rogue are the only classes with `SubclassSource` entries so far
+- All 12 classes have `ClassSource` entries; all 48 subclasses have `SubclassSource` registrations. Only Fighter (champion, battlemaster, eldritchknight) and Rogue (thief, assassin, arcanetrickster) have populated `features` arrays — the remaining 42 subclass entries have empty `features: []` stubs awaiting implementation
+- Subclass selection is uniformly at class level 3 for all 12 classes (array index 2 of `ClassSource.levels`), matching the 2024 PHB rule
+- Weapon masteries are defined in `src/types/items.ts` as `WEAPON_MASTERIES` and granted via `weapon-mastery-choice` grants in `ClassSource.levels`; Barbarian, Fighter, Paladin, Ranger, and Rogue receive mastery choices at various levels
 
 ### Database Schema
 

--- a/README.md
+++ b/README.md
@@ -1,12 +1,12 @@
 # D&D Campaign Manager
 
-A free, open-source campaign management tool for D&D 5th Edition. Run it locally as a private, self-hosted app to organize your campaigns, characters, sessions, and DM notes.
+A free, open-source campaign management tool for D&D 5.5e (2024 Player's Handbook). Run it locally as a private, self-hosted app to organize your campaigns, characters, sessions, and DM notes.
 
 ## Features
 
 - **Campaign Management** — Create and manage multiple campaigns with setting info, status tracking, and a dashboard overview
-- **Character Builder** — 7-step wizard (Basics → Abilities → Skills → Class Features → Proficiencies → Equipment → Backstory) with autosave
-- **Character Sheets** — Build and track PCs and NPCs with full 5e stats: ability scores, skills, equipment, spells, and backstory
+- **Character Builder** — 7-step wizard (Basics → Abilities → Skills → Class Features → Proficiencies → Equipment → Backstory) with autosave; implements 2024 species, backgrounds, feat catalog, weapon masteries, and subclass selection at level 3
+- **Character Sheets** — Build and track PCs and NPCs with full 5.5e stats: ability scores, skills, equipment, spells, heroic inspiration, exhaustion, and weapon mastery display
 - **Session Log** — Record session summaries, XP awards, loot tracking, and link encounters to sessions
 - **Encounter Tracker** — Plan encounters with combatant lists and status tracking
 - **DM Notes** — Organize notes by category (plot, NPC, location, loot, rules) with tagging and pinning

--- a/docs/dnd-2024.md
+++ b/docs/dnd-2024.md
@@ -1,0 +1,67 @@
+# D&D 2024 Data Shapes — Contributor Reference
+
+This file describes the data shapes as implemented in this codebase for the D&D 2024 PHB baseline. It is a reference for contributors adding new content — not a complete rules summary. The primary source files are `src/lib/dnd-helpers.ts`, `src/lib/sources/`, and `src/types/`. When in doubt, the code is authoritative.
+
+## Species
+
+Source-of-truth: `src/lib/dnd-helpers.ts` (`SpeciesId`, `DND_SPECIES`), `src/lib/sources/species.ts` (`SPECIES_SOURCES`).
+
+- `SpeciesId` union: `'aasimar' | 'dragonborn' | 'dwarf' | 'elf' | 'gnome' | 'goliath' | 'halfling' | 'human' | 'orc' | 'tiefling'`
+- Each species is a `SpeciesSource` with `id`, `defaultSize` (`'small' | 'medium'`), `defaultSpeed` (number, feet), and `grants` (`Grant[]`).
+- Five species have a `lineage-choice` grant: Dragonborn (15 lineages: chromatic × 5, metallic × 5, gem × 5), Elf (`drow`, `high-elf`, `wood-elf`), Gnome (`forest`, `rock`, `deep`), Goliath (`cloud`, `fire`, `frost`, `hill`, `stone`, `storm`), Tiefling (`abyssal`, `chthonic`, `infernal`).
+- Species do not grant Ability Score Increases — ASIs come entirely from backgrounds (a key 2024 structural change).
+- i18n: display names live at `gamedata.species.<speciesId>` (e.g., `t('species.dwarf')`).
+
+## Backgrounds
+
+Source-of-truth: `src/lib/sources/backgrounds.ts` (`BACKGROUND_SOURCES`), `src/lib/dnd-helpers.ts` (`BackgroundId`).
+
+- `BackgroundId` union: `'acolyte' | 'artisan' | 'charlatan' | 'criminal' | 'entertainer' | 'farmer' | 'guard' | 'guide' | 'hermit' | 'merchant' | 'noble' | 'sage' | 'sailor' | 'scribe' | 'soldier' | 'wayfarer'`
+- Each background is a `BackgroundSource` with `id` and `grants`.
+- Every background grants exactly: one `asi` grant (3 points distributed among a named subset of abilities), two skill proficiencies, one tool proficiency (sometimes a choice), one language choice, and one Origin feat via `{ type: 'feat', featId: '...' }`.
+- Backgrounds are the sole source of ASIs in the 2024 ruleset — species and classes do not grant ability score improvements (except class ASI grants at specific levels).
+- i18n: `gamedata.backgrounds.<backgroundId>`.
+
+## Feat Catalog
+
+Source-of-truth: `src/lib/sources/feats.ts` (`FEAT_SOURCES`), `src/lib/dnd-helpers.ts` (`FeatId`, `FEAT_IDS`), `src/types/sources.ts` (`FeatCategory`, `FeatSource`, `FeatPrerequisite`).
+
+- `FeatCategory`: `'origin' | 'general' | 'fightingStyle' | 'epicBoon'`
+- **Origin feats** (12 total, `prerequisites: []`, granted exclusively by backgrounds): `alert`, `crafter`, `healer`, `lucky`, `magic-initiate-cleric`, `magic-initiate-druid`, `magic-initiate-wizard`, `musician`, `savage-attacker`, `skilled`, `tavern-brawler`, `tough`.
+- **Fighting Style feats** (6 total, `prerequisites: []`, granted by class): `archery`, `defense`, `dueling`, `great-weapon-fighting`, `protection`, `two-weapon-fighting`. Note: `fightingStyle` category feat IDs mirror `FightingStyleId` values — the same string serves both roles intentionally.
+- **General feats** (`level-minimum: 4` prerequisite): approximately 40 entries.
+- **Epic Boon feats** (`level-minimum: 19` prerequisite): 13 entries (`boon-of-combat-prowess` through `boon-of-truesight`).
+- `FeatPrerequisite` union types: `level-minimum`, `ability-minimum`, `proficiency`, `spellcasting`, `class-feature`.
+- Each `FeatSource` grants one or more `Grant` entries — typically `{ type: 'feature', feature: { id: '...' } }`.
+- i18n: `gamedata.feats.<featId>.name` and `.description`.
+
+## Weapon Mastery
+
+Source-of-truth: `src/types/items.ts` (`WEAPON_MASTERIES`, `WeaponMasteryId`, `WeaponDef.mastery`), `src/types/grants.ts` (`WeaponMasteryChoiceGrant`), `src/types/database.ts` (`Character.weapon_masteries`).
+
+- `WEAPON_MASTERIES` values (8): `'cleave' | 'graze' | 'nick' | 'push' | 'sap' | 'slow' | 'topple' | 'vex'`
+- `WeaponDef` carries an optional `mastery?: WeaponMasteryId` field — each weapon in the catalog that has a mastery property lists it here.
+- Characters receive mastery via `weapon-mastery-choice` grants (`WeaponMasteryChoiceGrant`: `{ type: 'weapon-mastery-choice', key, count }`). This is a choice of which proficient weapons to apply a mastery to — not a grant of the mastery mechanic itself.
+- Classes that grant `weapon-mastery-choice`: **Barbarian** (L1: 2, L4: +1, L10: +1), **Fighter** (L1: 2, L4: +1, L8: +1, L13: +1), **Paladin** (L1: 2), **Ranger** (L1: 2), **Rogue** (L1: 1).
+- Stored on the `Character` row as `weapon_masteries: { weaponId: string; masteryId: WeaponMasteryId }[] | null`.
+- i18n: `gamedata.masteries.<masteryId>.name` and `.description`.
+
+## Subclass Selection
+
+Source-of-truth: `src/lib/sources/subclasses.ts` (`SUBCLASS_SOURCES`, `SUBCLASS_IDS_BY_CLASS`), `src/types/sources.ts` (`SubclassSource`, `SubclassFeature`).
+
+- All 12 classes select a subclass at class level 3 (index 2 of `ClassSource.levels`), matching the uniform 2024 PHB rule.
+- `SUBCLASS_IDS_BY_CLASS` maps each `ClassId` to exactly 4 subclass IDs.
+- `SubclassSource` shape: `{ features: SubclassFeature[] }` where `SubclassFeature = { classLevel: number, grants: Grant[] }`.
+- **Populated** subclasses (features implemented): Fighter — `champion`, `battlemaster`, `eldritchknight`; Rogue — `thief`, `assassin`, `arcanetrickster`.
+- **Stub** subclasses (registered but `features: []`): all 42 remaining entries.
+- Subclass grants are injected into the resolver via the `{ type: 'subclass', classId, key }` grant, which produces a `pending-choice` in `ResolvedCharacter` until the player selects one.
+
+## Conditions
+
+Source-of-truth: `src/lib/sources/conditions.ts` (`CONDITION_IDS`, `ConditionId`).
+
+- `CONDITION_IDS` (15 values): `'blinded' | 'charmed' | 'deafened' | 'exhaustion' | 'frightened' | 'grappled' | 'incapacitated' | 'invisible' | 'paralyzed' | 'petrified' | 'poisoned' | 'prone' | 'restrained' | 'stunned' | 'unconscious'`
+- Conditions are stored on `Combatant.conditions: readonly ConditionId[]` in the `Encounter` JSONB column.
+- Exhaustion specifically uses `ExhaustionLevel` (type: `0 | 1 | 2 | 3 | 4 | 5 | 6`) on the `Character` row, defined in `src/lib/dnd-helpers.ts`. The `exhaustionPenalty(level)` function there computes `{ d20Penalty, speedPenalty, dead }`.
+- i18n: `gamedata.conditions.<conditionId>`.

--- a/docs/dnd-2024.md
+++ b/docs/dnd-2024.md
@@ -7,7 +7,7 @@ This file describes the data shapes as implemented in this codebase for the D&D 
 Source-of-truth: `src/lib/dnd-helpers.ts` (`SpeciesId`, `DND_SPECIES`), `src/lib/sources/species.ts` (`SPECIES_SOURCES`).
 
 - `SpeciesId` union: `'aasimar' | 'dragonborn' | 'dwarf' | 'elf' | 'gnome' | 'goliath' | 'halfling' | 'human' | 'orc' | 'tiefling'`
-- Each species is a `SpeciesSource` with `id`, `defaultSize` (`'small' | 'medium'`), `defaultSpeed` (number, feet), and `grants` (`Grant[]`).
+- Each species is a `SpeciesSource` with `id`, `defaultSize` (a `SizeId`; all 10 current species are `small` or `medium`), `defaultSpeed` (number, feet), and `grants` (`Grant[]`).
 - Five species have a `lineage-choice` grant: Dragonborn (15 lineages: chromatic × 5, metallic × 5, gem × 5), Elf (`drow`, `high-elf`, `wood-elf`), Gnome (`forest`, `rock`, `deep`), Goliath (`cloud`, `fire`, `frost`, `hill`, `stone`, `storm`), Tiefling (`abyssal`, `chthonic`, `infernal`).
 - Species do not grant Ability Score Increases — ASIs come entirely from backgrounds (a key 2024 structural change).
 - i18n: display names live at `gamedata.species.<speciesId>` (e.g., `t('species.dwarf')`).
@@ -29,7 +29,7 @@ Source-of-truth: `src/lib/sources/feats.ts` (`FEAT_SOURCES`), `src/lib/dnd-helpe
 - `FeatCategory`: `'origin' | 'general' | 'fightingStyle' | 'epicBoon'`
 - **Origin feats** (12 total, `prerequisites: []`, granted exclusively by backgrounds): `alert`, `crafter`, `healer`, `lucky`, `magic-initiate-cleric`, `magic-initiate-druid`, `magic-initiate-wizard`, `musician`, `savage-attacker`, `skilled`, `tavern-brawler`, `tough`.
 - **Fighting Style feats** (6 total, `prerequisites: []`, granted by class): `archery`, `defense`, `dueling`, `great-weapon-fighting`, `protection`, `two-weapon-fighting`. Note: `fightingStyle` category feat IDs mirror `FightingStyleId` values — the same string serves both roles intentionally.
-- **General feats** (`level-minimum: 4` prerequisite): approximately 40 entries.
+- **General feats** (`level-minimum: 4` prerequisite): approximately 50 entries.
 - **Epic Boon feats** (`level-minimum: 19` prerequisite): 13 entries (`boon-of-combat-prowess` through `boon-of-truesight`).
 - `FeatPrerequisite` union types: `level-minimum`, `ability-minimum`, `proficiency`, `spellcasting`, `class-feature`.
 - Each `FeatSource` grants one or more `Grant` entries — typically `{ type: 'feature', feature: { id: '...' } }`.
@@ -42,9 +42,9 @@ Source-of-truth: `src/types/items.ts` (`WEAPON_MASTERIES`, `WeaponMasteryId`, `W
 - `WEAPON_MASTERIES` values (8): `'cleave' | 'graze' | 'nick' | 'push' | 'sap' | 'slow' | 'topple' | 'vex'`
 - `WeaponDef` carries an optional `mastery?: WeaponMasteryId` field — each weapon in the catalog that has a mastery property lists it here.
 - Characters receive mastery via `weapon-mastery-choice` grants (`WeaponMasteryChoiceGrant`: `{ type: 'weapon-mastery-choice', key, count }`). This is a choice of which proficient weapons to apply a mastery to — not a grant of the mastery mechanic itself.
-- Classes that grant `weapon-mastery-choice`: **Barbarian** (L1: 2, L4: +1, L10: +1), **Fighter** (L1: 2, L4: +1, L8: +1, L13: +1), **Paladin** (L1: 2), **Ranger** (L1: 2), **Rogue** (L1: 1).
+- Classes that grant `weapon-mastery-choice`: **Barbarian** (L1: 2, L4: +1, L10: +1), **Fighter** (L1: 3, L4: +1, L10: +1, L16: +1), **Paladin** (L1: 2), **Ranger** (L1: 2), **Rogue** (L1: 2).
 - Stored on the `Character` row as `weapon_masteries: { weaponId: string; masteryId: WeaponMasteryId }[] | null`.
-- i18n: `gamedata.masteries.<masteryId>.name` and `.description`.
+- i18n: `gamedata.weaponMasteries.<masteryId>.name` and `.description`.
 
 ## Subclass Selection
 


### PR DESCRIPTION
Closes #101

## Summary

Documentation-only update aligning project docs with the D&D 5.5e (2024 PHB) baseline. Refreshes `CLAUDE.md` and `README.md` to state the new edition and corrects stale references (`RaceId` → `SpeciesId`, `races.*` → `species.*`, `dwarf-hill` → `dwarf`). Adds a new contributor reference at `docs/dnd-2024.md` documenting the actual implemented data shapes for species, backgrounds, the feat catalog, weapon mastery, subclass selection, and conditions.

## What Changed

- `CLAUDE.md` — 5 targeted edits: edition statement, i18n examples, dnd-helpers description, subclass coverage (48 registrations / 6 populated / 42 stubs), uniform level-3 subclass rule, new weapon-mastery bullet
- `README.md` — edition statement + feature bullet refresh (2024 species/backgrounds/feats/masteries, level-3 subclass, heroic inspiration, exhaustion, mastery display)
- `docs/dnd-2024.md` — new file: data-shape reference for species, backgrounds, feat catalog (origin/general/fightingStyle/epicBoon), weapon mastery (8 masteries + which classes grant them), subclass selection, and conditions

## Agents Used

- Architecture: `a928845e1d515c958` (feature-dev:code-architect)
- Implementation: `a4ed67f75e555d4f6` (typescript-node-implementer)

## Testing

- [x] All claims verified against source code (file:line excerpts in the architecture brief)
- [x] Diff is documentation-only — no TypeScript/JSON/component files touched
- [x] Implementer ran `npm run typecheck` and `npm run lint` clean against the docs commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)