### PR TITLE
feat(subclasses): implement Ranger subclasses through level 10 (#119)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -1246,6 +1246,191 @@ describe('getSubclassSource — Oath of Vengeance', () => {
   });
 });
 
+describe('getSubclassSource — Beast Master', () => {
+  it('returns defined for beastmaster', () => {
+    expect(getSubclassSource('beastmaster')).toBeDefined();
+  });
+
+  it('beastmaster has 2 feature levels (L3, L7)', () => {
+    const source = getSubclassSource('beastmaster');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 7]);
+  });
+
+  it('beastmaster level 3 grants 1 feature: primal-companion', () => {
+    const source = getSubclassSource('beastmaster');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(1);
+    expect(level3?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'beastmaster-primal-companion' },
+    });
+  });
+
+  it('beastmaster level 7 grants 1 feature: exceptional-training', () => {
+    const source = getSubclassSource('beastmaster');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(1);
+    expect(level7?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'beastmaster-exceptional-training' },
+    });
+  });
+});
+
+describe('getSubclassSource — Fey Wanderer', () => {
+  it('returns defined for feywanderer', () => {
+    expect(getSubclassSource('feywanderer')).toBeDefined();
+  });
+
+  it('feywanderer has 2 feature levels (L3, L7)', () => {
+    const source = getSubclassSource('feywanderer');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 7]);
+  });
+
+  it('feywanderer level 3 grants 4 items: dreadful-strikes, skill proficiency-choice, otherworldly-glamour, subclass-spells', () => {
+    const source = getSubclassSource('feywanderer');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(4);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'feywanderer-dreadful-strikes' }),
+        }),
+        expect.objectContaining({
+          type: 'proficiency-choice',
+          category: 'skill',
+          count: 1,
+          from: expect.arrayContaining(['deception', 'performance', 'persuasion']),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'feywanderer-otherworldly-glamour' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'feywanderer-subclass-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('feywanderer level 3 proficiency-choice from list contains exactly deception, performance, persuasion', () => {
+    const source = getSubclassSource('feywanderer');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    const choiceGrant = level3?.grants.find((g) => g.type === 'proficiency-choice');
+    expect(choiceGrant).toBeDefined();
+    if (choiceGrant?.type === 'proficiency-choice' && choiceGrant.category === 'skill') {
+      expect(choiceGrant.from).toEqual(expect.arrayContaining(['deception', 'performance', 'persuasion']));
+      expect(choiceGrant.from).toHaveLength(3);
+    }
+  });
+
+  it('feywanderer level 7 grants 1 feature: beguiling-twist', () => {
+    const source = getSubclassSource('feywanderer');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(1);
+    expect(level7?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'feywanderer-beguiling-twist' },
+    });
+  });
+});
+
+describe('getSubclassSource — Gloom Stalker', () => {
+  it('returns defined for gloomstalker', () => {
+    expect(getSubclassSource('gloomstalker')).toBeDefined();
+  });
+
+  it('gloomstalker has 2 feature levels (L3, L7)', () => {
+    const source = getSubclassSource('gloomstalker');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 7]);
+  });
+
+  it('gloomstalker level 3 grants 3 features: dread-ambusher, umbral-sight, subclass-spells', () => {
+    const source = getSubclassSource('gloomstalker');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'gloomstalker-dread-ambusher' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'gloomstalker-umbral-sight' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'gloomstalker-subclass-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('gloomstalker level 7 grants 1 feature: iron-mind', () => {
+    const source = getSubclassSource('gloomstalker');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(1);
+    expect(level7?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'gloomstalker-iron-mind' },
+    });
+  });
+});
+
+describe('getSubclassSource — Hunter', () => {
+  it('returns defined for hunter', () => {
+    expect(getSubclassSource('hunter')).toBeDefined();
+  });
+
+  it('hunter has 2 feature levels (L3, L7)', () => {
+    const source = getSubclassSource('hunter');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 7]);
+  });
+
+  it('hunter level 3 grants 2 features: hunters-lore and hunters-prey', () => {
+    const source = getSubclassSource('hunter');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'hunter-hunters-lore' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'hunter-hunters-prey' }),
+        }),
+      ])
+    );
+  });
+
+  it('hunter level 7 grants 1 feature: defensive-tactics', () => {
+    const source = getSubclassSource('hunter');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(1);
+    expect(level7?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'hunter-defensive-tactics' },
+    });
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -625,10 +625,105 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
     ] satisfies readonly SubclassFeature[],
   },
   // Ranger
-  beastmaster: { features: [] },
-  feywanderer: { features: [] },
-  gloomstalker: { features: [] },
-  hunter: { features: [] },
+  beastmaster: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Primal Companion: expend 1 spell slot (or Hunter's Mark slot) to summon a Beast of the Land/Sea/Sky
+          // Stat block scales with PB and Ranger level; no companion grant exists — modeled as inert feature grant
+          { type: 'feature', feature: { id: 'beastmaster-primal-companion' } },
+        ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          // Exceptional Training: companion gains Hunter's Mark on your Hunter's Mark, and can take any
+          // combat action as a Bonus Action when commanded
+          { type: 'feature', feature: { id: 'beastmaster-exceptional-training' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  feywanderer: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Dreadful Strikes: when you hit a creature with a weapon, it takes extra 1d4 psychic damage
+          // (once per turn per target)
+          { type: 'feature', feature: { id: 'feywanderer-dreadful-strikes' } },
+          // Otherworldly Glamour (skill proficiency): choose 1 of Deception, Performance, or Persuasion
+          {
+            type: 'proficiency-choice',
+            category: 'skill',
+            key: createChoiceKey('skill-choice', 'class', 'feywanderer', 0),
+            count: 1,
+            from: ['deception', 'performance', 'persuasion'],
+          },
+          // Otherworldly Glamour (WIS-to-CHA bonus): inert feature grant; no modifier-substitution grant exists
+          { type: 'feature', feature: { id: 'feywanderer-otherworldly-glamour' } },
+          // TODO #93: model Fey Wanderer subclass spells as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'feywanderer-subclass-spells' } },
+        ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          // Beguiling Twist: you and allies within 30 ft have Advantage on Charmed/Frightened saves;
+          // Reaction to redirect a failed Charmed/Frightened save to another creature within range
+          { type: 'feature', feature: { id: 'feywanderer-beguiling-twist' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  gloomstalker: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Dread Ambusher: first turn of combat — +WIS mod to initiative, walk speed +10,
+          // extra attack on Attack action that deals 1d8 extra damage
+          { type: 'feature', feature: { id: 'gloomstalker-dread-ambusher' } },
+          // Umbral Sight: Darkvision 60 ft (or +30 to existing); invisible to creatures relying on Darkvision
+          { type: 'feature', feature: { id: 'gloomstalker-umbral-sight' } },
+          // TODO #93: model Gloom Stalker subclass spells as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'gloomstalker-subclass-spells' } },
+        ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          // Iron Mind: gain proficiency in WIS, INT, or CHA saving throw of your choice
+          // ProficiencyChoiceGrant does not support category: 'saving-throw'; modeled as inert feature grant
+          // (same pattern as wildheart-rage-of-the-wilds, zealot-divine-fury, etc.)
+          { type: 'feature', feature: { id: 'gloomstalker-iron-mind' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  hunter: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Hunter's Lore: when you mark a creature with Hunter's Mark, you learn its damage resistances/immunities
+          { type: 'feature', feature: { id: 'hunter-hunters-lore' } },
+          // Hunter's Prey: one-time choice of Colossus Slayer or Horde Breaker
+          // No pending-choice mechanism for free-form options; collapsed to inert feature grant
+          { type: 'feature', feature: { id: 'hunter-hunters-prey' } },
+        ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          // Defensive Tactics: one-time choice of Escape the Horde, Multiattack Defense, or Steel Will
+          // No pending-choice mechanism for free-form options; collapsed to inert feature grant
+          { type: 'feature', feature: { id: 'hunter-defensive-tactics' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
   // Rogue
   thief: {
     features: [

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1331,6 +1331,58 @@
       "name": "Relentless Avenger",
       "description": "Your supernatural focus helps you close off a foe's retreat. When you hit a creature with an opportunity attack, you can move up to half your speed immediately after the attack as part of the same Reaction. This movement doesn't provoke opportunity attacks."
     },
+    "beastmaster-primal-companion": {
+      "name": "Primal Companion",
+      "description": "You magically summon a primal beast — a Beast of the Land, Sea, or Sky — by expending one spell slot. The beast obeys your commands and uses your Proficiency Bonus in place of its own. Its stat block scales with your Ranger level. On each of your turns, you can command the beast to take an action as a Bonus Action. If the beast is slain, you can resummon it by expending a spell slot."
+    },
+    "beastmaster-exceptional-training": {
+      "name": "Exceptional Training",
+      "description": "Your primal companion's capabilities improve. When you use Hunter's Mark on a creature, your companion can also mark the same creature without expending a use of Hunter's Mark. In addition, when you command your companion to take an action, it can also take any combat action as a Bonus Action on the same turn."
+    },
+    "feywanderer-dreadful-strikes": {
+      "name": "Dreadful Strikes",
+      "description": "You can augment your weapon strikes with mind-scarring magic drawn from the murky Feywild. When you hit a creature with a weapon, you can deal an extra 1d4 Psychic damage to the target, which can take this extra damage only once per turn."
+    },
+    "feywanderer-otherworldly-glamour": {
+      "name": "Otherworldly Glamour",
+      "description": "Whenever you make a Charisma check, you can add your Wisdom modifier to the roll. (Skill proficiency choice — Deception, Performance, or Persuasion — is tracked separately.)"
+    },
+    "feywanderer-subclass-spells": {
+      "name": "Fey Wanderer Spells",
+      "description": "You always have certain spells prepared based on your Fey Wanderer subclass. (Spell grant system pending — see TODO #93.)"
+    },
+    "feywanderer-beguiling-twist": {
+      "name": "Beguiling Twist",
+      "description": "The magic of the Feywild guards your mind. You and each creature within 30 feet of you have Advantage on saving throws against being Charmed or Frightened. In addition, whenever a creature within 30 feet of you that you can see succeeds on a saving throw against being Charmed or Frightened, you can use your Reaction to force a different creature you can see within 30 feet to make a WIS saving throw (DC = 8 + your Proficiency Bonus + your WIS modifier). If that creature fails the save, it has the Charmed or Frightened condition (your choice) for 1 minute. The condition ends if the target takes any damage."
+    },
+    "gloomstalker-dread-ambusher": {
+      "name": "Dread Ambusher",
+      "description": "On the first turn of each combat, you gain two benefits: your walking speed increases by 10 feet, and if you make an attack with a weapon as part of the Attack action, you can make one additional attack as part of that action. That extra attack deals 1d8 extra damage of the weapon's type on a hit. You also add your Wisdom modifier to your initiative rolls."
+    },
+    "gloomstalker-umbral-sight": {
+      "name": "Umbral Sight",
+      "description": "You gain Darkvision to a range of 60 feet. If you already have Darkvision, its range increases by 30 feet. You are also naturally adept at hiding from creatures that rely on Darkvision — you are invisible to creatures with Darkvision when they try to detect you using that sense."
+    },
+    "gloomstalker-subclass-spells": {
+      "name": "Gloom Stalker Spells",
+      "description": "You always have certain spells prepared based on your Gloom Stalker subclass. (Spell grant system pending — see TODO #93.)"
+    },
+    "gloomstalker-iron-mind": {
+      "name": "Iron Mind",
+      "description": "You have honed your ability to resist the mind-altering powers of your prey. You gain proficiency in Wisdom, Intelligence, or Charisma saving throws (your choice). (One-time choice at level 7; no pending-choice mechanism — modeled as inert feature grant.)"
+    },
+    "hunter-hunters-lore": {
+      "name": "Hunter's Lore",
+      "description": "When you use Hunter's Mark on a creature, you immediately learn whether the creature has any damage Immunities or Resistances and what they are."
+    },
+    "hunter-hunters-prey": {
+      "name": "Hunter's Prey",
+      "description": "You gain one of the following features of your choice. Colossus Slayer: once per turn, your weapon attack deals an extra 1d8 damage if the target has fewer Hit Points than its Hit Point maximum. Horde Breaker: once on each of your turns when you make an attack with a weapon as part of the Attack action, you can make another attack with the same weapon against a different creature that is within 5 feet of the original target and within your weapon's range."
+    },
+    "hunter-defensive-tactics": {
+      "name": "Defensive Tactics",
+      "description": "You gain one of the following features of your choice. Escape the Horde: Opportunity Attacks against you are made with Disadvantage. Multiattack Defense: when a creature hits you with an attack roll, you gain a +4 bonus to AC against all subsequent attacks made by that creature for the rest of the current turn. Steel Will: you have Advantage on saving throws against the Frightened condition."
+    },
     "ranger-favored-enemy": {
       "name": "Favored Enemy",
       "description": "You have advantage on Wisdom (Survival) checks to track your favored enemies, as well as on Intelligence checks to recall information about them."


### PR DESCRIPTION
Closes #119. Part of meta-issue #111.

## Summary

- Populates `features` for the 4 Ranger subclasses (`beastmaster`, `feywanderer`, `gloomstalker`, `hunter`) at levels 3 and 7 in `src/lib/sources/subclasses.ts`
- Fey Wanderer L3 Otherworldly Glamour uses a `proficiency-choice` grant (skill, 1 of deception/performance/persuasion)
- All other one-time choices modeled as inert `feature` grants per established pattern
- Adds 13 new feature i18n entries to `src/locales/en/gamedata.json`
- Adds behavioral tests per subclass

## Rules ambiguities (follow-up issue will be filed)

1. **Gloom Stalker Iron Mind (L7)** — Spec requested `proficiency-choice` with `category: 'saving-throw'`. `ProficiencyChoiceGrant` only supports `armor | weapon | tool | skill | language`, so this is modeled as an inert `feature` grant. Adding a saving-throw variant to `ProficiencyChoiceGrant` would be the structural fix.
2. **Hunter's Prey (L3) and Defensive Tactics (L7)** — Each is a one-time choice among 2–3 options. No pending-choice mechanism for free-form option lists; collapsed to single inert `feature` grants.
3. **Beast Master Primal Companion (L3) and Exceptional Training (L7)** — No companion grant type; both inert `feature` grants.
4. **Subclass spell lists (Fey Wanderer, Gloom Stalker)** — Tagged `// TODO #93`.
5. **Initiative bonus (Gloom Stalker Dread Ambusher)** — No initiative-bonus grant; described in feature text.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1447 tests pass (17 new Ranger tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)