### PR TITLE
feat(subclasses): implement Bard subclasses through level 10 (#113)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -289,6 +289,179 @@ describe('getSubclassSource — Zealot', () => {
   });
 });
 
+describe('getSubclassSource — College of Dance', () => {
+  it('returns defined for collegedance', () => {
+    expect(getSubclassSource('collegedance')).toBeDefined();
+  });
+
+  it('collegedance has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('collegedance');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('collegedance level 3 grants 3 features: inspirational-dance, unarmored-defense, frolicking-steps', () => {
+    const source = getSubclassSource('collegedance');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'collegedance-inspirational-dance' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'collegedance-unarmored-defense' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'collegedance-frolicking-steps' }),
+        }),
+      ])
+    );
+  });
+
+  it('collegedance level 6 grants dance-of-victory feature', () => {
+    const source = getSubclassSource('collegedance');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'collegedance-dance-of-victory' },
+    });
+  });
+});
+
+describe('getSubclassSource — College of Glamour', () => {
+  it('returns defined for collegeglamour', () => {
+    expect(getSubclassSource('collegeglamour')).toBeDefined();
+  });
+
+  it('collegeglamour has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('collegeglamour');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('collegeglamour level 3 grants 2 features: mantle-of-inspiration and enthralling-performance', () => {
+    const source = getSubclassSource('collegeglamour');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'collegeglamour-mantle-of-inspiration' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'collegeglamour-enthralling-performance' }),
+        }),
+      ])
+    );
+  });
+
+  it('collegeglamour level 6 grants mantle-of-majesty feature', () => {
+    const source = getSubclassSource('collegeglamour');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'collegeglamour-mantle-of-majesty' },
+    });
+  });
+});
+
+describe('getSubclassSource — College of Lore', () => {
+  it('returns defined for collegelore', () => {
+    expect(getSubclassSource('collegelore')).toBeDefined();
+  });
+
+  it('collegelore has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('collegelore');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('collegelore level 3 grants 2 items: skill proficiency-choice and cutting-words feature', () => {
+    const source = getSubclassSource('collegelore');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'proficiency-choice',
+          category: 'skill',
+          count: 3,
+          from: null,
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'collegelore-cutting-words' }),
+        }),
+      ])
+    );
+  });
+
+  it('collegelore level 6 grants magical-secrets feature', () => {
+    const source = getSubclassSource('collegelore');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'collegelore-magical-secrets' },
+    });
+  });
+});
+
+describe('getSubclassSource — College of Valor', () => {
+  it('returns defined for collegevalor', () => {
+    expect(getSubclassSource('collegevalor')).toBeDefined();
+  });
+
+  it('collegevalor has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('collegevalor');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('collegevalor level 3 grants 4 items: medium armor, shields, martial weapons proficiencies and combat-inspiration', () => {
+    const source = getSubclassSource('collegevalor');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(4);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'proficiency', category: 'armor', id: 'medium' }),
+        expect.objectContaining({ type: 'proficiency', category: 'armor', id: 'shields' }),
+        expect.objectContaining({ type: 'proficiency', category: 'weapon', id: 'martial' }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'collegevalor-combat-inspiration' }),
+        }),
+      ])
+    );
+  });
+
+  it('collegevalor level 6 grants extra-attack feature', () => {
+    const source = getSubclassSource('collegevalor');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'collegevalor-extra-attack' },
+    });
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -107,10 +107,85 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
     ] satisfies readonly SubclassFeature[],
   },
   // Bard
-  collegedance: { features: [] },
-  collegeglamour: { features: [] },
-  collegelore: { features: [] },
-  collegevalor: { features: [] },
+  collegedance: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Inspirational Dance: use Bardic Inspiration die for unarmed strike damage
+          { type: 'feature', feature: { id: 'collegedance-inspirational-dance' } },
+          // Unarmored Defense: AC = 10 + DEX mod + Bardic Inspiration die (dynamic; no static ac-bonus)
+          { type: 'feature', feature: { id: 'collegedance-unarmored-defense' } },
+          // Frolicking Steps: Dash lets you move through hostile creature spaces
+          { type: 'feature', feature: { id: 'collegedance-frolicking-steps' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Dance of Victory: additional Bardic die damage at start of next turn
+          { type: 'feature', feature: { id: 'collegedance-dance-of-victory' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  collegeglamour: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          { type: 'feature', feature: { id: 'collegeglamour-mantle-of-inspiration' } },
+          { type: 'feature', feature: { id: 'collegeglamour-enthralling-performance' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [{ type: 'feature', feature: { id: 'collegeglamour-mantle-of-majesty' } }],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  collegelore: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          {
+            type: 'proficiency-choice',
+            category: 'skill',
+            key: createChoiceKey('skill-choice', 'class', 'collegelore', 0),
+            count: 3,
+            from: null,
+          },
+          // Cutting Words: reaction to subtract Bardic die from a creature's roll
+          { type: 'feature', feature: { id: 'collegelore-cutting-words' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // TODO #93: model as spell grants when spell id system supports arbitrary class spell lists
+          { type: 'feature', feature: { id: 'collegelore-magical-secrets' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  collegevalor: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          { type: 'proficiency', category: 'armor', id: 'medium' },
+          { type: 'proficiency', category: 'armor', id: 'shields' },
+          { type: 'proficiency', category: 'weapon', id: 'martial' },
+          { type: 'feature', feature: { id: 'collegevalor-combat-inspiration' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [{ type: 'feature', feature: { id: 'collegevalor-extra-attack' } }],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
   // Cleric
   lifedomain: { features: [] },
   lightdomain: { features: [] },

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -475,6 +475,50 @@
       "name": "Zealous Presence",
       "description": "As a Bonus Action, you unleash a battle cry infused with divine energy. Up to 10 creatures of your choice within 60 feet of you gain Advantage on attack rolls and saving throws until the start of your next turn. Once you use this feature, you can't use it again until you finish a Long Rest."
     },
+    "collegedance-inspirational-dance": {
+      "name": "Inspirational Dance",
+      "description": "When you hit a creature with an Unarmed Strike, you can expend one use of your Bardic Inspiration and roll the Bardic Inspiration die. The Unarmed Strike deals extra damage equal to the number rolled, and you gain a bonus to your AC equal to the number rolled until the start of your next turn."
+    },
+    "collegedance-unarmored-defense": {
+      "name": "Unarmored Defense (College of Dance)",
+      "description": "While you aren't wearing armor or wielding a Shield, your AC equals 10 plus your Dexterity modifier plus your Bardic Inspiration die size modifier (determined by your Bard level)."
+    },
+    "collegedance-frolicking-steps": {
+      "name": "Frolicking Steps",
+      "description": "When you take the Dash action, you can move through the space of any hostile creature once during that action."
+    },
+    "collegedance-dance-of-victory": {
+      "name": "Dance of Victory",
+      "description": "When you use Bardic Inspiration to add damage to an attack, the target takes additional damage equal to your Bardic Inspiration die at the start of your next turn."
+    },
+    "collegeglamour-mantle-of-inspiration": {
+      "name": "Mantle of Inspiration",
+      "description": "As a Bonus Action, you expend one use of your Bardic Inspiration and choose a number of creatures within 60 feet equal to your CHA modifier (minimum 1). Each creature gains Temporary Hit Points equal to your Bardic Inspiration die roll, plus a free Reaction to move up to their speed without provoking Opportunity Attacks."
+    },
+    "collegeglamour-enthralling-performance": {
+      "name": "Enthralling Performance",
+      "description": "If you perform for at least 1 minute, you can attempt to inspire wonder in your audience. Each humanoid within 60 feet that watched and listened must succeed on a WIS save (DC = 8 + your proficiency bonus + your CHA modifier) or be charmed for 1 hour. While charmed, the creature regards you as a wondrous performer; it is not hostile toward you. The effect ends if the creature takes damage. You can use this feature once per Short or Long Rest."
+    },
+    "collegeglamour-mantle-of-majesty": {
+      "name": "Mantle of Majesty",
+      "description": "As a Bonus Action, you cast Command on yourself without expending a spell slot, and it requires no Concentration. For 1 minute, you can cast Command as a Bonus Action on each of your turns without expending a spell slot, and the targets are automatically charmed by you for the duration. Once you use this feature, you can't use it again until you finish a Long Rest, unless you expend a spell slot of 3rd level or higher to use it again."
+    },
+    "collegelore-cutting-words": {
+      "name": "Cutting Words",
+      "description": "As a Reaction when a creature you can see within 60 feet makes an attack roll, ability check, or damage roll, you expend one use of your Bardic Inspiration and subtract the number rolled from the creature's roll."
+    },
+    "collegelore-magical-secrets": {
+      "name": "Magical Secrets",
+      "description": "You have plundered magical knowledge from a wide spectrum of disciplines. Choose two spells from any class's spell list, including this one. The chosen spells count as Bard spells for you and are added to your Bard spell list."
+    },
+    "collegevalor-combat-inspiration": {
+      "name": "Combat Inspiration",
+      "description": "A creature that has a Bardic Inspiration die from you can use it to add the result to a weapon attack's damage roll, or as a Reaction when it is hit by an attack to add the result to its AC against that attack."
+    },
+    "collegevalor-extra-attack": {
+      "name": "Extra Attack",
+      "description": "You can attack twice, instead of once, whenever you take the Attack action on your turn."
+    },
     "human-resourceful": {
       "name": "Resourceful",
       "description": "You gain Heroic Inspiration whenever you finish a Long Rest."


### PR DESCRIPTION
Closes #113. Part of meta-issue #111.

## Summary

- Populates `features` for the 4 Bard subclasses (`collegedance`, `collegeglamour`, `collegelore`, `collegevalor`) at levels 3 and 6 in `src/lib/sources/subclasses.ts`
- College of Lore uses a `proficiency-choice` grant for the 3 bonus skill proficiencies (choice key origin `class` since `ChoiceOrigin` does not include `'subclass'`)
- College of Valor uses `proficiency` grants for medium armor, shields, and martial weapons
- Adds 11 new feature `name`/`description` i18n entries to `src/locales/en/gamedata.json`
- Adds behavioral tests for each subclass mirroring the existing Champion/Barbarian patterns

## Rules ambiguities (follow-up issue will be filed)

1. **Bardic-die-scaled mechanics** — College of Dance Unarmored Defense (AC = 10 + DEX + Bardic die size), College of Dance Inspirational Dance damage, College of Glamour Mantle of Inspiration temp HP — all scale with the Bardic Inspiration die, which has no static integer grant equivalent. Modeled as inert `feature` grants.
2. **College of Lore Magical Secrets** — Learn 2 spells from any class's list. Requires the spell system (#93); marked `// TODO #93` and modeled as an inert `feature` grant.
3. **ChoiceOrigin coverage** — `ChoiceOrigin` is currently `species | background | class`; no `'subclass'` option. The College of Lore skill-choice key uses `'class'` as the origin. Worth considering whether `'subclass'` should be added.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1357 tests pass (16 new Bard tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)