### PR TITLE
docs: clarify Dragonborn lineage ID prefix and Species ASI sourcing

### DIFF
--- a/docs/dnd-2024.md
+++ b/docs/dnd-2024.md
@@ -8,8 +8,8 @@ Source-of-truth: `src/lib/dnd-helpers.ts` (`SpeciesId`, `DND_SPECIES`), `src/lib
 
 - `SpeciesId` union: `'aasimar' | 'dragonborn' | 'dwarf' | 'elf' | 'gnome' | 'goliath' | 'halfling' | 'human' | 'orc' | 'tiefling'`
 - Each species is a `SpeciesSource` with `id`, `defaultSize` (a `SizeId`; all 10 current species are `small` or `medium`), `defaultSpeed` (number, feet), and `grants` (`Grant[]`).
-- Five species have a `lineage-choice` grant: Dragonborn (15 lineages: chromatic × 5, metallic × 5, gem × 5), Elf (`drow`, `high-elf`, `wood-elf`), Gnome (`forest`, `rock`, `deep`), Goliath (`cloud`, `fire`, `frost`, `hill`, `stone`, `storm`), Tiefling (`abyssal`, `chthonic`, `infernal`).
-- Species do not grant Ability Score Increases — ASIs come entirely from backgrounds (a key 2024 structural change).
+- Five species have a `lineage-choice` grant: Dragonborn (15 lineages with prefixed IDs — `chromatic-{black,blue,green,red,white}`, `metallic-{brass,bronze,copper,gold,silver}`, `gem-{amethyst,crystal,emerald,sapphire,topaz}`), Elf (`drow`, `high-elf`, `wood-elf`), Gnome (`forest`, `rock`, `deep`), Goliath (`cloud`, `fire`, `frost`, `hill`, `stone`, `storm`), Tiefling (`abyssal`, `chthonic`, `infernal`). Only Dragonborn uses a `<category>-<name>` prefix convention; all other species use unprefixed lineage IDs.
+- Species do not grant Ability Score Increases — ASIs come entirely from backgrounds in the 2024 ruleset (except class ASI grants at specific levels; see Backgrounds below).
 - i18n: display names live at `gamedata.species.<speciesId>` (e.g., `t('species.dwarf')`).
 
 ## Backgrounds


### PR DESCRIPTION
## Summary

Addresses the two deferred suggestions from the PR #133 review of `docs/dnd-2024.md`.

- **Dragonborn lineage IDs**: Enumerate the actual prefixed IDs (`chromatic-{black,blue,green,red,white}`, `metallic-{brass,bronze,copper,gold,silver}`, `gem-{amethyst,crystal,emerald,sapphire,topaz}`) instead of vague counts, and note that only Dragonborn uses the `<category>-<name>` prefix — Elf, Gnome, Goliath, and Tiefling lineages use unprefixed IDs.
- **Species ASI sourcing**: Mirror the Backgrounds section's "(except class ASI grants at specific levels)" qualifier so the two sections describe ASI sourcing consistently.

## Test plan

- [ ] Verify Dragonborn lineage IDs match `src/lib/sources/species.ts` (verified via grep; all 15 IDs present)
- [ ] Confirm phrasing parity with Backgrounds section line on class ASI grants

🤖 Generated with [Claude Code](https://claude.com/claude-code)