### PR TITLE
feat(subclasses): implement Cleric divine domains through level 10 (#114)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -462,6 +462,194 @@ describe('getSubclassSource — College of Valor', () => {
   });
 });
 
+describe('getSubclassSource — Life Domain', () => {
+  it('returns defined for lifedomain', () => {
+    expect(getSubclassSource('lifedomain')).toBeDefined();
+  });
+
+  it('lifedomain has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('lifedomain');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('lifedomain level 3 grants heavy armor proficiency, disciple-of-life, preserve-life, and domain-spells', () => {
+    const source = getSubclassSource('lifedomain');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(4);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'proficiency', category: 'armor', id: 'heavy' }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'lifedomain-disciple-of-life' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'lifedomain-preserve-life' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'lifedomain-domain-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('lifedomain level 6 grants blessed-strikes feature', () => {
+    const source = getSubclassSource('lifedomain');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'lifedomain-blessed-strikes' },
+    });
+  });
+});
+
+describe('getSubclassSource — Light Domain', () => {
+  it('returns defined for lightdomain', () => {
+    expect(getSubclassSource('lightdomain')).toBeDefined();
+  });
+
+  it('lightdomain has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('lightdomain');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('lightdomain level 3 grants bonus-cantrip, warding-flare, radiance-of-the-dawn, and domain-spells', () => {
+    const source = getSubclassSource('lightdomain');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(4);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'lightdomain-bonus-cantrip' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'lightdomain-warding-flare' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'lightdomain-radiance-of-the-dawn' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'lightdomain-domain-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('lightdomain level 6 grants improved-warding-flare feature', () => {
+    const source = getSubclassSource('lightdomain');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'lightdomain-improved-warding-flare' },
+    });
+  });
+});
+
+describe('getSubclassSource — Trickery Domain', () => {
+  it('returns defined for trickerydomain', () => {
+    expect(getSubclassSource('trickerydomain')).toBeDefined();
+  });
+
+  it('trickerydomain has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('trickerydomain');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('trickerydomain level 3 grants blessing-of-the-trickster, invoke-duplicity, and domain-spells', () => {
+    const source = getSubclassSource('trickerydomain');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'trickerydomain-blessing-of-the-trickster' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'trickerydomain-invoke-duplicity' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'trickerydomain-domain-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('trickerydomain level 6 grants tricksters-transposition feature', () => {
+    const source = getSubclassSource('trickerydomain');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'trickerydomain-tricksters-transposition' },
+    });
+  });
+});
+
+describe('getSubclassSource — War Domain', () => {
+  it('returns defined for wardomain', () => {
+    expect(getSubclassSource('wardomain')).toBeDefined();
+  });
+
+  it('wardomain has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('wardomain');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('wardomain level 3 grants heavy armor, martial weapons proficiencies, war-priest, guided-strike, and domain-spells', () => {
+    const source = getSubclassSource('wardomain');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(5);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'proficiency', category: 'armor', id: 'heavy' }),
+        expect.objectContaining({ type: 'proficiency', category: 'weapon', id: 'martial' }),
+        expect.objectContaining({ type: 'feature', feature: expect.objectContaining({ id: 'wardomain-war-priest' }) }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'wardomain-guided-strike' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'wardomain-domain-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('wardomain level 6 grants war-gods-blessing feature', () => {
+    const source = getSubclassSource('wardomain');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'wardomain-war-gods-blessing' },
+    });
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -187,10 +187,84 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
     ] satisfies readonly SubclassFeature[],
   },
   // Cleric
-  lifedomain: { features: [] },
-  lightdomain: { features: [] },
-  trickerydomain: { features: [] },
-  wardomain: { features: [] },
+  lifedomain: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          { type: 'proficiency', category: 'armor', id: 'heavy' },
+          { type: 'feature', feature: { id: 'lifedomain-disciple-of-life' } },
+          { type: 'feature', feature: { id: 'lifedomain-preserve-life' } },
+          // TODO #93: model domain spells (Bless, Cure Wounds, etc.) as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'lifedomain-domain-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        // Blessed Strikes: once per turn, a weapon or cantrip hit deals +1d8 necrotic or radiant damage
+        // Per 2024 PHB, Blessed Strikes is the canonical Life Domain L6 feature.
+        // NOTE: The 2024 PHB class table also lists Blessed Strikes as a class-wide Cleric feature at L7
+        // in some printings; this implementation treats the domain entry as authoritative for Life Domain.
+        grants: [{ type: 'feature', feature: { id: 'lifedomain-blessed-strikes' } }],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  lightdomain: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Light cantrip always known — modeled as inert feature grant; no SpellGrant caller exists yet
+          // TODO #93: replace with a spell grant when the spell id system supports cantrips
+          { type: 'feature', feature: { id: 'lightdomain-bonus-cantrip' } },
+          { type: 'feature', feature: { id: 'lightdomain-warding-flare' } },
+          { type: 'feature', feature: { id: 'lightdomain-radiance-of-the-dawn' } },
+          // TODO #93: model domain spells as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'lightdomain-domain-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [{ type: 'feature', feature: { id: 'lightdomain-improved-warding-flare' } }],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  trickerydomain: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          { type: 'feature', feature: { id: 'trickerydomain-blessing-of-the-trickster' } },
+          { type: 'feature', feature: { id: 'trickerydomain-invoke-duplicity' } },
+          // TODO #93: model domain spells as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'trickerydomain-domain-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [{ type: 'feature', feature: { id: 'trickerydomain-tricksters-transposition' } }],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  wardomain: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          { type: 'proficiency', category: 'armor', id: 'heavy' },
+          { type: 'proficiency', category: 'weapon', id: 'martial' },
+          { type: 'feature', feature: { id: 'wardomain-war-priest' } },
+          { type: 'feature', feature: { id: 'wardomain-guided-strike' } },
+          // TODO #93: model domain spells as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'wardomain-domain-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [{ type: 'feature', feature: { id: 'wardomain-war-gods-blessing' } }],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
   // Druid
   circleland: { features: [] },
   circlemoon: { features: [] },

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -907,6 +907,74 @@
       "name": "Greater Divine Intervention",
       "description": "Your Divine Intervention now always succeeds. Once you use it, you can't use it again until 2d4 days have passed."
     },
+    "lifedomain-domain-spells": {
+      "name": "Life Domain Spells",
+      "description": "Your domain connection lets you always have certain spells prepared. These spells don't count against the number of spells you can prepare each day: Bless, Cure Wounds (L1); Aid, Lesser Restoration (L3); Mass Healing Word, Revivify (L5); Death Ward, Guardian of Faith (L7); Mass Cure Wounds, Raise Dead (L9)."
+    },
+    "lifedomain-disciple-of-life": {
+      "name": "Disciple of Life",
+      "description": "When you cast a spell of 1st level or higher that restores Hit Points to a creature, that creature regains additional Hit Points equal to 2 + the spell's level."
+    },
+    "lifedomain-preserve-life": {
+      "name": "Preserve Life",
+      "description": "As a Magic action, you present your holy symbol and evoke healing energy that can restore a number of Hit Points equal to five times your Cleric level. Choose any creatures within 30 feet of you, and divide those Hit Points among them. This feature can restore a creature to no more than half its Hit Point maximum. You can use this feature a number of times equal to your Wisdom modifier (minimum once), and you regain all expended uses when you finish a Long Rest."
+    },
+    "lifedomain-blessed-strikes": {
+      "name": "Blessed Strikes (Life Domain)",
+      "description": "Divine power infuses you in battle. Once on each of your turns when you hit a creature with a weapon attack or deal damage to a creature with a Cleric cantrip, you can deal extra 1d8 Necrotic or Radiant damage (your choice) to that creature."
+    },
+    "lightdomain-domain-spells": {
+      "name": "Light Domain Spells",
+      "description": "Your domain connection lets you always have certain spells prepared. These spells don't count against the number of spells you can prepare each day: Burning Hands, Faerie Fire (L1); Flaming Sphere, See Invisibility (L3); Daylight, Fireball (L5); Guardian of Faith, Wall of Fire (L7); Flame Strike, Scrying (L9)."
+    },
+    "lightdomain-bonus-cantrip": {
+      "name": "Bonus Cantrip (Light)",
+      "description": "You know the Light cantrip. It doesn't count against the number of Cleric cantrips you know."
+    },
+    "lightdomain-warding-flare": {
+      "name": "Warding Flare",
+      "description": "When a creature you can see within 30 feet of you makes an attack roll, you can use your Reaction to impose Disadvantage on the attack roll, causing light to flare before the attacker before it hits or misses. You can use this feature a number of times equal to your Wisdom modifier (minimum once), and you regain all expended uses when you finish a Long Rest."
+    },
+    "lightdomain-radiance-of-the-dawn": {
+      "name": "Radiance of the Dawn",
+      "description": "As a Magic action, you present your holy symbol and any magical darkness within 30 feet of you is dispelled. Additionally, each hostile creature within 30 feet of you must make a Constitution saving throw. A creature takes 2d10 + your Cleric level Radiant damage on a failed save, or half as much damage on a successful one. A creature that has total cover from you is not affected."
+    },
+    "lightdomain-improved-warding-flare": {
+      "name": "Improved Warding Flare",
+      "description": "You can also use your Warding Flare when a creature that you can see within 30 feet of you attacks a target other than you."
+    },
+    "trickerydomain-domain-spells": {
+      "name": "Trickery Domain Spells",
+      "description": "Your domain connection lets you always have certain spells prepared. These spells don't count against the number of spells you can prepare each day: Charm Person, Disguise Self (L1); Mirror Image, Pass Without Trace (L3); Blink, Dispel Magic (L5); Dimension Door, Polymorph (L7); Dominate Person, Modify Memory (L9)."
+    },
+    "trickerydomain-blessing-of-the-trickster": {
+      "name": "Blessing of the Trickster",
+      "description": "As a Magic action, you can choose yourself or a willing creature within 30 feet of you to gain Advantage on Dexterity (Stealth) checks. This blessing lasts until you use this feature again or until you finish a Long Rest."
+    },
+    "trickerydomain-invoke-duplicity": {
+      "name": "Invoke Duplicity",
+      "description": "As a Bonus Action, you create a perfect illusory duplicate of yourself in an unoccupied space you can see within 30 feet of you. The duplicate lasts for 1 minute, until you are Incapacitated, or until you end it as a Bonus Action. While the duplicate persists, you can cast spells as though you were in its space, and you and the duplicate can flank the same target."
+    },
+    "trickerydomain-tricksters-transposition": {
+      "name": "Trickster's Transposition",
+      "description": "Whenever you create your illusory duplicate, you can swap places with it once on each of your turns as a Bonus Action."
+    },
+    "wardomain-domain-spells": {
+      "name": "War Domain Spells",
+      "description": "Your domain connection lets you always have certain spells prepared. These spells don't count against the number of spells you can prepare each day: Divine Favor, Shield of Faith (L1); Magic Weapon, Spiritual Weapon (L3); Crusader's Mantle, Spirit Guardians (L5); Fire Shield, Freedom of Movement (L7); Destructive Wave, Hold Monster (L9)."
+    },
+    "wardomain-war-priest": {
+      "name": "War Priest",
+      "description": "Your deity empowers your assaults. Whenever you use the Attack action, you can make one extra weapon attack as a Bonus Action. You can use this feature a number of times equal to your Wisdom modifier (minimum once), and you regain all expended uses when you finish a Short or Long Rest."
+    },
+    "wardomain-guided-strike": {
+      "name": "Guided Strike",
+      "description": "When you or a creature within 30 feet of you misses with an attack roll, you can expend one use of your Channel Divinity and give that roll a +10 bonus, potentially turning the miss into a hit. You can use this feature before or after the d20 is rolled."
+    },
+    "wardomain-war-gods-blessing": {
+      "name": "War God's Blessing",
+      "description": "You can use your Reaction to expend one use of your Channel Divinity and give an attack roll made by a creature within 30 feet of you a +10 bonus. You make this choice after you see the roll but before the DM says whether it hits or misses."
+    },
     "druid-primal-order": {
       "name": "Primal Order",
       "description": "You have dedicated yourself to one of the following sacred roles of your choice: Magician or Warden."


### PR DESCRIPTION
Closes #114. Part of meta-issue #111.

## Summary

- Populates `features` for the 4 Cleric domains (`lifedomain`, `lightdomain`, `trickerydomain`, `wardomain`) at levels 3 and 6 in `src/lib/sources/subclasses.ts`
- War Domain grants heavy armor + martial weapon proficiencies via `proficiency` grants
- Life Domain grants heavy armor proficiency via a `proficiency` grant
- Adds 17 new feature i18n entries to `src/locales/en/gamedata.json`
- Adds behavioral tests per domain mirroring existing patterns

## Rules ambiguities (follow-up issue will be filed)

1. **Domain spells (all 4 domains)** — Always-prepared spell lists; tagged `// TODO #93` and modeled as inert `feature` grants pending the spellcasting system.
2. **Light Domain bonus Light cantrip (L3)** — Inert `feature` grant for the same reason.
3. **Life Domain L6 Blessed Strikes** — Namespaced as `lifedomain-blessed-strikes` to avoid colliding with the existing `cleric-blessed-strikes` class-level feature. Some 2024 PHB printings list Blessed Strikes at the class level (L7) rather than as a domain feature; the authoritative form should be confirmed.
4. **War Priest** — Some printings file War Priest under the Holy Order class feature rather than as War Domain L3; we follow the issue spec and place it on the subclass.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1373 tests pass (16 new Cleric tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)