### PR TITLE
feat(subclasses): implement Fighter Psi Warrior through level 10 (#116)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -860,6 +860,56 @@ describe('getSubclassSource — Circle of Stars', () => {
   });
 });
 
+describe('getSubclassSource — Psi Warrior', () => {
+  it('returns defined for psiwarrior', () => {
+    expect(getSubclassSource('psiwarrior')).toBeDefined();
+  });
+
+  it('psiwarrior has 3 feature levels (L3, L7, L10)', () => {
+    const source = getSubclassSource('psiwarrior');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 7, 10]);
+  });
+
+  it('psiwarrior level 3 grants 1 feature: psionic-power', () => {
+    const source = getSubclassSource('psiwarrior');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(1);
+    expect(level3?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'psiwarrior-psionic-power' },
+    });
+  });
+
+  it('psiwarrior level 7 grants 1 feature: telekinetic-adept', () => {
+    const source = getSubclassSource('psiwarrior');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(1);
+    expect(level7?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'psiwarrior-telekinetic-adept' },
+    });
+  });
+
+  it('psiwarrior level 10 grants 2 items: psychic resistance and guarded-mind feature', () => {
+    const source = getSubclassSource('psiwarrior');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(2);
+    expect(level10?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'resistance', damageType: 'psychic' }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'psiwarrior-guarded-mind' }),
+        }),
+      ])
+    );
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -423,7 +423,34 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       { classLevel: 18, grants: [{ type: 'feature', feature: { id: 'eldritchknight-improved-war-magic' } }] },
     ],
   },
-  psiwarrior: { features: [] },
+  psiwarrior: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Single umbrella feature for Psionic Power pool (Protective Field, Psionic Strike,
+          // Telekinetic Movement). Die size scales with PB (d6 at PB+2 → d12 at PB+6); encoded in description.
+          { type: 'feature', feature: { id: 'psiwarrior-psionic-power' } },
+        ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          // Umbrella feature for Psi-Powered Leap and Telekinetic Thrust
+          { type: 'feature', feature: { id: 'psiwarrior-telekinetic-adept' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // Resistance to psychic damage (structural grant)
+          { type: 'resistance', damageType: 'psychic' },
+          // Charmed/Frightened cleansing mechanic (descriptive feature grant)
+          { type: 'feature', feature: { id: 'psiwarrior-guarded-mind' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
   // Monk
   warriorofmercy: { features: [] },
   warriorofshadow: { features: [] },

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -315,6 +315,18 @@
       "name": "Improved War Magic",
       "description": "When you cast a spell (not just a cantrip), you can make one weapon attack as a bonus action."
     },
+    "psiwarrior-psionic-power": {
+      "name": "Psionic Power",
+      "description": "You have a pool of Psionic Energy dice that fuel your psionic abilities. The die size scales with your proficiency bonus: d6 (PB +2), d8 (PB +3), d10 (PB +4), d12 (PB +5 or +6). You start each Long Rest with 4 dice; a Short Rest replenishes 1. Three options: Protective Field — Reaction to reduce damage to you or a creature within 30 ft by rolling one die + INT mod; Psionic Strike — after hitting with a weapon attack, roll a die and deal extra Force damage equal to the roll + INT mod (once per turn); Telekinetic Movement — as an Action, move a willing creature or object within 30 ft up to 30 ft (usable once per Short Rest without expending a die)."
+    },
+    "psiwarrior-telekinetic-adept": {
+      "name": "Telekinetic Adept",
+      "description": "You gain two psionic abilities: Psi-Powered Leap — as a Bonus Action, you gain a fly speed equal to twice your walking speed until the end of the current turn (usable once per Short Rest without expending a die); Telekinetic Thrust — when you damage a creature with Psionic Strike, you can force the target to make a STR saving throw (DC = 8 + proficiency bonus + INT mod) or be knocked Prone or pushed up to 10 ft away from you."
+    },
+    "psiwarrior-guarded-mind": {
+      "name": "Guarded Mind",
+      "description": "You have Resistance to Psychic damage. In addition, if you start your turn with the Charmed or Frightened condition, you can spend one Psionic Energy die (no action required) to end one of those conditions on yourself."
+    },
     "fighting-style-archery": {
       "name": "Fighting Style: Archery",
       "description": "You gain a +2 bonus to attack rolls you make with ranged weapons."


### PR DESCRIPTION
Closes #116. Part of meta-issue #111.

## Summary

- Populates `features` for `psiwarrior` at levels 3, 7, and 10 in `src/lib/sources/subclasses.ts`
- L10 Guarded Mind emits a `resistance` grant (`damageType: 'psychic'`) plus a `feature` grant
- L3 Psionic Power and L7 Telekinetic Adept use umbrella `feature` grants (mirroring Battlemaster's Combat Superiority pattern)
- Adds 3 new feature i18n entries to `src/locales/en/gamedata.json`
- Adds Psi Warrior describe block to `subclasses.test.ts`

## Rules ambiguities (follow-up issue will be filed)

1. **Psionic Energy resource pool** — 4 dice per long rest + 1 on short rest; die size scales with proficiency bonus (d6 → d8 → d10 → d12). All described in feature text; no resource-pool grant exists.
2. **"Once per short rest without expending a die"** — Telekinetic Movement and Psi-Powered Leap have a free-use clause that is descriptive only.
3. **Telekinetic Thrust DC** — DC = 8 + PB + INT mod is in the description text only; not structurally computed.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1398 tests pass (5 new Psi Warrior tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)