### PR TITLE
feat(subclasses): implement Monk warriors through level 10 (#117)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -910,6 +910,158 @@ describe('getSubclassSource — Psi Warrior', () => {
   });
 });
 
+describe('getSubclassSource — Warrior of Mercy', () => {
+  it('returns defined for warriorofmercy', () => {
+    expect(getSubclassSource('warriorofmercy')).toBeDefined();
+  });
+
+  it('warriorofmercy has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('warriorofmercy');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('warriorofmercy level 3 grants 2 features: hand-of-healing and hand-of-harm', () => {
+    const source = getSubclassSource('warriorofmercy');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'warriorofmercy-hand-of-healing' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'warriorofmercy-hand-of-harm' }),
+        }),
+      ])
+    );
+  });
+
+  it('warriorofmercy level 6 grants physicians-touch feature', () => {
+    const source = getSubclassSource('warriorofmercy');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'warriorofmercy-physicians-touch' },
+    });
+  });
+});
+
+describe('getSubclassSource — Warrior of Shadow', () => {
+  it('returns defined for warriorofshadow', () => {
+    expect(getSubclassSource('warriorofshadow')).toBeDefined();
+  });
+
+  it('warriorofshadow has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('warriorofshadow');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('warriorofshadow level 3 grants 1 feature: shadow-arts', () => {
+    const source = getSubclassSource('warriorofshadow');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(1);
+    expect(level3?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'warriorofshadow-shadow-arts' },
+    });
+  });
+
+  it('warriorofshadow level 6 grants shadow-step feature', () => {
+    const source = getSubclassSource('warriorofshadow');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'warriorofshadow-shadow-step' },
+    });
+  });
+});
+
+describe('getSubclassSource — Warrior of the Elements', () => {
+  it('returns defined for warriorofelements', () => {
+    expect(getSubclassSource('warriorofelements')).toBeDefined();
+  });
+
+  it('warriorofelements has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('warriorofelements');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('warriorofelements level 3 grants 2 features: elemental-attunement and elemental-burst', () => {
+    const source = getSubclassSource('warriorofelements');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'warriorofelements-elemental-attunement' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'warriorofelements-elemental-burst' }),
+        }),
+      ])
+    );
+  });
+
+  it('warriorofelements level 6 grants elemental-epitome feature', () => {
+    const source = getSubclassSource('warriorofelements');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'warriorofelements-elemental-epitome' },
+    });
+  });
+});
+
+describe('getSubclassSource — Warrior of the Open Hand', () => {
+  it('returns defined for warrioropenhand', () => {
+    expect(getSubclassSource('warrioropenhand')).toBeDefined();
+  });
+
+  it('warrioropenhand has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('warrioropenhand');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('warrioropenhand level 3 grants 1 feature: open-hand-technique', () => {
+    const source = getSubclassSource('warrioropenhand');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(1);
+    expect(level3?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'warrioropenhand-open-hand-technique' },
+    });
+  });
+
+  it('warrioropenhand level 6 grants wholeness-of-body feature', () => {
+    const source = getSubclassSource('warrioropenhand');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'warrioropenhand-wholeness-of-body' },
+    });
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -452,10 +452,88 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
     ] satisfies readonly SubclassFeature[],
   },
   // Monk
-  warriorofmercy: { features: [] },
-  warriorofshadow: { features: [] },
-  warriorofelements: { features: [] },
-  warrioropenhand: { features: [] },
+  warriorofmercy: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Focus Point cost: as part of Flurry of Blows, replace a strike with healing equal to Martial Arts die + WIS mod
+          { type: 'feature', feature: { id: 'warriorofmercy-hand-of-healing' } },
+          // Focus Point cost: when you hit with an unarmed strike, deal extra necrotic damage equal to Martial Arts die
+          { type: 'feature', feature: { id: 'warriorofmercy-hand-of-harm' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Enhances Hand of Healing (end a condition) and Hand of Harm (Poisoned on failed CON save)
+          { type: 'feature', feature: { id: 'warriorofmercy-physicians-touch' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  warriorofshadow: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Minor Illusion cantrip; Focus Point cost to cast Darkness, Darkvision, Pass without Trace, or Silence
+          // TODO #93: replace spell-cost casts with spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'warriorofshadow-shadow-arts' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Bonus Action: in dim light or darkness, teleport up to 60 ft to another dim/dark space you can see;
+          // next melee attack before end of turn has Advantage
+          { type: 'feature', feature: { id: 'warriorofshadow-shadow-step' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  warriorofelements: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Focus Point cost: Bonus Action — infuse unarmed strikes with chosen element (Acid/Cold/Fire/Lightning/Thunder)
+          // for 10 min; deal Martial Arts die extra damage on hit; push target 10 ft
+          { type: 'feature', feature: { id: 'warriorofelements-elemental-attunement' } },
+          // Focus Point cost: Action — choose a point within 60 ft; all creatures within 20 ft make DEX save or
+          // take 2d8 + Monk level damage of attunement element, half on success
+          { type: 'feature', feature: { id: 'warriorofelements-elemental-burst' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Canonical 2024 PHB L6 feature name unconfirmed; modeled as elemental-epitome per implementation notes.
+          // When Elemental Attunement is active, enhances push/pull distance and adds elemental aura effects.
+          { type: 'feature', feature: { id: 'warriorofelements-elemental-epitome' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  warrioropenhand: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // When you hit with Flurry of Blows, impose one of: knock Prone (STR save), push 15 ft (STR save),
+          // or prevent Reactions until end of your next turn (no save)
+          { type: 'feature', feature: { id: 'warrioropenhand-open-hand-technique' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Bonus Action: regain HP equal to 3× Martial Arts die roll; usable PB times per long rest
+          { type: 'feature', feature: { id: 'warrioropenhand-wholeness-of-body' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
   // Paladin
   oathofdevotion: { features: [] },
   oathofglory: { features: [] },

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -327,6 +327,46 @@
       "name": "Guarded Mind",
       "description": "You have Resistance to Psychic damage. In addition, if you start your turn with the Charmed or Frightened condition, you can spend one Psionic Energy die (no action required) to end one of those conditions on yourself."
     },
+    "warriorofmercy-hand-of-healing": {
+      "name": "Hand of Healing",
+      "description": "Focus Point: when you use Flurry of Blows, you can replace one of the strikes with a healing touch — the target regains Hit Points equal to a roll of your Martial Arts die + your Wisdom modifier."
+    },
+    "warriorofmercy-hand-of-harm": {
+      "name": "Hand of Harm",
+      "description": "Focus Point (1): when you hit a creature with an Unarmed Strike, you can spend 1 Focus Point to deal extra Necrotic damage equal to a roll of your Martial Arts die."
+    },
+    "warriorofmercy-physicians-touch": {
+      "name": "Physician's Touch",
+      "description": "Your Hand of Healing is enhanced: when you use it, you can also end one of the following conditions on the target — Diseased, Poisoned, Charmed, Frightened, Paralyzed, or Stunned. Your Hand of Harm is enhanced: the target must succeed on a CON saving throw (DC = 8 + your proficiency bonus + your WIS modifier) or have the Poisoned condition until the end of your next turn."
+    },
+    "warriorofshadow-shadow-arts": {
+      "name": "Shadow Arts",
+      "description": "You gain the Minor Illusion cantrip (WIS is your spellcasting ability). You can also spend Focus Points to cast the following spells without material components, using your Monk level as the spellcaster level and WIS as your spellcasting ability: Darkness (1 Focus Point), Darkvision (1 Focus Point), Pass without Trace (2 Focus Points), Silence (2 Focus Points)."
+    },
+    "warriorofshadow-shadow-step": {
+      "name": "Shadow Step",
+      "description": "Bonus Action: while in dim light or darkness, teleport up to 60 feet to an unoccupied space you can see that is also in dim light or darkness. The first melee attack you make before the end of the current turn has Advantage."
+    },
+    "warriorofelements-elemental-attunement": {
+      "name": "Elemental Attunement",
+      "description": "Focus Point: as a Bonus Action, infuse your Unarmed Strikes with elemental energy, choosing Acid, Cold, Fire, Lightning, or Thunder. This lasts 10 minutes. While active, your Unarmed Strikes deal extra damage of the chosen type equal to a roll of your Martial Arts die, and you can push the target up to 10 feet away from you on a hit."
+    },
+    "warriorofelements-elemental-burst": {
+      "name": "Elemental Burst",
+      "description": "Focus Point: as an Action, choose a point within 60 feet of you. All creatures within 20 feet of that point must make a DEX saving throw (DC = 8 + your proficiency bonus + your WIS modifier). On a failed save, a creature takes 2d8 + your Monk level damage of your attunement element; it takes half as much on a successful save."
+    },
+    "warriorofelements-elemental-epitome": {
+      "name": "Elemental Epitome",
+      "description": "While your Elemental Attunement is active, your mastery of elemental power grows: the push distance from Elemental Attunement increases to 15 feet, and you can choose to pull targets toward you instead of pushing them. You also gain resistance to the damage type you chose for your Elemental Attunement."
+    },
+    "warrioropenhand-open-hand-technique": {
+      "name": "Open Hand Technique",
+      "description": "When you hit a creature with one of the attacks granted by your Flurry of Blows, you can impose one of the following effects on that target: it must succeed on a STR saving throw or be knocked Prone; it must succeed on a STR saving throw or be pushed up to 15 feet away from you; or it can't take Reactions until the end of your next turn (no saving throw)."
+    },
+    "warrioropenhand-wholeness-of-body": {
+      "name": "Wholeness of Body",
+      "description": "Bonus Action: you can heal yourself. Roll your Martial Arts die and regain Hit Points equal to 3 times the result. You can use this feature a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest."
+    },
     "fighting-style-archery": {
       "name": "Fighting Style: Archery",
       "description": "You gain a +2 bonus to attack rolls you make with ranged weapons."


### PR DESCRIPTION
Closes #117. Part of meta-issue #111.

## Summary

- Populates `features` for the 4 Monk subclasses (`warriorofmercy`, `warriorofshadow`, `warriorofelements`, `warrioropenhand`) at levels 3 and 6 in `src/lib/sources/subclasses.ts`
- All features modeled as `feature` grants (Focus-Point-cost mechanics described in feature text)
- Adds 10 new feature i18n entries to `src/locales/en/gamedata.json`
- Adds behavioral tests per subclass

## Rules ambiguities (follow-up issue will be filed)

1. **Warrior of the Elements L6 name** — Used `warriorofelements-elemental-epitome` as a fallback id (PHB-canonical name not confirmed in this session). The description text describes a plausible enhancement to Elemental Attunement; verify against the printed 2024 PHB and patch if needed.
2. **Open Hand Technique per-hit sub-option** — The three on-Flurry-hit options (Prone / push 15ft / no Reactions) are per-hit choices. Collapsed into a single `feature` grant since no per-attack pending-choice mechanism exists.
3. **Shadow Arts spell-casting** — Focus-Point-cost Darkness/Darkvision/Pass without Trace/Silence tagged `// TODO #93` pending the spell system.
4. **Focus-Point resource pool, save DCs** — Described in i18n text only; no resource-pool or computed-DC grants.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1414 tests pass (16 new Monk tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)