### PR TITLE
feat(subclasses): implement Rogue Soulknife through level 10 (#120)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -1431,6 +1431,48 @@ describe('getSubclassSource — Hunter', () => {
   });
 });
 
+describe('getSubclassSource — Soulknife', () => {
+  it('returns defined for soulknife', () => {
+    expect(getSubclassSource('soulknife')).toBeDefined();
+  });
+
+  it('soulknife has 2 feature levels (L3, L9)', () => {
+    const source = getSubclassSource('soulknife');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 9]);
+  });
+
+  it('soulknife level 3 grants 2 features: psionic-power and psychic-blades', () => {
+    const source = getSubclassSource('soulknife');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'soulknife-psionic-power' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'soulknife-psychic-blades' }),
+        }),
+      ])
+    );
+  });
+
+  it('soulknife level 9 grants 1 feature: soul-blades', () => {
+    const source = getSubclassSource('soulknife');
+    const level9 = source?.features.find((f) => f.classLevel === 9);
+    expect(level9).toBeDefined();
+    expect(level9?.grants).toHaveLength(1);
+    expect(level9?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'soulknife-soul-blades' },
+    });
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -774,7 +774,29 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       { classLevel: 9, grants: [{ type: 'feature', feature: { id: 'arcanetrickster-magical-ambush' } }] },
     ],
   },
-  soulknife: { features: [] },
+  soulknife: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Single umbrella feature for Psionic Power pool (Psi-Bolstered Knack, Psychic Whispers).
+          // Die size scales with PB (d6 at PB+2 → d12 at PB+6); shared resource pool with psiwarrior.
+          { type: 'feature', feature: { id: 'soulknife-psionic-power' } },
+          // Psychic Blades: Bonus Action to produce glowing psychic blades as Unarmed Strike alternatives;
+          // 1d6 psychic damage (1d8 for the off-hand blade in a two-weapon attack); counts as Finesse for Sneak Attack.
+          // No weapon-grant infrastructure exists — described entirely in feature text.
+          { type: 'feature', feature: { id: 'soulknife-psychic-blades' } },
+        ],
+      },
+      {
+        classLevel: 9,
+        grants: [
+          // Umbrella feature for Soul Blades options (Homing Strikes, Psychic Teleportation).
+          { type: 'feature', feature: { id: 'soulknife-soul-blades' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
   // Sorcerer
   aberrantsorcery: { features: [] },
   clockworksorcery: { features: [] },

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -467,6 +467,18 @@
       "name": "Magical Ambush",
       "description": "If hidden when you cast a spell, the target has disadvantage on saving throws against it this turn."
     },
+    "soulknife-psionic-power": {
+      "name": "Psionic Power",
+      "description": "You have a pool of Psionic Energy dice that fuel your psionic abilities. The die size scales with your proficiency bonus: d6 (PB +2), d8 (PB +3), d10 (PB +4), d12 (PB +5 or +6). You start each Long Rest with 4 dice; a Short Rest replenishes 1. Two options enabled at L3: Psi-Bolstered Knack — when you fail an ability check using a skill or tool you are proficient in, you can roll one Psionic Energy die and add it to the check; if this causes the check to succeed, the die is not expended; Psychic Whispers — as an Action, choose a number of creatures equal to your Proficiency Bonus that you can see within 1 mile; those creatures can communicate telepathically with you in a language you both know for up to 1 hour; this uses 1 Psionic Energy die."
+    },
+    "soulknife-psychic-blades": {
+      "name": "Psychic Blades",
+      "description": "As part of the Attack action or as a Bonus Action, you can manifest a glowing psychic blade from your hand to make a melee attack against a creature within reach. The blade deals 1d6 Psychic damage on a hit, using your Dexterity modifier for the attack and damage rolls. If you make this attack as a Bonus Action as part of a two-weapon fighting sequence, the off-hand blade deals 1d8 Psychic damage instead. The blades vanish immediately after an attack and have the Finesse property for the purpose of qualifying for Sneak Attack. No weapon proficiency or material components are required."
+    },
+    "soulknife-soul-blades": {
+      "name": "Soul Blades",
+      "description": "Your Psychic Blades gain two additional options powered by Psionic Energy dice: Homing Strikes — when you make an attack roll with your Psychic Blades and miss, you can roll one Psionic Energy die and add the result to the attack roll; if this causes the attack to hit, the die is not expended; Psychic Teleportation — as a Bonus Action, you manifest a Psychic Blade and throw it up to 30 feet to an unoccupied space you can see, then teleport to a space adjacent to where the blade landed, expending 1 Psionic Energy die."
+    },
     "berserker-frenzy": {
       "name": "Frenzy",
       "description": "While raging, you can use a Bonus Action on each of your turns to make one melee attack with a weapon or an Unarmed Strike. When your Rage ends, you have 1 Exhaustion level."


### PR DESCRIPTION
Closes #120. Part of meta-issue #111.

## Summary

- Populates `features` for `soulknife` at levels 3 and 9 in `src/lib/sources/subclasses.ts`
- L3: separate `feature` grants for Psionic Power (umbrella covering Psi-Bolstered Knack + Psychic Whispers) and Psychic Blades
- L9: single `feature` grant for Soul Blades (covering Homing Strikes + Psychic Teleportation)
- Adds 3 new feature i18n entries to `src/locales/en/gamedata.json`
- Adds Soulknife describe block to `subclasses.test.ts` (4 tests)

## Notes

The Psionic Energy resource pool is shared with Psi Warrior; both subclasses' resource-pool gap is tracked in the existing follow-up issue #146 (Psi Warrior follow-up). No new follow-up issue filed for Soulknife — its gaps overlap with the existing #146.

Psychic Blades weapon-like mechanics are described in feature text; weapon-grant infrastructure is out of scope.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1451 tests pass (4 new Soulknife tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)