### PR TITLE
feat(subclasses): implement Paladin oaths through level 10 (#118)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -1062,6 +1062,190 @@ describe('getSubclassSource — Warrior of the Open Hand', () => {
   });
 });
 
+describe('getSubclassSource — Oath of Devotion', () => {
+  it('returns defined for oathofdevotion', () => {
+    expect(getSubclassSource('oathofdevotion')).toBeDefined();
+  });
+
+  it('oathofdevotion has 2 feature levels (L3, L7)', () => {
+    const source = getSubclassSource('oathofdevotion');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 7]);
+  });
+
+  it('oathofdevotion level 3 grants 3 items: sacred-weapon, holy-rebuke, and oath-spells', () => {
+    const source = getSubclassSource('oathofdevotion');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofdevotion-sacred-weapon' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofdevotion-holy-rebuke' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofdevotion-oath-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('oathofdevotion level 7 grants aura-of-devotion feature', () => {
+    const source = getSubclassSource('oathofdevotion');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(1);
+    expect(level7?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'oathofdevotion-aura-of-devotion' },
+    });
+  });
+});
+
+describe('getSubclassSource — Oath of Glory', () => {
+  it('returns defined for oathofglory', () => {
+    expect(getSubclassSource('oathofglory')).toBeDefined();
+  });
+
+  it('oathofglory has 2 feature levels (L3, L7)', () => {
+    const source = getSubclassSource('oathofglory');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 7]);
+  });
+
+  it('oathofglory level 3 grants 3 items: peerless-athlete, inspiring-smite, and oath-spells', () => {
+    const source = getSubclassSource('oathofglory');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofglory-peerless-athlete' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofglory-inspiring-smite' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofglory-oath-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('oathofglory level 7 grants aura-of-alacrity feature', () => {
+    const source = getSubclassSource('oathofglory');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(1);
+    expect(level7?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'oathofglory-aura-of-alacrity' },
+    });
+  });
+});
+
+describe('getSubclassSource — Oath of the Ancients', () => {
+  it('returns defined for oathofancients', () => {
+    expect(getSubclassSource('oathofancients')).toBeDefined();
+  });
+
+  it('oathofancients has 2 feature levels (L3, L7)', () => {
+    const source = getSubclassSource('oathofancients');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 7]);
+  });
+
+  it('oathofancients level 3 grants 3 items: natures-wrath, turn-the-faithless, and oath-spells', () => {
+    const source = getSubclassSource('oathofancients');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofancients-natures-wrath' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofancients-turn-the-faithless' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofancients-oath-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('oathofancients level 7 grants aura-of-warding feature', () => {
+    const source = getSubclassSource('oathofancients');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(1);
+    expect(level7?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'oathofancients-aura-of-warding' },
+    });
+  });
+});
+
+describe('getSubclassSource — Oath of Vengeance', () => {
+  it('returns defined for oathofvengeance', () => {
+    expect(getSubclassSource('oathofvengeance')).toBeDefined();
+  });
+
+  it('oathofvengeance has 2 feature levels (L3, L7)', () => {
+    const source = getSubclassSource('oathofvengeance');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 7]);
+  });
+
+  it('oathofvengeance level 3 grants 3 items: vow-of-enmity, abjure-enemy, and oath-spells', () => {
+    const source = getSubclassSource('oathofvengeance');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofvengeance-vow-of-enmity' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofvengeance-abjure-enemy' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofvengeance-oath-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('oathofvengeance level 7 grants relentless-avenger feature', () => {
+    const source = getSubclassSource('oathofvengeance');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(1);
+    expect(level7?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'oathofvengeance-relentless-avenger' },
+    });
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -535,10 +535,95 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
     ] satisfies readonly SubclassFeature[],
   },
   // Paladin
-  oathofdevotion: { features: [] },
-  oathofglory: { features: [] },
-  oathofancients: { features: [] },
-  oathofvengeance: { features: [] },
+  oathofdevotion: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Sacred Weapon: 1 minute — weapon glows, +CHA mod to attack rolls (Channel Divinity option)
+          { type: 'feature', feature: { id: 'oathofdevotion-sacred-weapon' } },
+          // Holy Rebuke: Reaction within 30 ft when ally is attacked — target takes radiant damage (Channel Divinity option)
+          { type: 'feature', feature: { id: 'oathofdevotion-holy-rebuke' } },
+          // TODO #93: model as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'oathofdevotion-oath-spells' } },
+        ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          // Aura of Devotion: you and allies within 10 ft can't be Charmed; expands to 30 ft at L18
+          { type: 'feature', feature: { id: 'oathofdevotion-aura-of-devotion' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  oathofglory: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Peerless Athlete: 1 minute — Advantage on STR/DEX checks, carry capacity doubles, jump distance doubles (Channel Divinity option)
+          { type: 'feature', feature: { id: 'oathofglory-peerless-athlete' } },
+          // Inspiring Smite: after Divine Smite, distribute 2d8 + Paladin level temp HP to creatures within 30 ft (Channel Divinity option)
+          { type: 'feature', feature: { id: 'oathofglory-inspiring-smite' } },
+          // TODO #93: model as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'oathofglory-oath-spells' } },
+        ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          // Aura of Alacrity: you and allies within 10 ft gain +10 ft to walking speed; expands at L18
+          { type: 'feature', feature: { id: 'oathofglory-aura-of-alacrity' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  oathofancients: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Nature's Wrath: DEX or STR save vs Restrained by spectral vines (Channel Divinity option)
+          { type: 'feature', feature: { id: 'oathofancients-natures-wrath' } },
+          // Turn the Faithless: Fey and Fiend WIS save vs Turned for 1 minute (Channel Divinity option)
+          { type: 'feature', feature: { id: 'oathofancients-turn-the-faithless' } },
+          // TODO #93: model as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'oathofancients-oath-spells' } },
+        ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          // Aura of Warding: you and allies within 10 ft have resistance to damage from spells; expands at L18
+          // Modeled as feature grant — source-conditional resistance (spells only) doesn't map to existing resistance grant
+          { type: 'feature', feature: { id: 'oathofancients-aura-of-warding' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  oathofvengeance: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Vow of Enmity: Bonus Action, single target within 10 ft for 1 min — Advantage on attack rolls against it (Channel Divinity option)
+          { type: 'feature', feature: { id: 'oathofvengeance-vow-of-enmity' } },
+          // Abjure Enemy: 60 ft creature WIS save or Frightened and half speed for 1 minute (Channel Divinity option)
+          { type: 'feature', feature: { id: 'oathofvengeance-abjure-enemy' } },
+          // TODO #93: model as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'oathofvengeance-oath-spells' } },
+        ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          // Relentless Avenger: when you hit with an opportunity attack, move up to half your speed (no OA provocation)
+          { type: 'feature', feature: { id: 'oathofvengeance-relentless-avenger' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
   // Ranger
   beastmaster: { features: [] },
   feywanderer: { features: [] },

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1267,6 +1267,70 @@
       "name": "Epic Boon",
       "description": "You gain an Epic Boon feat or another feat of your choice."
     },
+    "oathofdevotion-sacred-weapon": {
+      "name": "Sacred Weapon",
+      "description": "Channel Divinity: for 1 minute, your weapon glows with divine light and you add your Charisma modifier to attack rolls made with it."
+    },
+    "oathofdevotion-holy-rebuke": {
+      "name": "Holy Rebuke",
+      "description": "Channel Divinity: when a creature within 30 feet attacks an ally, you can use your Reaction to rebuke it — the creature takes radiant damage and is rebuked."
+    },
+    "oathofdevotion-oath-spells": {
+      "name": "Oath of Devotion Spells",
+      "description": "Your sacred oath lets you always have certain spells prepared. These spells don't count against the number of spells you can prepare each day. Consult the Oath of Devotion Spells table in the Player's Handbook for the full list."
+    },
+    "oathofdevotion-aura-of-devotion": {
+      "name": "Aura of Devotion",
+      "description": "You and friendly creatures within 10 feet of you can't be Charmed while you are conscious. At level 18, the range of this aura increases to 30 feet."
+    },
+    "oathofglory-peerless-athlete": {
+      "name": "Peerless Athlete",
+      "description": "Channel Divinity: for 1 minute, you have Advantage on Strength (Athletics) and Dexterity (Acrobatics) checks, your carrying capacity doubles, and the distance of your long and high jumps doubles."
+    },
+    "oathofglory-inspiring-smite": {
+      "name": "Inspiring Smite",
+      "description": "Channel Divinity: immediately after you deal damage with Divine Smite, you can distribute Temporary Hit Points equal to 2d8 plus your Paladin level among creatures of your choice within 30 feet of you, including yourself."
+    },
+    "oathofglory-oath-spells": {
+      "name": "Oath of Glory Spells",
+      "description": "Your sacred oath lets you always have certain spells prepared. These spells don't count against the number of spells you can prepare each day. Consult the Oath of Glory Spells table in the Player's Handbook for the full list."
+    },
+    "oathofglory-aura-of-alacrity": {
+      "name": "Aura of Alacrity",
+      "description": "You and friendly creatures within 10 feet of you gain a +10-foot bonus to walking speed while you are conscious. At level 18, the range of this aura increases."
+    },
+    "oathofancients-natures-wrath": {
+      "name": "Nature's Wrath",
+      "description": "Channel Divinity: you can cause spectral vines to spring up and bind a creature. The target must succeed on a Dexterity or Strength saving throw or be Restrained until you use this feature again."
+    },
+    "oathofancients-turn-the-faithless": {
+      "name": "Turn the Faithless",
+      "description": "Channel Divinity: you can utter ancient words that are painful for Fey and Fiends to hear. Each Fey or Fiend within 30 feet of you must make a Wisdom saving throw. On a failed save, the creature is Turned for 1 minute or until it takes damage."
+    },
+    "oathofancients-oath-spells": {
+      "name": "Oath of the Ancients Spells",
+      "description": "Your sacred oath lets you always have certain spells prepared. These spells don't count against the number of spells you can prepare each day. Consult the Oath of the Ancients Spells table in the Player's Handbook for the full list."
+    },
+    "oathofancients-aura-of-warding": {
+      "name": "Aura of Warding",
+      "description": "Ancient magic lies so heavily upon you that it forms an aura. You and friendly creatures within 10 feet of you have resistance to damage from spells while you are conscious. At level 18, the range of this aura increases to 30 feet."
+    },
+    "oathofvengeance-vow-of-enmity": {
+      "name": "Vow of Enmity",
+      "description": "Channel Divinity: as a Bonus Action, you can utter a vow of enmity against a creature you can see within 10 feet of you. You gain Advantage on attack rolls against the creature for 1 minute or until you use this feature again."
+    },
+    "oathofvengeance-abjure-enemy": {
+      "name": "Abjure Enemy",
+      "description": "Channel Divinity: as an Action, you present your holy symbol and speak a prayer of denunciation. One creature within 60 feet must make a Wisdom saving throw. On a failed save, the creature is Frightened for 1 minute or until it takes damage; its speed is also halved."
+    },
+    "oathofvengeance-oath-spells": {
+      "name": "Oath of Vengeance Spells",
+      "description": "Your sacred oath lets you always have certain spells prepared. These spells don't count against the number of spells you can prepare each day. Consult the Oath of Vengeance Spells table in the Player's Handbook for the full list."
+    },
+    "oathofvengeance-relentless-avenger": {
+      "name": "Relentless Avenger",
+      "description": "Your supernatural focus helps you close off a foe's retreat. When you hit a creature with an opportunity attack, you can move up to half your speed immediately after the attack as part of the same Reaction. This movement doesn't provoke opportunity attacks."
+    },
     "ranger-favored-enemy": {
       "name": "Favored Enemy",
       "description": "You have advantage on Wisdom (Survival) checks to track your favored enemies, as well as on Intelligence checks to recall information about them."


### PR DESCRIPTION
Closes #118. Part of meta-issue #111.

## Summary

- Populates `features` for the 4 Paladin oaths (`oathofdevotion`, `oathofglory`, `oathofancients`, `oathofvengeance`) at levels 3 and 7 in `src/lib/sources/subclasses.ts`
- Each oath: 2 Channel Divinity option feature grants + 1 oath-spells feature grant (TODO #93) at L3, 1 aura feature grant at L7
- Adds 16 new feature i18n entries to `src/locales/en/gamedata.json`
- Adds behavioral tests per oath

## Rules ambiguities (follow-up issue will be filed)

1. **Oath spells (all 4 oaths)** — Always-prepared spell lists tagged `// TODO #93` as inert `feature` grants pending the spellcasting system.
2. **Aura of Warding (Ancients L7)** — "Resistance to damage from spells" is source-conditional. The `resistance` grant is unconditional by damage type, so this is a `feature` grant.
3. **Aura range scaling, Channel Divinity uses, computed save DCs** — Described in i18n text only; not structurally modeled.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1430 tests pass (16 new Paladin tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)