### PR TITLE
feat(subclasses): implement Druid circles through level 10 (#115)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -650,6 +650,216 @@ describe('getSubclassSource — War Domain', () => {
   });
 });
 
+describe('getSubclassSource — Circle of the Land', () => {
+  it('returns defined for circleland', () => {
+    expect(getSubclassSource('circleland')).toBeDefined();
+  });
+
+  it('circleland has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('circleland');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('circleland level 3 grants 3 features: lands-aid, bonus-cantrip, bonus-spells', () => {
+    const source = getSubclassSource('circleland');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'feature', feature: expect.objectContaining({ id: 'circleland-lands-aid' }) }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'circleland-bonus-cantrip' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'circleland-bonus-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('circleland level 6 grants natural-recovery feature', () => {
+    const source = getSubclassSource('circleland');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'circleland-natural-recovery' },
+    });
+  });
+
+  it('circleland level 10 grants natures-ward feature', () => {
+    const source = getSubclassSource('circleland');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'circleland-natures-ward' },
+    });
+  });
+});
+
+describe('getSubclassSource — Circle of the Moon', () => {
+  it('returns defined for circlemoon', () => {
+    expect(getSubclassSource('circlemoon')).toBeDefined();
+  });
+
+  it('circlemoon has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('circlemoon');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('circlemoon level 3 grants 2 features: circle-forms and improved-wild-shape', () => {
+    const source = getSubclassSource('circlemoon');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'circlemoon-circle-forms' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'circlemoon-improved-wild-shape' }),
+        }),
+      ])
+    );
+  });
+
+  it('circlemoon level 6 grants improved-circle-forms feature', () => {
+    const source = getSubclassSource('circlemoon');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'circlemoon-improved-circle-forms' },
+    });
+  });
+
+  it('circlemoon level 10 grants elemental-wild-shape feature', () => {
+    const source = getSubclassSource('circlemoon');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'circlemoon-elemental-wild-shape' },
+    });
+  });
+});
+
+describe('getSubclassSource — Circle of the Sea', () => {
+  it('returns defined for circlesea', () => {
+    expect(getSubclassSource('circlesea')).toBeDefined();
+  });
+
+  it('circlesea has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('circlesea');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('circlesea level 3 grants 1 feature: wrath-of-the-sea', () => {
+    const source = getSubclassSource('circlesea');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(1);
+    expect(level3?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'circlesea-wrath-of-the-sea' },
+    });
+  });
+
+  it('circlesea level 6 grants 2 items: swim speed grant and aquatic-affinity feature', () => {
+    const source = getSubclassSource('circlesea');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(2);
+    expect(level6?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'speed', mode: 'swim', value: 30 }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'circlesea-aquatic-affinity' }),
+        }),
+      ])
+    );
+  });
+
+  it('circlesea level 10 grants stormborn feature', () => {
+    const source = getSubclassSource('circlesea');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'circlesea-stormborn' },
+    });
+  });
+});
+
+describe('getSubclassSource — Circle of Stars', () => {
+  it('returns defined for circlestars', () => {
+    expect(getSubclassSource('circlestars')).toBeDefined();
+  });
+
+  it('circlestars has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('circlestars');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('circlestars level 3 grants 2 features: star-map and starry-form', () => {
+    const source = getSubclassSource('circlestars');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'circlestars-star-map' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'circlestars-starry-form' }),
+        }),
+      ])
+    );
+  });
+
+  it('circlestars level 6 grants cosmic-omen feature', () => {
+    const source = getSubclassSource('circlestars');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'circlestars-cosmic-omen' },
+    });
+  });
+
+  it('circlestars level 10 grants twinkling-constellations feature', () => {
+    const source = getSubclassSource('circlestars');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'circlestars-twinkling-constellations' },
+    });
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -266,10 +266,113 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
     ] satisfies readonly SubclassFeature[],
   },
   // Druid
-  circleland: { features: [] },
-  circlemoon: { features: [] },
-  circlesea: { features: [] },
-  circlestars: { features: [] },
+  circleland: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          { type: 'feature', feature: { id: 'circleland-lands-aid' } },
+          // Bonus Cantrip: gain one additional Druid cantrip of choice; modeled as inert feature grant
+          // TODO #93: replace with a cantrip-choice spell grant when spell id system supports it
+          { type: 'feature', feature: { id: 'circleland-bonus-cantrip' } },
+          // Land's Bonus Spells: bonus prepared spells keyed to chosen Land type (Arctic/Coast/etc.)
+          // Land type is a free-form choice with no pending-choice mechanism; collapsed to inert feature grant
+          // TODO #93: model as spell grants per Land type when spell id system is available
+          { type: 'feature', feature: { id: 'circleland-bonus-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [{ type: 'feature', feature: { id: 'circleland-natural-recovery' } }],
+      },
+      {
+        classLevel: 10,
+        grants: [{ type: 'feature', feature: { id: 'circleland-natures-ward' } }],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  circlemoon: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Circle Forms: Wild Shape up to CR = floor(druid level / 3), min CR 1; swim/fly speed allowed at L3
+          // Wild Shape mechanics (CR cap, resource pools) modeled as inert feature grant
+          { type: 'feature', feature: { id: 'circlemoon-circle-forms' } },
+          // Improved Wild Shape: use Wild Shape as Bonus Action; 2 uses replenish on Short Rest
+          { type: 'feature', feature: { id: 'circlemoon-improved-wild-shape' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Expend spell slot while in Wild Shape to regain 1d8 HP per spell slot level
+          { type: 'feature', feature: { id: 'circlemoon-improved-circle-forms' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // Expend 2 Wild Shape uses to transform into an Air/Earth/Fire/Water Elemental
+          { type: 'feature', feature: { id: 'circlemoon-elemental-wild-shape' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  circlesea: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Wrath of the Sea aura within 10 ft on Wild Shape entry; Bonus Action cold/lightning damage
+          { type: 'feature', feature: { id: 'circlesea-wrath-of-the-sea' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Swim speed approximated as 30 ft (equal to typical walking speed); see implementation note
+          { type: 'speed', mode: 'swim', value: 30 },
+          // Underwater breathing is a distinct feature; both grants are required for full Aquatic Affinity
+          { type: 'feature', feature: { id: 'circlesea-aquatic-affinity' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // Fly speed 30 ft while in a non-enclosed space; conditional speed not supported — inert feature grant
+          { type: 'feature', feature: { id: 'circlesea-stormborn' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  circlestars: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Star Map: grants access to Archer/Chalice/Dragon constellation forms on Wild Shape activation
+          { type: 'feature', feature: { id: 'circlestars-star-map' } },
+          // Starry Form: use Wild Shape to manifest a constellation (Archer, Chalice, or Dragon)
+          { type: 'feature', feature: { id: 'circlestars-starry-form' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // After each Long Rest, roll d6: even = Weal, odd = Woe; Reaction to add/subtract d6 from rolls
+          { type: 'feature', feature: { id: 'circlestars-cosmic-omen' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // Starry Form improvements: Archer d10, Chalice d8, Dragon fly speed; Bonus Action to switch form
+          { type: 'feature', feature: { id: 'circlestars-twinkling-constellations' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
   // Fighter
   champion: {
     features: [

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1015,6 +1015,70 @@
       "name": "Archdruid",
       "description": "The vitality of nature constantly blooms within you, granting you the following benefits."
     },
+    "circleland-lands-aid": {
+      "name": "Land's Aid",
+      "description": "As a Magic action, expend a use of Channel Nature to create a 10-foot radius bloom of vegetation centered on a point within 60 feet. Creatures of your choice within the bloom regain 2d6 Hit Points; other creatures make a CON save or take 2d6 Necrotic damage (save halves). The bloom persists until the start of your next turn."
+    },
+    "circleland-bonus-cantrip": {
+      "name": "Bonus Cantrip",
+      "description": "You learn one additional Druid cantrip of your choice."
+    },
+    "circleland-bonus-spells": {
+      "name": "Land's Bonus Spells",
+      "description": "Your connection to the land grants you bonus prepared spells based on your chosen Land type: Arctic, Coast, Desert, Forest, Grassland, Mountain, Swamp, or Underdark. (Land type selection and associated spells are modeled as a descriptive feature pending spell system support.)"
+    },
+    "circleland-natural-recovery": {
+      "name": "Natural Recovery",
+      "description": "During a Short Rest, you can recover expended spell slots with a combined level equal to half your Druid level (rounded up). You can't recover a slot of 6th level or higher. You can use this feature once per Long Rest."
+    },
+    "circleland-natures-ward": {
+      "name": "Nature's Ward",
+      "description": "You are immune to the Poisoned condition and to disease. You can't be Charmed or Frightened by Elementals or Fey."
+    },
+    "circlemoon-circle-forms": {
+      "name": "Circle Forms",
+      "description": "You can use Wild Shape to transform into a Beast with a CR equal to one-third your Druid level (rounded down, minimum CR 1). Beasts with a Swim or Fly speed are available starting at level 3."
+    },
+    "circlemoon-improved-wild-shape": {
+      "name": "Improved Wild Shape",
+      "description": "You can use Wild Shape as a Bonus Action. In addition, you regain 2 expended uses of Wild Shape whenever you finish a Short Rest."
+    },
+    "circlemoon-improved-circle-forms": {
+      "name": "Improved Circle Forms",
+      "description": "While in a Wild Shape form, you can expend a spell slot as a Bonus Action to regain a number of Hit Points equal to 1d8 times the level of the spell slot expended."
+    },
+    "circlemoon-elemental-wild-shape": {
+      "name": "Elemental Wild Shape",
+      "description": "You can expend 2 uses of Wild Shape to transform into an Air Elemental, Earth Elemental, Fire Elemental, or Water Elemental using the corresponding stat block."
+    },
+    "circlesea-wrath-of-the-sea": {
+      "name": "Wrath of the Sea",
+      "description": "When you enter Wild Shape, you conjure a Wrath of the Sea aura within 10 feet of you that lasts until your Wild Shape ends. As a Bonus Action on each of your turns, you can choose Cold or Lightning damage and deal that damage to one creature within the aura (no save)."
+    },
+    "circlesea-aquatic-affinity": {
+      "name": "Aquatic Affinity",
+      "description": "You can breathe underwater, and you gain a Swim speed equal to your walking speed. (Swim speed is approximated as 30 ft in this implementation; actual value equals walking speed.)"
+    },
+    "circlesea-stormborn": {
+      "name": "Stormborn",
+      "description": "You gain a Fly speed of 30 feet while you are not in a confined space. (Conditional fly speed is modeled as a descriptive feature pending conditional speed support.)"
+    },
+    "circlestars-star-map": {
+      "name": "Star Map",
+      "description": "You have a star map that serves as a spellcasting focus and grants access to your three constellation forms — Archer, Chalice, and Dragon — usable when you activate Starry Form."
+    },
+    "circlestars-starry-form": {
+      "name": "Starry Form",
+      "description": "You can use Wild Shape to assume a starry form instead of a Beast shape. While in this form, you shed dim light in a 10-foot radius and gain benefits depending on the constellation chosen: Archer (ranged radiant attack as a Bonus Action), Chalice (heal yourself when you cast a healing spell), or Dragon (make CON saves with advantage)."
+    },
+    "circlestars-cosmic-omen": {
+      "name": "Cosmic Omen",
+      "description": "After each Long Rest, roll a d6. On an even result you have Weal; on an odd result you have Woe. Once per turn, you can use a Reaction to add a d6 to (Weal) or subtract a d6 from (Woe) an attack roll, saving throw, or ability check made by a creature you can see within 30 feet."
+    },
+    "circlestars-twinkling-constellations": {
+      "name": "Twinkling Constellations",
+      "description": "Your Starry Form benefits improve: Archer's Bonus Action attack deals 1d10 + WIS radiant damage; Chalice healing improves to 1d8 + WIS; Dragon grants a Fly speed of 20 feet. While in Starry Form, you can switch constellations as a Bonus Action."
+    },
     "monk-martial-arts": {
       "name": "Martial Arts",
       "description": "Your practice of martial arts gives you mastery of combat styles that use unarmed strikes and monk weapons."


### PR DESCRIPTION
Closes #115. Part of meta-issue #111.

## Summary

- Populates `features` for the 4 Druid circles (`circleland`, `circlemoon`, `circlesea`, `circlestars`) at levels 3, 6, and 10 in `src/lib/sources/subclasses.ts`
- `circlesea` L6 Aquatic Affinity uses a `SpeedGrant` with `mode: 'swim'`, value 30
- Adds 16 new feature i18n entries to `src/locales/en/gamedata.json`
- Adds behavioral tests per circle

## Rules ambiguities (follow-up issue will be filed)

1. **Circle of the Land L3 Land type choice** — Arctic/Coast/Desert/Forest/Grassland/Mountain/Swamp/Underdark selection has no pending-choice mechanism. The selection + associated bonus spells are collapsed into a single `circleland-bonus-spells` feature grant tagged `// TODO #93`.
2. **Circle of the Sea L6 swim speed** — `SpeedGrant.value` is a fixed number; PHB says swim speed equals walking speed (species-dependent). Hard-coded to 30; note in description text.
3. **Circle of the Sea L10 Stormborn** — Fly speed is conditional (only in non-enclosed spaces); modeled as a `feature` grant since conditional speed grants don't exist.
4. **Wild Shape resource pools** — Circle of the Moon's CR caps, use replenishment, and elemental forms are described in feature text only; resource-pool tracking is outside the source/grant/resolver pipeline.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1393 tests pass (20 new Druid tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)