### PR TITLE
[5.5e] Tests: update existing & extend coverage for 2024 mechanics

### DIFF
--- a/src/lib/resolver/abilities.test.ts
+++ b/src/lib/resolver/abilities.test.ts
@@ -387,7 +387,7 @@ describe('resolveAbilities', () => {
       expect(result.dex.total).toBe(10); // unchanged
     });
 
-    it('background ASI that would push a score from 18 to 21 is capped at 20', () => {
+    it('background ASI +3 wis to a base of 18 caps at 20 — raw 21 clamps to 20', () => {
       const highBase = { ...BASE, wis: 18 };
       const bundles: GrantBundle[] = [
         {
@@ -403,12 +403,13 @@ describe('resolveAbilities', () => {
         },
       ];
       const choices: Readonly<Record<ChoiceKey, ChoiceDecision>> = {
-        'asi:background:acolyte:0': { type: 'asi', allocation: { wis: 2, cha: 1 } },
+        // +3 to wis: raw 18 + 3 = 21, must clamp to 20
+        'asi:background:acolyte:0': { type: 'asi', allocation: { wis: 3 } },
       };
       const result = resolveAbilities(highBase, bundles, choices);
-      expect(result.wis.total).toBe(20); // capped — 18 + 2 would be 20, excess dropped
+      expect(result.wis.total).toBe(20); // capped — raw 21 clamped to 20
       expect(result.wis.modifier).toBe(5);
-      expect(result.cha.total).toBe(11); // unaffected by cap
+      expect(result.cha.total).toBe(10); // unaffected
     });
   });
 });

--- a/src/lib/resolver/abilities.test.ts
+++ b/src/lib/resolver/abilities.test.ts
@@ -350,5 +350,65 @@ describe('resolveAbilities', () => {
       expect(result.wis.bonuses[0].source).toEqual(backgroundSource);
       expect(result.wis.bonuses[0].source.origin).toBe('background');
     });
+
+    it('background ASI and class ASI in the same call both apply — totals sum correctly', () => {
+      const bundles: GrantBundle[] = [
+        {
+          source: { origin: 'background', id: 'acolyte' },
+          grants: [
+            {
+              type: 'asi',
+              key: 'asi:background:acolyte:0',
+              points: 3,
+              from: ['int', 'wis', 'cha'],
+            },
+          ],
+        },
+        {
+          source: { origin: 'class', id: 'fighter', level: 4 },
+          grants: [
+            {
+              type: 'asi',
+              key: 'asi:class:fighter:0',
+              points: 2,
+              from: null,
+            },
+          ],
+        },
+      ];
+      const choices: Readonly<Record<ChoiceKey, ChoiceDecision>> = {
+        'asi:background:acolyte:0': { type: 'asi', allocation: { wis: 2, cha: 1 } },
+        'asi:class:fighter:0': { type: 'asi', allocation: { str: 2 } },
+      };
+      const result = resolveAbilities(BASE, bundles, choices);
+      expect(result.str.total).toBe(12); // 10 + 2 from class ASI
+      expect(result.wis.total).toBe(12); // 10 + 2 from background ASI
+      expect(result.cha.total).toBe(11); // 10 + 1 from background ASI
+      expect(result.dex.total).toBe(10); // unchanged
+    });
+
+    it('background ASI that would push a score from 18 to 21 is capped at 20', () => {
+      const highBase = { ...BASE, wis: 18 };
+      const bundles: GrantBundle[] = [
+        {
+          source: { origin: 'background', id: 'acolyte' },
+          grants: [
+            {
+              type: 'asi',
+              key: 'asi:background:acolyte:0',
+              points: 3,
+              from: ['int', 'wis', 'cha'],
+            },
+          ],
+        },
+      ];
+      const choices: Readonly<Record<ChoiceKey, ChoiceDecision>> = {
+        'asi:background:acolyte:0': { type: 'asi', allocation: { wis: 2, cha: 1 } },
+      };
+      const result = resolveAbilities(highBase, bundles, choices);
+      expect(result.wis.total).toBe(20); // capped — 18 + 2 would be 20, excess dropped
+      expect(result.wis.modifier).toBe(5);
+      expect(result.cha.total).toBe(11); // unaffected by cap
+    });
   });
 });

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -1183,6 +1183,120 @@ describe('Dragonborn lineage-choice integration', () => {
   });
 });
 
+describe('Tiefling lineage-choice integration', () => {
+  const lineageKey = createChoiceKey('lineage-choice', 'species', 'tiefling', 0);
+
+  const tieflingBuild: CharacterBuild = {
+    speciesId: 'tiefling',
+    backgroundId: null,
+    baseAbilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 },
+    abilityMethod: 'standard-array',
+    levels: [{ classId: 'fighter' as ClassId, classLevel: 1, hpRoll: null }],
+    choices: {
+      'skill-choice:class:fighter:0': { type: 'skill-choice', skills: ['athletics', 'perception'] },
+      'fighting-style-choice:class:fighter:0': { type: 'fighting-style-choice', styles: ['defense'] },
+      'bundle-choice:class:fighter:0': { type: 'bundle-choice', bundleId: 'fighter-chainmail', slotPicks: {} },
+      'bundle-choice:class:fighter:1': {
+        type: 'bundle-choice',
+        bundleId: 'martial-weapon-and-shield',
+        slotPicks: { weapon: 'longsword', shield: 'shield' },
+      },
+      'bundle-choice:class:fighter:2': { type: 'bundle-choice', bundleId: 'light-crossbow-kit', slotPicks: {} },
+      'bundle-choice:class:fighter:3': { type: 'bundle-choice', bundleId: 'dungeoneers-pack', slotPicks: {} },
+    } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    feats: [],
+    activeItems: [],
+  };
+
+  it('emits a pending lineage-choice with 3 options when no lineage decision is made', () => {
+    const { bundles } = collectBundles(tieflingBuild);
+    const input: ResolverInput = {
+      baseAbilities: tieflingBuild.baseAbilities,
+      level: 1,
+      bundles,
+      choices: tieflingBuild.choices,
+      levels: tieflingBuild.levels,
+    };
+    const result = resolveCharacter(input);
+    const pending = result.pendingChoices.find((c) => c.type === 'lineage-choice');
+    expect(pending).toBeDefined();
+    expect(pending?.choiceKey).toBe(lineageKey);
+    if (pending?.type === 'lineage-choice') {
+      expect(pending.from.length).toBe(3);
+      expect(pending.speciesId).toBe('tiefling');
+    }
+  });
+
+  it('resolves fire resistance and infernal feature when infernal lineage is chosen', () => {
+    const buildWithLineage: CharacterBuild = {
+      ...tieflingBuild,
+      choices: {
+        ...tieflingBuild.choices,
+        [lineageKey]: { type: 'lineage-choice', lineageId: 'infernal' },
+      } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    };
+    const { bundles } = collectBundles(buildWithLineage);
+    const input: ResolverInput = {
+      baseAbilities: buildWithLineage.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithLineage.choices,
+      levels: buildWithLineage.levels,
+    };
+    const result = resolveCharacter(input);
+    expect(result.resistances.map((r) => r.value)).toContain('fire');
+    expect(result.features.map((f) => f.feature.id)).toContain('tiefling-fiendish-legacy-infernal');
+    const pending = result.pendingChoices.find((c) => c.type === 'lineage-choice');
+    expect(pending).toBeUndefined();
+  });
+
+  it('resolves poison resistance and abyssal feature when abyssal lineage is chosen', () => {
+    const buildWithLineage: CharacterBuild = {
+      ...tieflingBuild,
+      choices: {
+        ...tieflingBuild.choices,
+        [lineageKey]: { type: 'lineage-choice', lineageId: 'abyssal' },
+      } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    };
+    const { bundles } = collectBundles(buildWithLineage);
+    const input: ResolverInput = {
+      baseAbilities: buildWithLineage.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithLineage.choices,
+      levels: buildWithLineage.levels,
+    };
+    const result = resolveCharacter(input);
+    expect(result.resistances.map((r) => r.value)).toContain('poison');
+    expect(result.features.map((f) => f.feature.id)).toContain('tiefling-fiendish-legacy-abyssal');
+    const pending = result.pendingChoices.find((c) => c.type === 'lineage-choice');
+    expect(pending).toBeUndefined();
+  });
+
+  it('resolves necrotic resistance and chthonic feature when chthonic lineage is chosen', () => {
+    const buildWithLineage: CharacterBuild = {
+      ...tieflingBuild,
+      choices: {
+        ...tieflingBuild.choices,
+        [lineageKey]: { type: 'lineage-choice', lineageId: 'chthonic' },
+      } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    };
+    const { bundles } = collectBundles(buildWithLineage);
+    const input: ResolverInput = {
+      baseAbilities: buildWithLineage.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithLineage.choices,
+      levels: buildWithLineage.levels,
+    };
+    const result = resolveCharacter(input);
+    expect(result.resistances.map((r) => r.value)).toContain('necrotic');
+    expect(result.features.map((f) => f.feature.id)).toContain('tiefling-fiendish-legacy-chthonic');
+    const pending = result.pendingChoices.find((c) => c.type === 'lineage-choice');
+    expect(pending).toBeUndefined();
+  });
+});
+
 describe('expertise-choice count and validity validation', () => {
   const expertiseKey0 = createChoiceKey('expertise-choice', 'class', 'rogue', 0);
 
@@ -1456,6 +1570,169 @@ describe('Weapon mastery resolver', () => {
     expect(pending).toHaveLength(1);
     if (pending[0].type !== 'weapon-mastery-choice') throw new Error('Expected weapon-mastery-choice');
     expect(pending[0].count).toBe(2);
+  });
+
+  it('L1 Paladin has a weapon-mastery-choice pending choice with count 2', () => {
+    const paladinBuild: CharacterBuild = {
+      speciesId: 'human',
+      backgroundId: 'soldier',
+      baseAbilities: { str: 15, dex: 13, con: 14, int: 8, wis: 10, cha: 12 },
+      abilityMethod: 'standard-array',
+      choices: {
+        'skill-choice:class:paladin:0': { type: 'skill-choice', skills: ['athletics', 'persuasion'] },
+        'skill-choice:species:human:0': { type: 'skill-choice', skills: ['intimidation'] },
+        'language-choice:species:human:0': { type: 'language-choice', languages: ['elvish'] },
+        'asi:background:soldier:0': { type: 'asi', allocation: { str: 2, con: 1 } },
+        'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+        'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      },
+      levels: [{ classId: 'paladin' as ClassId, classLevel: 1, hpRoll: null }],
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(paladinBuild);
+    const result = resolveCharacter({
+      baseAbilities: paladinBuild.baseAbilities,
+      level: 1,
+      bundles,
+      choices: paladinBuild.choices,
+      levels: paladinBuild.levels,
+    });
+    const pending = result.pendingChoices.filter((c) => c.type === 'weapon-mastery-choice');
+    expect(pending).toHaveLength(1);
+    if (pending[0].type !== 'weapon-mastery-choice') throw new Error('Expected weapon-mastery-choice');
+    expect(pending[0].count).toBe(2);
+  });
+
+  it('L1 Ranger has a weapon-mastery-choice pending choice with count 2', () => {
+    const rangerBuild: CharacterBuild = {
+      speciesId: 'human',
+      backgroundId: 'soldier',
+      baseAbilities: { str: 15, dex: 13, con: 14, int: 8, wis: 10, cha: 12 },
+      abilityMethod: 'standard-array',
+      choices: {
+        'skill-choice:class:ranger:0': { type: 'skill-choice', skills: ['athletics', 'perception'] },
+        'skill-choice:species:human:0': { type: 'skill-choice', skills: ['intimidation'] },
+        'language-choice:species:human:0': { type: 'language-choice', languages: ['elvish'] },
+        'asi:background:soldier:0': { type: 'asi', allocation: { str: 2, con: 1 } },
+        'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+        'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      },
+      levels: [{ classId: 'ranger' as ClassId, classLevel: 1, hpRoll: null }],
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(rangerBuild);
+    const result = resolveCharacter({
+      baseAbilities: rangerBuild.baseAbilities,
+      level: 1,
+      bundles,
+      choices: rangerBuild.choices,
+      levels: rangerBuild.levels,
+    });
+    const pending = result.pendingChoices.filter((c) => c.type === 'weapon-mastery-choice');
+    expect(pending).toHaveLength(1);
+    if (pending[0].type !== 'weapon-mastery-choice') throw new Error('Expected weapon-mastery-choice');
+    expect(pending[0].count).toBe(2);
+  });
+
+  it('L1 Rogue has a weapon-mastery-choice pending choice with count 2', () => {
+    const rogueBuild: CharacterBuild = {
+      speciesId: 'human',
+      backgroundId: 'soldier',
+      baseAbilities: { str: 15, dex: 13, con: 14, int: 8, wis: 10, cha: 12 },
+      abilityMethod: 'standard-array',
+      choices: {
+        'skill-choice:class:rogue:0': {
+          type: 'skill-choice',
+          skills: ['stealth', 'deception', 'perception', 'sleightofhand'],
+        },
+        'skill-choice:species:human:0': { type: 'skill-choice', skills: ['intimidation'] },
+        'language-choice:species:human:0': { type: 'language-choice', languages: ['elvish'] },
+        'asi:background:soldier:0': { type: 'asi', allocation: { str: 2, con: 1 } },
+        'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+        'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      },
+      levels: [{ classId: 'rogue' as ClassId, classLevel: 1, hpRoll: null }],
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(rogueBuild);
+    const result = resolveCharacter({
+      baseAbilities: rogueBuild.baseAbilities,
+      level: 1,
+      bundles,
+      choices: rogueBuild.choices,
+      levels: rogueBuild.levels,
+    });
+    const pending = result.pendingChoices.filter((c) => c.type === 'weapon-mastery-choice');
+    expect(pending).toHaveLength(1);
+    if (pending[0].type !== 'weapon-mastery-choice') throw new Error('Expected weapon-mastery-choice');
+    expect(pending[0].count).toBe(2);
+  });
+
+  it('Fighter at L10 has 3 pending weapon-mastery-choice entries (L1+L4+L10) when no decisions provided', () => {
+    const fighterL10Build: CharacterBuild = {
+      ...fighterL1Build,
+      levels: [
+        { classId: 'fighter' as ClassId, classLevel: 1, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 2, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 3, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 4, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 5, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 6, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 7, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 8, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 9, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 10, hpRoll: null },
+      ],
+    };
+    const { bundles } = collectBundles(fighterL10Build);
+    const result = resolveCharacter({
+      baseAbilities: fighterL10Build.baseAbilities,
+      level: 10,
+      bundles,
+      choices: fighterL10Build.choices,
+      levels: fighterL10Build.levels,
+    });
+    const pending = result.pendingChoices.filter((c) => c.type === 'weapon-mastery-choice');
+    expect(pending).toHaveLength(3);
+  });
+
+  it('Wizard L5 has no weapon-mastery-choice in pendingChoices', () => {
+    const wizardBuild: CharacterBuild = {
+      speciesId: 'human',
+      backgroundId: 'soldier',
+      baseAbilities: { str: 8, dex: 13, con: 14, int: 16, wis: 10, cha: 12 },
+      abilityMethod: 'standard-array',
+      choices: {
+        'skill-choice:class:wizard:0': { type: 'skill-choice', skills: ['arcana', 'history'] },
+        'skill-choice:species:human:0': { type: 'skill-choice', skills: ['intimidation'] },
+        'language-choice:species:human:0': { type: 'language-choice', languages: ['elvish'] },
+        'asi:background:soldier:0': { type: 'asi', allocation: { int: 2, con: 1 } },
+        'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+        'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      },
+      levels: [
+        { classId: 'wizard' as ClassId, classLevel: 1, hpRoll: null },
+        { classId: 'wizard' as ClassId, classLevel: 2, hpRoll: null },
+        { classId: 'wizard' as ClassId, classLevel: 3, hpRoll: null },
+        { classId: 'wizard' as ClassId, classLevel: 4, hpRoll: null },
+        { classId: 'wizard' as ClassId, classLevel: 5, hpRoll: null },
+      ],
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(wizardBuild);
+    const result = resolveCharacter({
+      baseAbilities: wizardBuild.baseAbilities,
+      level: 5,
+      bundles,
+      choices: wizardBuild.choices,
+      levels: wizardBuild.levels,
+    });
+    const pending = result.pendingChoices.filter((c) => c.type === 'weapon-mastery-choice');
+    expect(pending).toHaveLength(0);
   });
 
   it('resolved weaponMasteries reflects user decisions', () => {

--- a/src/lib/resolver/spellcasting.test.ts
+++ b/src/lib/resolver/spellcasting.test.ts
@@ -228,6 +228,41 @@ describe('resolveSpellcasting', () => {
       const result = resolveSpellcasting(makeClericBundles(1), abilities, 2, 1);
       expect(result!.preparedCount).toBe(1);
     });
+
+    it('druid L1 wis+2 → 3', () => {
+      // max(1, 1 + 2) = 3
+      const abilities = makeAbilities({ wis: 14 });
+      const result = resolveSpellcasting(makeDruidBundles(1), abilities, 2, 1);
+      expect(result!.preparedCount).toBe(3);
+    });
+
+    it('druid L20 wis+4 → 24', () => {
+      // max(1, 20 + 4) = 24
+      const abilities = makeAbilities({ wis: 18 });
+      const result = resolveSpellcasting(makeDruidBundles(20), abilities, 6, 20);
+      expect(result!.preparedCount).toBe(24);
+    });
+
+    it('wizard L1 int 8 (mod -1) → 1 (floor)', () => {
+      // max(1, 1 + (-1)) = max(1, 0) = 1
+      const abilities = makeAbilities({ int: 8 });
+      const result = resolveSpellcasting(makeWizardBundles(1), abilities, 2, 1);
+      expect(result!.preparedCount).toBe(1);
+    });
+
+    it('paladin L2 cha+1 → 3', () => {
+      // max(1, 2 + 1) = 3
+      const abilities = makeAbilities({ cha: 12 });
+      const result = resolveSpellcasting(makePaladinBundles(2), abilities, 2, 2);
+      expect(result!.preparedCount).toBe(3);
+    });
+
+    it('ranger L2 wis 8 (mod -1) → 1 (floor at first ranger spellcasting level)', () => {
+      // max(1, 2 + (-1)) = max(1, 1) = 1
+      const abilities = makeAbilities({ wis: 8 });
+      const result = resolveSpellcasting(makeRangerBundles({ level: 2 }), abilities, 2, 2);
+      expect(result!.preparedCount).toBe(1);
+    });
   });
 
   describe('spell grant routing', () => {

--- a/src/lib/resolver/spellcasting.test.ts
+++ b/src/lib/resolver/spellcasting.test.ts
@@ -257,9 +257,9 @@ describe('resolveSpellcasting', () => {
       expect(result!.preparedCount).toBe(3);
     });
 
-    it('ranger L2 wis 8 (mod -1) → 1 (floor at first ranger spellcasting level)', () => {
-      // max(1, 2 + (-1)) = max(1, 1) = 1
-      const abilities = makeAbilities({ wis: 8 });
+    it('ranger L2 wis 6 (mod -2) → 1 (floor — raw 0 clamped)', () => {
+      // max(1, 2 + (-2)) = max(1, 0) = 1 — floor branch actually triggers
+      const abilities = makeAbilities({ wis: 6 });
       const result = resolveSpellcasting(makeRangerBundles({ level: 2 }), abilities, 2, 2);
       expect(result!.preparedCount).toBe(1);
     });


### PR DESCRIPTION
Closes #100

## Summary

Extends the test suite to cover the new 2024 PHB mechanics that landed during the 5.5e migration. The existing suite was already green (1299 tests passing) — this PR adds 16 new cases targeting documented gaps.

## What Changed

- `src/lib/resolver/abilities.test.ts` (+60 / 2 cases) — background ASI stacking with class ASI; 20-cap when background ASI pushes above 18.
- `src/lib/resolver/index.test.ts` (+277 / 9 cases) — weapon mastery aggregation for Paladin/Ranger/Rogue at L1, Fighter L10 multi-grant accumulation, Wizard L5 zero-mastery negative case, plus a full Tiefling lineage-choice integration block (pending + infernal/abyssal/chthonic resolution).
- `src/lib/resolver/spellcasting.test.ts` (+35 / 5 cases) — `preparedCount` for Druid L1/L20, Wizard floor-at-1, Paladin L2, Ranger L2 floor.

Coverage areas from the issue:
- [x] Background-granted ASIs aggregating into ability scores
- [x] Weapon mastery aggregation per class / level
- [N/A] Exhaustion penalty math at levels 0-6 — already fully covered in `dnd-helpers.test.ts:79-91`
- [x] Prepared-spell formula (`level + ability mod`)
- [x] Lineage / legacy selectors for dragonborn and tiefling (tiefling integration added; dragonborn already covered)

## Agents Used

- Codebase exploration: `feature-dev:code-explorer` (agent_id `a607d062fea8ef05b`)
- Implementation: `typescript-node-implementer` (agent_id `ae9f5ef07a1ece742`)

## Testing

- [x] `npm run test` — 1315 passed (was 1299, +16)
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — clean (max-warnings 0)
- [x] No source code modified (tests-only PR per issue scope)

🤖 Generated with [Claude Code](https://claude.com/claude-code)