### PR TITLE
feat(subclasses): implement Barbarian subclasses through level 10 (#112)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -88,6 +88,207 @@ describe('getSubclassSource — Champion', () => {
   });
 });
 
+describe('getSubclassSource — Berserker', () => {
+  it('returns defined for berserker', () => {
+    expect(getSubclassSource('berserker')).toBeDefined();
+  });
+
+  it('berserker has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('berserker');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('berserker level 3 grants 2 features: frenzy and mindless-rage', () => {
+    const source = getSubclassSource('berserker');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'feature', feature: expect.objectContaining({ id: 'berserker-frenzy' }) }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'berserker-mindless-rage' }),
+        }),
+      ])
+    );
+  });
+
+  it('berserker level 6 grants retaliation feature', () => {
+    const source = getSubclassSource('berserker');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'berserker-retaliation' },
+    });
+  });
+
+  it('berserker level 10 grants intimidating-presence feature', () => {
+    const source = getSubclassSource('berserker');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'berserker-intimidating-presence' },
+    });
+  });
+});
+
+describe('getSubclassSource — Wild Heart', () => {
+  it('returns defined for wildheart', () => {
+    expect(getSubclassSource('wildheart')).toBeDefined();
+  });
+
+  it('wildheart has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('wildheart');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('wildheart level 3 grants 2 features: animal-speaker and rage-of-the-wilds', () => {
+    const source = getSubclassSource('wildheart');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'wildheart-animal-speaker' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'wildheart-rage-of-the-wilds' }),
+        }),
+      ])
+    );
+  });
+
+  it('wildheart level 6 grants aspect-of-the-wilds feature', () => {
+    const source = getSubclassSource('wildheart');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'wildheart-aspect-of-the-wilds' },
+    });
+  });
+
+  it('wildheart level 10 grants nature-speaker feature', () => {
+    const source = getSubclassSource('wildheart');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'wildheart-nature-speaker' },
+    });
+  });
+});
+
+describe('getSubclassSource — World Tree', () => {
+  it('returns defined for worldtree', () => {
+    expect(getSubclassSource('worldtree')).toBeDefined();
+  });
+
+  it('worldtree has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('worldtree');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('worldtree level 3 grants vitality-of-the-tree feature', () => {
+    const source = getSubclassSource('worldtree');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(1);
+    expect(level3?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'worldtree-vitality-of-the-tree' },
+    });
+  });
+
+  it('worldtree level 6 grants branches-of-the-tree feature', () => {
+    const source = getSubclassSource('worldtree');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'worldtree-branches-of-the-tree' },
+    });
+  });
+
+  it('worldtree level 10 grants battering-roots feature', () => {
+    const source = getSubclassSource('worldtree');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'worldtree-battering-roots' },
+    });
+  });
+});
+
+describe('getSubclassSource — Zealot', () => {
+  it('returns defined for zealot', () => {
+    expect(getSubclassSource('zealot')).toBeDefined();
+  });
+
+  it('zealot has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('zealot');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('zealot level 3 grants 2 features: divine-fury and warrior-of-the-gods', () => {
+    const source = getSubclassSource('zealot');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'zealot-divine-fury' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'zealot-warrior-of-the-gods' }),
+        }),
+      ])
+    );
+  });
+
+  it('zealot level 6 grants fanatical-focus feature', () => {
+    const source = getSubclassSource('zealot');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'zealot-fanatical-focus' },
+    });
+  });
+
+  it('zealot level 10 grants zealous-presence feature', () => {
+    const source = getSubclassSource('zealot');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'zealot-zealous-presence' },
+    });
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -23,10 +23,89 @@ export const SUBCLASS_IDS: readonly SubclassId[] = Object.values(SUBCLASS_IDS_BY
 
 export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
   // Barbarian
-  berserker: { features: [] },
-  wildheart: { features: [] },
-  worldtree: { features: [] },
-  zealot: { features: [] },
+  berserker: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          { type: 'feature', feature: { id: 'berserker-frenzy' } },
+          { type: 'feature', feature: { id: 'berserker-mindless-rage' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [{ type: 'feature', feature: { id: 'berserker-retaliation' } }],
+      },
+      {
+        classLevel: 10,
+        grants: [{ type: 'feature', feature: { id: 'berserker-intimidating-presence' } }],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  wildheart: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // TODO #93: model as spell grant when spell id system supports 'speak-with-animals'
+          { type: 'feature', feature: { id: 'wildheart-animal-speaker' } },
+          // Beast Spirit (Bear/Eagle/Elk/Tiger/Wolf) is a free-form choice; no pending-choice
+          // mechanism exists for arbitrary string options — modeled as inert feature grant for now
+          { type: 'feature', feature: { id: 'wildheart-rage-of-the-wilds' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Aspect benefit depends on the L3 Beast Spirit choice; collapsed to inert feature grant
+          { type: 'feature', feature: { id: 'wildheart-aspect-of-the-wilds' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // TODO #93: model as spell grant when spell id system supports 'commune-with-nature'
+          { type: 'feature', feature: { id: 'wildheart-nature-speaker' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  worldtree: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [{ type: 'feature', feature: { id: 'worldtree-vitality-of-the-tree' } }],
+      },
+      {
+        classLevel: 6,
+        grants: [{ type: 'feature', feature: { id: 'worldtree-branches-of-the-tree' } }],
+      },
+      {
+        classLevel: 10,
+        grants: [{ type: 'feature', feature: { id: 'worldtree-battering-roots' } }],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  zealot: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Damage type (radiant vs necrotic) chosen at L3 selection; collapsed to inert feature grant
+          { type: 'feature', feature: { id: 'zealot-divine-fury' } },
+          { type: 'feature', feature: { id: 'zealot-warrior-of-the-gods' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [{ type: 'feature', feature: { id: 'zealot-fanatical-focus' } }],
+      },
+      {
+        classLevel: 10,
+        grants: [{ type: 'feature', feature: { id: 'zealot-zealous-presence' } }],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
   // Bard
   collegedance: { features: [] },
   collegeglamour: { features: [] },

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -415,6 +415,66 @@
       "name": "Magical Ambush",
       "description": "If hidden when you cast a spell, the target has disadvantage on saving throws against it this turn."
     },
+    "berserker-frenzy": {
+      "name": "Frenzy",
+      "description": "While raging, you can use a Bonus Action on each of your turns to make one melee attack with a weapon or an Unarmed Strike. When your Rage ends, you have 1 Exhaustion level."
+    },
+    "berserker-mindless-rage": {
+      "name": "Mindless Rage",
+      "description": "While raging, you can't have the Charmed or Frightened condition, and if you do when you enter your Rage, the condition ends on you."
+    },
+    "berserker-retaliation": {
+      "name": "Retaliation",
+      "description": "When you take damage from a creature that is within 5 feet of you, you can use your Reaction to make one melee attack with a weapon or an Unarmed Strike against that creature."
+    },
+    "berserker-intimidating-presence": {
+      "name": "Intimidating Presence",
+      "description": "As an Action, you can cause one creature you can see within 30 feet of you to make a WIS save (DC = 8 + your proficiency bonus + your STR or CHA modifier). On a failed save, the creature has the Frightened condition until the start of your next turn."
+    },
+    "wildheart-animal-speaker": {
+      "name": "Animal Speaker",
+      "description": "You can cast Speak with Animals as a Ritual. Wisdom is your spellcasting ability for this spell."
+    },
+    "wildheart-rage-of-the-wilds": {
+      "name": "Rage of the Wilds",
+      "description": "When you activate your Rage, you choose a Beast Spirit (Bear, Eagle, Elk, Tiger, or Wolf) and gain its associated benefit for the duration of your Rage."
+    },
+    "wildheart-aspect-of-the-wilds": {
+      "name": "Aspect of the Wilds",
+      "description": "You gain an ongoing benefit based on the Beast Spirit you chose at level 3; this benefit can be changed on a Long Rest. Bear: resistance to one damage type. Eagle: you don't need to sleep and can't be forced to sleep. Elk: your Speed increases by 15 feet. Tiger: add d6 to one damage roll per turn. Wolf: knock a creature prone when you hit it with an opportunity attack."
+    },
+    "wildheart-nature-speaker": {
+      "name": "Nature Speaker",
+      "description": "You can cast Commune with Nature as a Ritual. Wisdom is your spellcasting ability for this spell."
+    },
+    "worldtree-vitality-of-the-tree": {
+      "name": "Vitality of the Tree",
+      "description": "When you activate your Rage, you gain Temporary Hit Points equal to your Barbarian level plus your CON modifier. As a Bonus Action while raging, you can grant 1d6 Temporary Hit Points to one creature within 60 feet of you."
+    },
+    "worldtree-branches-of-the-tree": {
+      "name": "Branches of the Tree",
+      "description": "When a creature hits you with an attack roll, you can use your Reaction to teleport that creature to an unoccupied space you can see within 10 feet of you."
+    },
+    "worldtree-battering-roots": {
+      "name": "Battering Roots",
+      "description": "Your reach increases by 10 feet for melee weapon attacks. When you hit a creature with a melee weapon attack while raging, you can knock the target Prone, push it up to 15 feet away from you, or grapple it."
+    },
+    "zealot-divine-fury": {
+      "name": "Divine Fury",
+      "description": "While raging, the first creature you hit on each of your turns takes an extra 1d6 + half your Barbarian level (rounded down) radiant or necrotic damage (your choice when you first gain this feature)."
+    },
+    "zealot-warrior-of-the-gods": {
+      "name": "Warrior of the Gods",
+      "description": "Revival spells cast on you require no Material components. In addition, if such a spell would normally have you return with 1 Hit Point, you return with hit points equal to half your Hit Point maximum."
+    },
+    "zealot-fanatical-focus": {
+      "name": "Fanatical Focus",
+      "description": "While raging, if you fail a saving throw, you can reroll it with a bonus equal to your Rage Damage bonus. You must use the new roll, and you can use this feature only once per Rage."
+    },
+    "zealot-zealous-presence": {
+      "name": "Zealous Presence",
+      "description": "As a Bonus Action, you unleash a battle cry infused with divine energy. Up to 10 creatures of your choice within 60 feet of you gain Advantage on attack rolls and saving throws until the start of your next turn. Once you use this feature, you can't use it again until you finish a Long Rest."
+    },
     "human-resourceful": {
       "name": "Resourceful",
       "description": "You gain Heroic Inspiration whenever you finish a Long Rest."


### PR DESCRIPTION
Closes #112. Part of the meta-issue #111 (PHB 2024 subclass migration).

## Summary

- Populates `features` for the 4 Barbarian subclasses (`berserker`, `wildheart`, `worldtree`, `zealot`) at levels 3, 6, and 10 in `src/lib/sources/subclasses.ts`
- Adds 15 new feature `name`/`description` i18n entries to `src/locales/en/gamedata.json`
- Mirrors the existing Champion/Thief/Assassin test patterns in `subclasses.test.ts` (per-subclass: defined, feature-level shape, per-level grant shape)

## Rules ambiguities (follow-up issues will be filed)

1. **Wild Heart Beast Spirit choice (L3)** — Free-form choice among Bear/Eagle/Elk/Tiger/Wolf. No pending-choice mechanism for arbitrary string options exists yet; modeled as a single inert `feature` grant.
2. **Wild Heart Aspect of the Wilds (L6)** — Mechanical benefit depends on the L3 Beast Spirit selection, so also modeled as an inert `feature` grant pending the choice mechanism.
3. **Wild Heart ritual spells** — Animal Speaker (Speak with Animals, L3) and Nature Speaker (Commune with Nature, L10) are natural `SpellGrant` candidates but no production `SpellGrant` callers exist yet; tagged with `// TODO #93` and modeled as `feature` grants for now.
4. **Zealot Divine Fury damage type (L3)** — PHB lets the player choose radiant or necrotic when first gaining the feature. Collapsed to a single `feature` grant pending a one-time-selection mechanism.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 56 test files, 1341 tests, all pass (20 new Barbarian tests added)

🤖 Generated with [Claude Code](https://claude.com/claude-code)