### PR TITLE
feat(subclasses): implement Sorcerer subclasses through level 10 (#121)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -1473,6 +1473,194 @@ describe('getSubclassSource — Soulknife', () => {
   });
 });
 
+describe('getSubclassSource — Aberrant Sorcery', () => {
+  it('returns defined for aberrantsorcery', () => {
+    expect(getSubclassSource('aberrantsorcery')).toBeDefined();
+  });
+
+  it('aberrantsorcery has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('aberrantsorcery');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('aberrantsorcery level 3 grants 3 features: telepathic-speech, psionic-sorcery, subclass-spells', () => {
+    const source = getSubclassSource('aberrantsorcery');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'aberrantsorcery-telepathic-speech' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'aberrantsorcery-psionic-sorcery' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'aberrantsorcery-subclass-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('aberrantsorcery level 6 grants 2 items: psychic resistance and psychic-defenses feature', () => {
+    const source = getSubclassSource('aberrantsorcery');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(2);
+    expect(level6?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'resistance', damageType: 'psychic' }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'aberrantsorcery-psychic-defenses' }),
+        }),
+      ])
+    );
+  });
+});
+
+describe('getSubclassSource — Clockwork Sorcery', () => {
+  it('returns defined for clockworksorcery', () => {
+    expect(getSubclassSource('clockworksorcery')).toBeDefined();
+  });
+
+  it('clockworksorcery has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('clockworksorcery');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('clockworksorcery level 3 grants 3 features: restore-balance, trance-of-order, subclass-spells', () => {
+    const source = getSubclassSource('clockworksorcery');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'clockworksorcery-restore-balance' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'clockworksorcery-trance-of-order' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'clockworksorcery-subclass-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('clockworksorcery level 6 grants 1 feature: bastion-of-law', () => {
+    const source = getSubclassSource('clockworksorcery');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'clockworksorcery-bastion-of-law' },
+    });
+  });
+});
+
+describe('getSubclassSource — Draconic Sorcery', () => {
+  it('returns defined for draconicsorcery', () => {
+    expect(getSubclassSource('draconicsorcery')).toBeDefined();
+  });
+
+  it('draconicsorcery has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('draconicsorcery');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('draconicsorcery level 3 grants 5 items: hp-bonus, armor-class, draconic language, dragon-ancestor feature, subclass-spells feature', () => {
+    const source = getSubclassSource('draconicsorcery');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(5);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'hp-bonus', perLevel: 1 }),
+        expect.objectContaining({ type: 'armor-class', calculation: { mode: 'natural', baseAc: 13 } }),
+        expect.objectContaining({ type: 'proficiency', category: 'language', id: 'draconic' }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'draconicsorcery-dragon-ancestor' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'draconicsorcery-subclass-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('draconicsorcery level 6 grants 1 feature: elemental-affinity', () => {
+    const source = getSubclassSource('draconicsorcery');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'draconicsorcery-elemental-affinity' },
+    });
+  });
+});
+
+describe('getSubclassSource — Wild Magic Sorcery', () => {
+  it('returns defined for wildmagicsorcery', () => {
+    expect(getSubclassSource('wildmagicsorcery')).toBeDefined();
+  });
+
+  it('wildmagicsorcery has 2 feature levels (L3, L6)', () => {
+    const source = getSubclassSource('wildmagicsorcery');
+    expect(source?.features).toHaveLength(2);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+  });
+
+  it('wildmagicsorcery level 3 grants 3 features: wild-magic-surge, tides-of-chaos, subclass-spells', () => {
+    const source = getSubclassSource('wildmagicsorcery');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'wildmagicsorcery-wild-magic-surge' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'wildmagicsorcery-tides-of-chaos' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'wildmagicsorcery-subclass-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('wildmagicsorcery level 6 grants 1 feature: bend-luck', () => {
+    const source = getSubclassSource('wildmagicsorcery');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'wildmagicsorcery-bend-luck' },
+    });
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -798,10 +798,102 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
     ] satisfies readonly SubclassFeature[],
   },
   // Sorcerer
-  aberrantsorcery: { features: [] },
-  clockworksorcery: { features: [] },
-  draconicsorcery: { features: [] },
-  wildmagicsorcery: { features: [] },
+  aberrantsorcery: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Telepathic Speech: speak telepathically to one willing creature within 30 ft for 10 min (Intelligence-focused)
+          { type: 'feature', feature: { id: 'aberrantsorcery-telepathic-speech' } },
+          // Psionic Sorcery: cast subclass spells without V/M components by spending additional Sorcery Points
+          { type: 'feature', feature: { id: 'aberrantsorcery-psionic-sorcery' } },
+          // TODO #93: model as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'aberrantsorcery-subclass-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Resistance to psychic damage (structural grant)
+          { type: 'resistance', damageType: 'psychic' },
+          // Psychic Defenses: advantage on saving throws vs Charmed and Frightened conditions
+          { type: 'feature', feature: { id: 'aberrantsorcery-psychic-defenses' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  clockworksorcery: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Restore Balance: Reaction within 60 ft — cancel Advantage or Disadvantage on a roll (PB/long rest)
+          { type: 'feature', feature: { id: 'clockworksorcery-restore-balance' } },
+          // Trance of Order: 1 min — no crits against you; treat 9-or-lower d20 as 10 once per turn
+          { type: 'feature', feature: { id: 'clockworksorcery-trance-of-order' } },
+          // TODO #93: model as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'clockworksorcery-subclass-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Bastion of Law: spend 1–5 Sorcery Points to create d8-per-SP ward on a creature within 30 ft
+          { type: 'feature', feature: { id: 'clockworksorcery-bastion-of-law' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  draconicsorcery: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Draconic Resilience: +1 HP per Sorcerer level (structural grant)
+          { type: 'hp-bonus', perLevel: 1 },
+          // Draconic Resilience: AC 13 + DEX mod when not wearing armor (natural armor; structural grant)
+          { type: 'armor-class', calculation: { mode: 'natural', baseAc: 13 } },
+          // Dragon Ancestor: gain proficiency in Draconic language
+          { type: 'proficiency', category: 'language', id: 'draconic' },
+          // Dragon Ancestor: free-form 1-of-10 ancestry choice (Black/Blue/Brass/Bronze/Copper/Gold/Green/Red/Silver/White);
+          // no pending-choice mechanism for arbitrary dragon type options — modeled as inert feature grant
+          { type: 'feature', feature: { id: 'draconicsorcery-dragon-ancestor' } },
+          // TODO #93: model as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'draconicsorcery-subclass-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Elemental Affinity: add CHA mod to one damage roll of ancestor's element; spend 1 SP for 1hr resistance
+          { type: 'feature', feature: { id: 'draconicsorcery-elemental-affinity' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  wildmagicsorcery: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Wild Magic Surge: after casting a L1+ Sorcerer spell, DM may have you roll d20; on 1, roll Wild Magic Surge table
+          { type: 'feature', feature: { id: 'wildmagicsorcery-wild-magic-surge' } },
+          // Tides of Chaos: gain Advantage on one attack roll, ability check, or saving throw per long rest;
+          // automatically replenishes when you experience a Wild Magic Surge
+          { type: 'feature', feature: { id: 'wildmagicsorcery-tides-of-chaos' } },
+          // TODO #93: model as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'wildmagicsorcery-subclass-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Bend Luck: Reaction — spend 2 Sorcery Points to add or subtract 1d4 from a creature's roll within 60 ft
+          { type: 'feature', feature: { id: 'wildmagicsorcery-bend-luck' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
   // Warlock
   archfeypatron: { features: [] },
   celestialpatron: { features: [] },

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -467,6 +467,66 @@
       "name": "Magical Ambush",
       "description": "If hidden when you cast a spell, the target has disadvantage on saving throws against it this turn."
     },
+    "aberrantsorcery-telepathic-speech": {
+      "name": "Telepathic Speech",
+      "description": "As a Bonus Action, choose one willing creature you can see within 30 feet of you. For 10 minutes, you and the chosen creature can speak telepathically with each other while you are within 30 feet of each other. To understand each other, you each must speak mentally in a language the other knows."
+    },
+    "aberrantsorcery-psionic-sorcery": {
+      "name": "Psionic Sorcery",
+      "description": "When you cast a spell from your Aberrant Sorcery expanded spell list, you can expend Sorcery Points equal to the spell's level to cast it without any Verbal or Material components, provided you have no Concentration on a spell."
+    },
+    "aberrantsorcery-subclass-spells": {
+      "name": "Aberrant Sorcery Spells",
+      "description": "You have access to additional spells from your aberrant connection. These spells are always prepared and don't count against your Spells Prepared total."
+    },
+    "aberrantsorcery-psychic-defenses": {
+      "name": "Psychic Defenses",
+      "description": "You gain Resistance to Psychic damage, and you have Advantage on saving throws to avoid or end the Charmed or Frightened condition."
+    },
+    "clockworksorcery-restore-balance": {
+      "name": "Restore Balance",
+      "description": "As a Reaction when a creature you can see within 60 feet is about to roll a d20 with Advantage or Disadvantage, you can cancel that Advantage or Disadvantage. You can use this feature a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest."
+    },
+    "clockworksorcery-trance-of-order": {
+      "name": "Trance of Order",
+      "description": "As a Bonus Action, you enter a state of clockwork consciousness for 1 minute. While in this trance, attack rolls against you can't benefit from Advantage, and whenever you make an attack roll, ability check, or saving throw and roll a 9 or lower on the d20, you can treat the d20 as a 10. This feature ends early if you are incapacitated. Once you use it, you can't use it again until you finish a Long Rest, unless you spend 5 Sorcery Points to use it again."
+    },
+    "clockworksorcery-subclass-spells": {
+      "name": "Clockwork Sorcery Spells",
+      "description": "You have access to additional spells from your clockwork connection. These spells are always prepared and don't count against your Spells Prepared total."
+    },
+    "clockworksorcery-bastion-of-law": {
+      "name": "Bastion of Law",
+      "description": "As a Magic action, you can expend 1–5 Sorcery Points to create a shimmering ward on a creature you can see within 30 feet of you, including yourself. The ward is represented by a number of d8s equal to the Sorcery Points spent. When the warded creature takes damage, it can expend any number of those dice, rolling them and reducing the damage taken by the total rolled. The ward lasts until you finish a Long Rest or until all dice are expended."
+    },
+    "draconicsorcery-dragon-ancestor": {
+      "name": "Dragon Ancestor",
+      "description": "Choose one type of dragon as your ancestor: Black (Acid), Blue (Lightning), Brass (Fire), Bronze (Lightning), Copper (Acid), Gold (Fire), Green (Poison), Red (Fire), Silver (Cold), or White (Cold). Your choice determines the damage type for several of your other features. You also gain the ability to speak, read, and write Draconic, and you have Advantage on Charisma checks made to interact with dragons."
+    },
+    "draconicsorcery-subclass-spells": {
+      "name": "Draconic Sorcery Spells",
+      "description": "You have access to additional spells from your draconic bloodline. These spells are always prepared and don't count against your Spells Prepared total."
+    },
+    "draconicsorcery-elemental-affinity": {
+      "name": "Elemental Affinity",
+      "description": "When you cast a spell that deals damage of the type associated with your Dragon Ancestor, you can add your Charisma modifier to one damage roll of that spell. In addition, you can spend 1 Sorcery Point to gain Resistance to that damage type for 1 hour."
+    },
+    "wildmagicsorcery-wild-magic-surge": {
+      "name": "Wild Magic Surge",
+      "description": "Immediately after you cast a Sorcerer spell of level 1 or higher, the DM can have you roll a d20. On a 1, roll on the Wild Magic Surge table to create a random magical effect. A Wild Magic Surge can happen once per turn."
+    },
+    "wildmagicsorcery-tides-of-chaos": {
+      "name": "Tides of Chaos",
+      "description": "You can manipulate the forces of chance to gain Advantage on one attack roll, ability check, or saving throw. Once you do so, you must finish a Long Rest before you can use this feature again. If you use Wild Magic Surge before you regain use of this feature, you immediately regain use of it."
+    },
+    "wildmagicsorcery-subclass-spells": {
+      "name": "Wild Magic Sorcery Spells",
+      "description": "You have access to additional spells tied to the wild, unpredictable magic that flows through you. These spells are always prepared and don't count against your Spells Prepared total."
+    },
+    "wildmagicsorcery-bend-luck": {
+      "name": "Bend Luck",
+      "description": "You have the ability to twist fate using your Wild Magic. As a Reaction when another creature you can see within 60 feet makes an attack roll, ability check, or saving throw, you can spend 2 Sorcery Points and roll 1d4. You can add or subtract the number rolled from the creature's roll (your choice)."
+    },
     "soulknife-psionic-power": {
       "name": "Psionic Power",
       "description": "You have a pool of Psionic Energy dice that fuel your psionic abilities. The die size scales with your proficiency bonus: d6 (PB +2), d8 (PB +3), d10 (PB +4), d12 (PB +5 or +6). You start each Long Rest with 4 dice; a Short Rest replenishes 1. Two options enabled at L3: Psi-Bolstered Knack — when you fail an ability check using a skill or tool you are proficient in, you can roll one Psionic Energy die and add it to the check; if this causes the check to succeed, the die is not expended; Psychic Whispers — as an Action, choose a number of creatures equal to your Proficiency Bonus that you can see within 1 mile; those creatures can communicate telepathically with you in a language you both know for up to 1 hour; this uses 1 Psionic Energy die."


### PR DESCRIPTION
Closes #121. Part of meta-issue #111.

## Summary

- Populates `features` for the 4 Sorcerer subclasses (`aberrantsorcery`, `clockworksorcery`, `draconicsorcery`, `wildmagicsorcery`) at levels 3 and 6 in `src/lib/sources/subclasses.ts`
- **aberrantsorcery L6**: `resistance` grant (`damageType: 'psychic'`) + `feature` grant for Psychic Defenses
- **draconicsorcery L3**: `hp-bonus` (`perLevel: 1`) + `armor-class` (`{ mode: 'natural', baseAc: 13 }`) + `proficiency` (`category: 'language', id: 'draconic'`) + 2 feature grants
- Adds 15 new feature i18n entries to `src/locales/en/gamedata.json`
- Adds per-subclass behavioral tests

## Rules ambiguities (follow-up issue will be filed)

1. **Subclass spell lists (all 4 subclasses)** — Always-prepared lists tagged `// TODO #93`.
2. **Draconic Sorcery Dragon Ancestor (L3)** — Free-form 1-of-10 ancestry choice (Black/Blue/Brass/etc.); inert `feature` grant. Same gap as Wild Heart Beast Spirit (#138).
3. **Sorcery Point spend mechanics** — Bastion of Law (variable SP), Elemental Affinity (1 SP for 1hr resistance), Bend Luck (2 SP), Psionic Sorcery (SP instead of slot). All described in i18n text; no SP resource grant.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1467 tests pass (16 new Sorcerer tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)