### PR TITLE
fix(resolver): suppress diagnostic for expanded feat grants

### DIFF
--- a/src/hooks/useCharacterContext.tsx
+++ b/src/hooks/useCharacterContext.tsx
@@ -262,7 +262,7 @@ function tryDeriveAndResolve(
     return { status: 'build-error', build: null, bundles: [], resolved: null, error: message, warnings: [] };
   }
 
-  const { bundles, warnings } = collectBundles(build);
+  const { bundles, warnings, expandedFeats } = collectBundles(build);
   if (warnings.length > 0) {
     logger.warn('collectBundles warnings:', warnings);
   }
@@ -279,6 +279,7 @@ function tryDeriveAndResolve(
       equippedItemIds: equippedItems,
       persistedItems,
       useDBInventory,
+      expandedFeats,
     });
     return { status: 'ok', build, bundles, resolved, error: null, warnings };
   } catch (err) {

--- a/src/hooks/useResolvedCharacter.ts
+++ b/src/hooks/useResolvedCharacter.ts
@@ -12,7 +12,7 @@ const logger = getLogger('resolved-character');
 export function useResolvedCharacter(build: CharacterBuild | null): ResolvedCharacter | null {
   return useMemo(() => {
     if (!build) return null;
-    const { bundles, warnings } = collectBundles(build);
+    const { bundles, warnings, expandedFeats } = collectBundles(build);
     if (warnings.length > 0) {
       logger.warn('collectBundles warnings:', warnings);
     }
@@ -22,6 +22,7 @@ export function useResolvedCharacter(build: CharacterBuild | null): ResolvedChar
       bundles,
       choices: build.choices,
       levels: build.levels,
+      expandedFeats,
     });
   }, [build]);
 }

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -1230,6 +1230,120 @@ describe('Dragonborn lineage-choice integration', () => {
   });
 });
 
+describe('Tiefling lineage-choice integration', () => {
+  const lineageKey = createChoiceKey('lineage-choice', 'species', 'tiefling', 0);
+
+  const tieflingBuild: CharacterBuild = {
+    speciesId: 'tiefling',
+    backgroundId: null,
+    baseAbilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 },
+    abilityMethod: 'standard-array',
+    levels: [{ classId: 'fighter' as ClassId, classLevel: 1, hpRoll: null }],
+    choices: {
+      'skill-choice:class:fighter:0': { type: 'skill-choice', skills: ['athletics', 'perception'] },
+      'fighting-style-choice:class:fighter:0': { type: 'fighting-style-choice', styles: ['defense'] },
+      'bundle-choice:class:fighter:0': { type: 'bundle-choice', bundleId: 'fighter-chainmail', slotPicks: {} },
+      'bundle-choice:class:fighter:1': {
+        type: 'bundle-choice',
+        bundleId: 'martial-weapon-and-shield',
+        slotPicks: { weapon: 'longsword', shield: 'shield' },
+      },
+      'bundle-choice:class:fighter:2': { type: 'bundle-choice', bundleId: 'light-crossbow-kit', slotPicks: {} },
+      'bundle-choice:class:fighter:3': { type: 'bundle-choice', bundleId: 'dungeoneers-pack', slotPicks: {} },
+    } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    feats: [],
+    activeItems: [],
+  };
+
+  it('emits a pending lineage-choice with 3 options when no lineage decision is made', () => {
+    const { bundles } = collectBundles(tieflingBuild);
+    const input: ResolverInput = {
+      baseAbilities: tieflingBuild.baseAbilities,
+      level: 1,
+      bundles,
+      choices: tieflingBuild.choices,
+      levels: tieflingBuild.levels,
+    };
+    const result = resolveCharacter(input);
+    const pending = result.pendingChoices.find((c) => c.type === 'lineage-choice');
+    expect(pending).toBeDefined();
+    expect(pending?.choiceKey).toBe(lineageKey);
+    if (pending?.type === 'lineage-choice') {
+      expect(pending.from.length).toBe(3);
+      expect(pending.speciesId).toBe('tiefling');
+    }
+  });
+
+  it('resolves fire resistance and infernal feature when infernal lineage is chosen', () => {
+    const buildWithLineage: CharacterBuild = {
+      ...tieflingBuild,
+      choices: {
+        ...tieflingBuild.choices,
+        [lineageKey]: { type: 'lineage-choice', lineageId: 'infernal' },
+      } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    };
+    const { bundles } = collectBundles(buildWithLineage);
+    const input: ResolverInput = {
+      baseAbilities: buildWithLineage.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithLineage.choices,
+      levels: buildWithLineage.levels,
+    };
+    const result = resolveCharacter(input);
+    expect(result.resistances.map((r) => r.value)).toContain('fire');
+    expect(result.features.map((f) => f.feature.id)).toContain('tiefling-fiendish-legacy-infernal');
+    const pending = result.pendingChoices.find((c) => c.type === 'lineage-choice');
+    expect(pending).toBeUndefined();
+  });
+
+  it('resolves poison resistance and abyssal feature when abyssal lineage is chosen', () => {
+    const buildWithLineage: CharacterBuild = {
+      ...tieflingBuild,
+      choices: {
+        ...tieflingBuild.choices,
+        [lineageKey]: { type: 'lineage-choice', lineageId: 'abyssal' },
+      } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    };
+    const { bundles } = collectBundles(buildWithLineage);
+    const input: ResolverInput = {
+      baseAbilities: buildWithLineage.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithLineage.choices,
+      levels: buildWithLineage.levels,
+    };
+    const result = resolveCharacter(input);
+    expect(result.resistances.map((r) => r.value)).toContain('poison');
+    expect(result.features.map((f) => f.feature.id)).toContain('tiefling-fiendish-legacy-abyssal');
+    const pending = result.pendingChoices.find((c) => c.type === 'lineage-choice');
+    expect(pending).toBeUndefined();
+  });
+
+  it('resolves necrotic resistance and chthonic feature when chthonic lineage is chosen', () => {
+    const buildWithLineage: CharacterBuild = {
+      ...tieflingBuild,
+      choices: {
+        ...tieflingBuild.choices,
+        [lineageKey]: { type: 'lineage-choice', lineageId: 'chthonic' },
+      } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    };
+    const { bundles } = collectBundles(buildWithLineage);
+    const input: ResolverInput = {
+      baseAbilities: buildWithLineage.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithLineage.choices,
+      levels: buildWithLineage.levels,
+    };
+    const result = resolveCharacter(input);
+    expect(result.resistances.map((r) => r.value)).toContain('necrotic');
+    expect(result.features.map((f) => f.feature.id)).toContain('tiefling-fiendish-legacy-chthonic');
+    const pending = result.pendingChoices.find((c) => c.type === 'lineage-choice');
+    expect(pending).toBeUndefined();
+  });
+});
+
 describe('expertise-choice count and validity validation', () => {
   const expertiseKey0 = createChoiceKey('expertise-choice', 'class', 'rogue', 0);
 

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -1,8 +1,9 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { resolveCharacter } from '@/lib/resolver';
 import type { ResolverInput } from '@/lib/resolver';
-import type { AbilityKey, ClassId } from '@/lib/dnd-helpers';
+import type { AbilityKey, ClassId, FeatId } from '@/lib/dnd-helpers';
 import { DND_SKILLS } from '@/lib/dnd-helpers';
+import { getLogger } from '@/lib/logger';
 import { collectBundles } from '@/lib/sources';
 import type { CharacterBuild, ChoiceDecision, ChoiceKey } from '@/types/choices';
 import { createChoiceKey } from '@/types/choices';
@@ -1056,6 +1057,52 @@ describe('FeatGrant passthrough behavior', () => {
     ];
     expect(() => resolveCharacter({ ...baseInput, bundles })).not.toThrow();
   });
+
+  it('emits logger.warn for unexpanded feat grant when not in expandedFeats', () => {
+    const resolverLogger = getLogger('resolver');
+    const warnSpy = vi.spyOn(resolverLogger, 'warn').mockImplementation(() => {});
+    const bundles: readonly GrantBundle[] = [
+      {
+        source: { origin: 'background', id: 'soldier' },
+        grants: [{ type: 'feat', featId: 'savage-attacker' }],
+      },
+    ];
+    resolveCharacter({ ...baseInput, bundles });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('savage-attacker'));
+  });
+});
+
+describe('FeatGrant diagnostic not fired for expanded feats', () => {
+  it('no logger.warn when feat grant is in expandedFeats', () => {
+    const resolverLogger = getLogger('resolver');
+    const warnSpy = vi.spyOn(resolverLogger, 'warn').mockImplementation(() => {});
+    const bundles: readonly GrantBundle[] = [
+      {
+        source: { origin: 'background', id: 'soldier' },
+        grants: [{ type: 'feat', featId: 'savage-attacker' }],
+      },
+    ];
+    resolveCharacter({ ...baseInput, bundles, expandedFeats: new Set<FeatId>(['savage-attacker' as FeatId]) });
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('savage-attacker'));
+  });
+
+  it('logger.warn fires for inner nested feat not in expandedFeats, not for outer expanded feat', () => {
+    const resolverLogger = getLogger('resolver');
+    const warnSpy = vi.spyOn(resolverLogger, 'warn').mockImplementation(() => {});
+    const bundles: readonly GrantBundle[] = [
+      {
+        source: { origin: 'background', id: 'soldier' },
+        grants: [{ type: 'feat', featId: 'outer-feat' as FeatId }],
+      },
+      {
+        source: { origin: 'feat', id: 'outer-feat' as FeatId },
+        grants: [{ type: 'feat', featId: 'inner-nested' as FeatId }],
+      },
+    ];
+    resolveCharacter({ ...baseInput, bundles, expandedFeats: new Set<FeatId>(['outer-feat' as FeatId]) });
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('inner-nested'));
+    expect(warnSpy).not.toHaveBeenCalledWith(expect.stringContaining('outer-feat'));
+  });
 });
 
 describe('Rogue L3 + Arcane Trickster subclass integration', () => {
@@ -1456,6 +1503,169 @@ describe('Weapon mastery resolver', () => {
     expect(pending).toHaveLength(1);
     if (pending[0].type !== 'weapon-mastery-choice') throw new Error('Expected weapon-mastery-choice');
     expect(pending[0].count).toBe(2);
+  });
+
+  it('L1 Paladin has a weapon-mastery-choice pending choice with count 2', () => {
+    const paladinBuild: CharacterBuild = {
+      speciesId: 'human',
+      backgroundId: 'soldier',
+      baseAbilities: { str: 15, dex: 13, con: 14, int: 8, wis: 10, cha: 12 },
+      abilityMethod: 'standard-array',
+      choices: {
+        'skill-choice:class:paladin:0': { type: 'skill-choice', skills: ['athletics', 'persuasion'] },
+        'skill-choice:species:human:0': { type: 'skill-choice', skills: ['intimidation'] },
+        'language-choice:species:human:0': { type: 'language-choice', languages: ['elvish'] },
+        'asi:background:soldier:0': { type: 'asi', allocation: { str: 2, con: 1 } },
+        'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+        'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      },
+      levels: [{ classId: 'paladin' as ClassId, classLevel: 1, hpRoll: null }],
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(paladinBuild);
+    const result = resolveCharacter({
+      baseAbilities: paladinBuild.baseAbilities,
+      level: 1,
+      bundles,
+      choices: paladinBuild.choices,
+      levels: paladinBuild.levels,
+    });
+    const pending = result.pendingChoices.filter((c) => c.type === 'weapon-mastery-choice');
+    expect(pending).toHaveLength(1);
+    if (pending[0].type !== 'weapon-mastery-choice') throw new Error('Expected weapon-mastery-choice');
+    expect(pending[0].count).toBe(2);
+  });
+
+  it('L1 Ranger has a weapon-mastery-choice pending choice with count 2', () => {
+    const rangerBuild: CharacterBuild = {
+      speciesId: 'human',
+      backgroundId: 'soldier',
+      baseAbilities: { str: 15, dex: 13, con: 14, int: 8, wis: 10, cha: 12 },
+      abilityMethod: 'standard-array',
+      choices: {
+        'skill-choice:class:ranger:0': { type: 'skill-choice', skills: ['athletics', 'perception'] },
+        'skill-choice:species:human:0': { type: 'skill-choice', skills: ['intimidation'] },
+        'language-choice:species:human:0': { type: 'language-choice', languages: ['elvish'] },
+        'asi:background:soldier:0': { type: 'asi', allocation: { str: 2, con: 1 } },
+        'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+        'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      },
+      levels: [{ classId: 'ranger' as ClassId, classLevel: 1, hpRoll: null }],
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(rangerBuild);
+    const result = resolveCharacter({
+      baseAbilities: rangerBuild.baseAbilities,
+      level: 1,
+      bundles,
+      choices: rangerBuild.choices,
+      levels: rangerBuild.levels,
+    });
+    const pending = result.pendingChoices.filter((c) => c.type === 'weapon-mastery-choice');
+    expect(pending).toHaveLength(1);
+    if (pending[0].type !== 'weapon-mastery-choice') throw new Error('Expected weapon-mastery-choice');
+    expect(pending[0].count).toBe(2);
+  });
+
+  it('L1 Rogue has a weapon-mastery-choice pending choice with count 2', () => {
+    const rogueBuild: CharacterBuild = {
+      speciesId: 'human',
+      backgroundId: 'soldier',
+      baseAbilities: { str: 15, dex: 13, con: 14, int: 8, wis: 10, cha: 12 },
+      abilityMethod: 'standard-array',
+      choices: {
+        'skill-choice:class:rogue:0': {
+          type: 'skill-choice',
+          skills: ['stealth', 'deception', 'perception', 'sleightofhand'],
+        },
+        'skill-choice:species:human:0': { type: 'skill-choice', skills: ['intimidation'] },
+        'language-choice:species:human:0': { type: 'language-choice', languages: ['elvish'] },
+        'asi:background:soldier:0': { type: 'asi', allocation: { str: 2, con: 1 } },
+        'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+        'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      },
+      levels: [{ classId: 'rogue' as ClassId, classLevel: 1, hpRoll: null }],
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(rogueBuild);
+    const result = resolveCharacter({
+      baseAbilities: rogueBuild.baseAbilities,
+      level: 1,
+      bundles,
+      choices: rogueBuild.choices,
+      levels: rogueBuild.levels,
+    });
+    const pending = result.pendingChoices.filter((c) => c.type === 'weapon-mastery-choice');
+    expect(pending).toHaveLength(1);
+    if (pending[0].type !== 'weapon-mastery-choice') throw new Error('Expected weapon-mastery-choice');
+    expect(pending[0].count).toBe(2);
+  });
+
+  it('Fighter at L10 has 3 pending weapon-mastery-choice entries (L1+L4+L10) when no decisions provided', () => {
+    const fighterL10Build: CharacterBuild = {
+      ...fighterL1Build,
+      levels: [
+        { classId: 'fighter' as ClassId, classLevel: 1, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 2, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 3, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 4, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 5, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 6, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 7, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 8, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 9, hpRoll: null },
+        { classId: 'fighter' as ClassId, classLevel: 10, hpRoll: null },
+      ],
+    };
+    const { bundles } = collectBundles(fighterL10Build);
+    const result = resolveCharacter({
+      baseAbilities: fighterL10Build.baseAbilities,
+      level: 10,
+      bundles,
+      choices: fighterL10Build.choices,
+      levels: fighterL10Build.levels,
+    });
+    const pending = result.pendingChoices.filter((c) => c.type === 'weapon-mastery-choice');
+    expect(pending).toHaveLength(3);
+  });
+
+  it('Wizard L5 has no weapon-mastery-choice in pendingChoices', () => {
+    const wizardBuild: CharacterBuild = {
+      speciesId: 'human',
+      backgroundId: 'soldier',
+      baseAbilities: { str: 8, dex: 13, con: 14, int: 16, wis: 10, cha: 12 },
+      abilityMethod: 'standard-array',
+      choices: {
+        'skill-choice:class:wizard:0': { type: 'skill-choice', skills: ['arcana', 'history'] },
+        'skill-choice:species:human:0': { type: 'skill-choice', skills: ['intimidation'] },
+        'language-choice:species:human:0': { type: 'language-choice', languages: ['elvish'] },
+        'asi:background:soldier:0': { type: 'asi', allocation: { int: 2, con: 1 } },
+        'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+        'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      },
+      levels: [
+        { classId: 'wizard' as ClassId, classLevel: 1, hpRoll: null },
+        { classId: 'wizard' as ClassId, classLevel: 2, hpRoll: null },
+        { classId: 'wizard' as ClassId, classLevel: 3, hpRoll: null },
+        { classId: 'wizard' as ClassId, classLevel: 4, hpRoll: null },
+        { classId: 'wizard' as ClassId, classLevel: 5, hpRoll: null },
+      ],
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(wizardBuild);
+    const result = resolveCharacter({
+      baseAbilities: wizardBuild.baseAbilities,
+      level: 5,
+      bundles,
+      choices: wizardBuild.choices,
+      levels: wizardBuild.levels,
+    });
+    const pending = result.pendingChoices.filter((c) => c.type === 'weapon-mastery-choice');
+    expect(pending).toHaveLength(0);
   });
 
   it('resolved weaponMasteries reflects user decisions', () => {

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -1,5 +1,5 @@
 import { getProficiencyBonus } from '@/lib/dnd-helpers';
-import type { AbilityKey, ToolProficiencyId, SkillId } from '@/lib/dnd-helpers';
+import type { AbilityKey, ToolProficiencyId, SkillId, FeatId } from '@/lib/dnd-helpers';
 import { getLogger } from '@/lib/logger';
 
 const logger = getLogger('resolver');
@@ -36,6 +36,7 @@ export interface ResolverInput {
   readonly equippedItemIds?: readonly string[];
   readonly persistedItems?: readonly PersistedItem[];
   readonly useDBInventory?: boolean;
+  readonly expandedFeats?: ReadonlySet<FeatId>;
 }
 
 function isValidExpertiseSkillPick(
@@ -52,6 +53,7 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
   const { baseAbilities, level, bundles, choices } = input;
   const hpRolls = input.hpRolls ?? input.levels?.map((l) => l.hpRoll) ?? [];
   const equippedItemIds = input.equippedItemIds ?? [];
+  const expandedFeats = input.expandedFeats ?? new Set<FeatId>();
 
   const proficiencyBonus = getProficiencyBonus(level);
   const abilities = resolveAbilities(baseAbilities, bundles, choices);
@@ -166,6 +168,7 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
 
   // Diagnostic: any feat grant that reaches the resolver was not expanded by collectBundles — this is a bug
   for (const { grant } of collectGrantsByType(bundles, 'feat')) {
+    if (expandedFeats.has(grant.featId)) continue; // expected leftover from expansion pass
     logger.warn(`BUG: unexpanded FeatGrant "${grant.featId}" reached resolver — nested feat grants are not supported`);
   }
 

--- a/src/lib/resolver/spellcasting.test.ts
+++ b/src/lib/resolver/spellcasting.test.ts
@@ -228,6 +228,41 @@ describe('resolveSpellcasting', () => {
       const result = resolveSpellcasting(makeClericBundles(1), abilities, 2, 1);
       expect(result!.preparedCount).toBe(1);
     });
+
+    it('druid L1 wis+2 → 3', () => {
+      // max(1, 1 + 2) = 3
+      const abilities = makeAbilities({ wis: 14 });
+      const result = resolveSpellcasting(makeDruidBundles(1), abilities, 2, 1);
+      expect(result!.preparedCount).toBe(3);
+    });
+
+    it('druid L20 wis+4 → 24', () => {
+      // max(1, 20 + 4) = 24
+      const abilities = makeAbilities({ wis: 18 });
+      const result = resolveSpellcasting(makeDruidBundles(20), abilities, 6, 20);
+      expect(result!.preparedCount).toBe(24);
+    });
+
+    it('wizard L1 int 8 (mod -1) → 1 (floor)', () => {
+      // max(1, 1 + (-1)) = max(1, 0) = 1
+      const abilities = makeAbilities({ int: 8 });
+      const result = resolveSpellcasting(makeWizardBundles(1), abilities, 2, 1);
+      expect(result!.preparedCount).toBe(1);
+    });
+
+    it('paladin L2 cha+1 → 3', () => {
+      // max(1, 2 + 1) = 3
+      const abilities = makeAbilities({ cha: 12 });
+      const result = resolveSpellcasting(makePaladinBundles(2), abilities, 2, 2);
+      expect(result!.preparedCount).toBe(3);
+    });
+
+    it('ranger L2 wis 8 (mod -1) → 1 (floor at first ranger spellcasting level)', () => {
+      // max(1, 2 + (-1)) = max(1, 1) = 1
+      const abilities = makeAbilities({ wis: 8 });
+      const result = resolveSpellcasting(makeRangerBundles({ level: 2 }), abilities, 2, 2);
+      expect(result!.preparedCount).toBe(1);
+    });
   });
 
   describe('spell grant routing', () => {

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -1,4 +1,17 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
+import type { FeatSource } from '@/types/sources';
+
+const mockFeatSources = vi.hoisted<{ value: readonly FeatSource[] | null }>(() => ({ value: null }));
+
+vi.mock('@/lib/sources/feats', async (importActual) => {
+  const actual = await importActual<typeof import('@/lib/sources/feats')>();
+  return {
+    get FEAT_SOURCES() {
+      return mockFeatSources.value ?? actual.FEAT_SOURCES;
+    },
+  };
+});
+
 import {
   getSpeciesSource,
   getClassSource,
@@ -245,5 +258,44 @@ describe('collectBundles', () => {
     const subclassBundles = bundles.filter((b) => b.source.origin === 'subclass');
     // only L3 feature, not L7, L10, L15, L18
     expect(subclassBundles).toHaveLength(1);
+  });
+
+  it('soldier background origin feat: expandedFeats contains savage-attacker', () => {
+    const { bundles, expandedFeats } = collectBundles(humanFighterL1Build);
+    expect(expandedFeats.has('savage-attacker')).toBe(true);
+    const featBundle = bundles.find((b) => b.source.origin === 'feat' && b.source.id === 'savage-attacker');
+    expect(featBundle).toBeDefined();
+  });
+
+  it('nested feat grant: outer feat is in expandedFeats, inner nested feat is not', () => {
+    mockFeatSources.value = [
+      {
+        id: 'savage-attacker',
+        category: 'origin',
+        prerequisites: [],
+        grants: [
+          { type: 'feature', feature: { id: 'feat-savage-attacker' } },
+          { type: 'feat', featId: 'nested-inner-feat' as FeatId },
+        ],
+      },
+    ];
+    try {
+      const { expandedFeats } = collectBundles(humanFighterL1Build);
+      expect(expandedFeats.has('savage-attacker')).toBe(true);
+      expect(expandedFeats.has('nested-inner-feat' as FeatId)).toBe(false);
+    } finally {
+      mockFeatSources.value = null;
+    }
+  });
+
+  it('missing feat source: not added to expandedFeats', () => {
+    mockFeatSources.value = [];
+    try {
+      const { expandedFeats, warnings } = collectBundles(humanFighterL1Build);
+      expect(expandedFeats.size).toBe(0);
+      expect(warnings.some((w) => w.includes('savage-attacker'))).toBe(true);
+    } finally {
+      mockFeatSources.value = null;
+    }
   });
 });

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -80,6 +80,7 @@ export function getItemSource(id: string): ItemSource | undefined {
 export interface CollectBundlesResult {
   readonly bundles: readonly GrantBundle[];
   readonly warnings: readonly string[];
+  readonly expandedFeats: ReadonlySet<FeatId>;
 }
 
 export function collectBundles(build: CharacterBuild): CollectBundlesResult {
@@ -222,6 +223,7 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
 
   // Expand FeatGrant grants embedded in already-collected bundles (e.g. background origin feats).
   // Snapshot current length to avoid iterating bundles we add in this pass.
+  const expandedFeats = new Set<FeatId>();
   const preFeatExpansionLength = bundles.length;
   for (let i = 0; i < preFeatExpansionLength; i++) {
     const bundle = bundles[i];
@@ -231,6 +233,7 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
         if (featSource) {
           const tag: SourceTag = { origin: 'feat', id: grant.featId };
           bundles.push({ source: tag, grants: featSource.grants });
+          expandedFeats.add(grant.featId);
         } else {
           const msg = `No source data found for feat "${grant.featId}" — feat grants will be empty`;
           warnings.push(msg);
@@ -266,5 +269,5 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
     }
   }
 
-  return { bundles, warnings };
+  return { bundles, warnings, expandedFeats };
 }


### PR DESCRIPTION
Closes #131

## Summary

The resolver's safety-net diagnostic at `src/lib/resolver/index.ts` was warning on every character with a 2024 background, because `collectBundles` leaves the original `{ type: 'feat', featId }` grant in the source bundle after expanding it into a new feat-origin bundle. The diagnostic correctly fires for unexpanded feat grants, but it had no way to distinguish "intentional leftover from a successful expansion" from "real failure".

This PR teaches the diagnostic about expanded feats by extending `CollectBundlesResult` with a `ReadonlySet<FeatId>` tracking which feat grants were successfully expanded. The resolver skips its warning when a feat grant is in that set.

## What Changed

- `src/lib/sources/index.ts` — `CollectBundlesResult` gains `expandedFeats`; populated during the expansion pass (only on successful `getFeatSource`).
- `src/lib/resolver/index.ts` — `ResolverInput` accepts optional `expandedFeats`; diagnostic skips leftovers that match.
- `src/hooks/useResolvedCharacter.ts`, `src/hooks/useCharacterContext.tsx` — pass `expandedFeats` through to `resolveCharacter`.
- Tests: new cases in `src/lib/sources/index.test.ts` and `src/lib/resolver/index.test.ts` covering the happy path, the no-warn path, the still-fires-for-nested-feat path, and the missing-source path.

## Why this shape

- **Preserves the diagnostic** for the failure modes the original commit (b8c9df3) intended to catch: nested feat grants, missing feat source data, future regressions that drop a feat into bundles after the expansion pass.
- **Structural, not conventional** — the "feat grant ⇒ either expanded or a bug" contract is encoded in the return type rather than relying on every caller to filter.
- **No mutation of source data** — `SPECIES_SOURCES`, `BACKGROUND_SOURCES`, etc. stay frozen.

## Agents Used

- Architecture: `feature-dev:code-architect` (agent `a65c991b543d54acc`)
- Implementation: `typescript-node-implementer` (agent `a63ad08b983aa544c`)

## Testing

- [x] TypeScript strict mode passing (`npm run typecheck`)
- [x] ESLint clean (`npm run lint`)
- [x] All unit tests passing (1321 / 1321)
- [x] Dev server console silent for normal characters with backgrounds
- [x] Warning still fires for synthetic nested-feat test case

🤖 Generated with [Claude Code](https://claude.com/claude-code)