### PR TITLE
feat(subclasses): implement Warlock patrons through level 10 (#122)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -1661,6 +1661,247 @@ describe('getSubclassSource — Wild Magic Sorcery', () => {
   });
 });
 
+describe('getSubclassSource — Archfey Patron', () => {
+  it('returns defined for archfeypatron', () => {
+    expect(getSubclassSource('archfeypatron')).toBeDefined();
+  });
+
+  it('archfeypatron has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('archfeypatron');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('archfeypatron level 3 grants 2 features: steps-of-the-fey and patron-spells', () => {
+    const source = getSubclassSource('archfeypatron');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'archfeypatron-steps-of-the-fey' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'archfeypatron-patron-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('archfeypatron level 6 grants 1 feature: misty-escape', () => {
+    const source = getSubclassSource('archfeypatron');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'archfeypatron-misty-escape' },
+    });
+  });
+
+  it('archfeypatron level 10 grants 1 feature: beguiling-defenses', () => {
+    const source = getSubclassSource('archfeypatron');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'archfeypatron-beguiling-defenses' },
+    });
+  });
+});
+
+describe('getSubclassSource — Celestial Patron', () => {
+  it('returns defined for celestialpatron', () => {
+    expect(getSubclassSource('celestialpatron')).toBeDefined();
+  });
+
+  it('celestialpatron has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('celestialpatron');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('celestialpatron level 3 grants 4 items: religion proficiency, bonus-cantrip, healing-light, patron-spells', () => {
+    const source = getSubclassSource('celestialpatron');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(4);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'proficiency', category: 'skill', id: 'religion' }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'celestialpatron-bonus-cantrip' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'celestialpatron-healing-light' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'celestialpatron-patron-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('celestialpatron level 6 grants 2 items: radiant resistance and radiant-soul feature', () => {
+    const source = getSubclassSource('celestialpatron');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(2);
+    expect(level6?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'resistance', damageType: 'radiant' }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'celestialpatron-radiant-soul' }),
+        }),
+      ])
+    );
+  });
+
+  it('celestialpatron level 10 grants 1 feature: celestial-resilience', () => {
+    const source = getSubclassSource('celestialpatron');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'celestialpatron-celestial-resilience' },
+    });
+  });
+});
+
+describe('getSubclassSource — Fiend Patron', () => {
+  it('returns defined for fiendpatron', () => {
+    expect(getSubclassSource('fiendpatron')).toBeDefined();
+  });
+
+  it('fiendpatron has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('fiendpatron');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('fiendpatron level 3 grants 2 features: dark-ones-blessing and patron-spells', () => {
+    const source = getSubclassSource('fiendpatron');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'fiendpatron-dark-ones-blessing' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'fiendpatron-patron-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('fiendpatron level 6 grants 1 feature: dark-ones-own-luck', () => {
+    const source = getSubclassSource('fiendpatron');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'fiendpatron-dark-ones-own-luck' },
+    });
+  });
+
+  it('fiendpatron level 10 grants 1 feature: fiendish-resilience', () => {
+    const source = getSubclassSource('fiendpatron');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'fiendpatron-fiendish-resilience' },
+    });
+  });
+});
+
+describe('getSubclassSource — Great Old One Patron', () => {
+  it('returns defined for greatoldonepatron', () => {
+    expect(getSubclassSource('greatoldonepatron')).toBeDefined();
+  });
+
+  it('greatoldonepatron has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('greatoldonepatron');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('greatoldonepatron level 3 grants 3 items: skill proficiency-choice, awakened-mind, and psychic-spells', () => {
+    const source = getSubclassSource('greatoldonepatron');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'proficiency-choice',
+          category: 'skill',
+          count: 1,
+          from: expect.arrayContaining(['arcana', 'history', 'intimidation', 'nature', 'religion', 'survival']),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'greatoldonepatron-awakened-mind' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'greatoldonepatron-psychic-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('greatoldonepatron level 3 proficiency-choice from list contains exactly the 6 allowed skills', () => {
+    const source = getSubclassSource('greatoldonepatron');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    const choiceGrant = level3?.grants.find((g) => g.type === 'proficiency-choice');
+    expect(choiceGrant).toBeDefined();
+    if (choiceGrant?.type === 'proficiency-choice' && choiceGrant.category === 'skill') {
+      expect(choiceGrant.from).toEqual(
+        expect.arrayContaining(['arcana', 'history', 'intimidation', 'nature', 'religion', 'survival'])
+      );
+      expect(choiceGrant.from).toHaveLength(6);
+    }
+  });
+
+  it('greatoldonepatron level 6 grants 1 feature: clairvoyant-combatant', () => {
+    const source = getSubclassSource('greatoldonepatron');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'greatoldonepatron-clairvoyant-combatant' },
+    });
+  });
+
+  it('greatoldonepatron level 10 grants 1 feature: eldritch-hex', () => {
+    const source = getSubclassSource('greatoldonepatron');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'greatoldonepatron-eldritch-hex' },
+    });
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -895,10 +895,128 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
     ] satisfies readonly SubclassFeature[],
   },
   // Warlock
-  archfeypatron: { features: [] },
-  celestialpatron: { features: [] },
-  fiendpatron: { features: [] },
-  greatoldonepatron: { features: [] },
+  archfeypatron: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Steps of the Fey: Misty Step is always prepared; Bonus Action teleport with rider effects (Refreshing Step or Taunting Step)
+          { type: 'feature', feature: { id: 'archfeypatron-steps-of-the-fey' } },
+          // TODO #93: model Archfey patron spells as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'archfeypatron-patron-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Misty Escape: Reaction when you take damage — Misty Step and become Invisible until end of next turn; uses = PB/long rest
+          { type: 'feature', feature: { id: 'archfeypatron-misty-escape' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // Beguiling Defenses: immunity to Charmed; when a creature tries to Charm you, target makes WIS save or is Charmed by you for 1 minute
+          { type: 'feature', feature: { id: 'archfeypatron-beguiling-defenses' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  celestialpatron: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Bonus Proficiency: Religion skill
+          { type: 'proficiency', category: 'skill', id: 'religion' },
+          // Bonus Cantrip: Light and Sacred Flame always known
+          // TODO #93: model as spell grants when spell id system supports cantrips
+          { type: 'feature', feature: { id: 'celestialpatron-bonus-cantrip' } },
+          // Healing Light: pool of d6s = 1 + Warlock level; spend as Bonus Action to heal creature within 60 ft
+          { type: 'feature', feature: { id: 'celestialpatron-healing-light' } },
+          // TODO #93: model Celestial patron spells as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'celestialpatron-patron-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Radiant Soul: resistance to Radiant damage + add CHA mod to one radiant/fire spell damage roll per turn
+          { type: 'resistance', damageType: 'radiant' },
+          { type: 'feature', feature: { id: 'celestialpatron-radiant-soul' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // Celestial Resilience: gain temp HP = Warlock level + CHA mod on short/long rest; allies gain half Warlock level
+          { type: 'feature', feature: { id: 'celestialpatron-celestial-resilience' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  fiendpatron: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Dark One's Blessing: when you reduce a hostile to 0 HP, gain temp HP = CHA mod + Warlock level
+          { type: 'feature', feature: { id: 'fiendpatron-dark-ones-blessing' } },
+          // TODO #93: model Fiend patron spells as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'fiendpatron-patron-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Dark One's Own Luck: add d10 to an ability check or save; uses = PB per long rest; replenishes on short/long rest
+          { type: 'feature', feature: { id: 'fiendpatron-dark-ones-own-luck' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // Fiendish Resilience: after short/long rest, choose one damage type to gain resistance to (runtime choice — no static resistance grant)
+          { type: 'feature', feature: { id: 'fiendpatron-fiendish-resilience' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  greatoldonepatron: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Bonus Proficiency (choice): Arcana, History, Intimidation, Nature, Religion, or Survival
+          {
+            type: 'proficiency-choice',
+            category: 'skill',
+            key: createChoiceKey('skill-choice', 'class', 'greatoldonepatron', 1),
+            count: 1,
+            from: ['arcana', 'history', 'intimidation', 'nature', 'religion', 'survival'],
+          },
+          // Awakened Mind: telepathic communication with creatures within 30 ft sharing a language
+          { type: 'feature', feature: { id: 'greatoldonepatron-awakened-mind' } },
+          // TODO #93: model Great Old One patron spells as spell grants when spell id system is available
+          { type: 'feature', feature: { id: 'greatoldonepatron-psychic-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Clairvoyant Combatant: creature within 60 ft must make WIS save or you have Advantage against it and are invisible to it for 1 min; uses = PB/long rest
+          { type: 'feature', feature: { id: 'greatoldonepatron-clairvoyant-combatant' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // Eldritch Hex: one creature you can see becomes Hexed; if it damages you, it takes psychic damage = PB; 1/day
+          { type: 'feature', feature: { id: 'greatoldonepatron-eldritch-hex' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
   // Wizard
   abjurer: { features: [] },
   diviner: { features: [] },

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -527,6 +527,74 @@
       "name": "Bend Luck",
       "description": "You have the ability to twist fate using your Wild Magic. As a Reaction when another creature you can see within 60 feet makes an attack roll, ability check, or saving throw, you can spend 2 Sorcery Points and roll 1d4. You can add or subtract the number rolled from the creature's roll (your choice)."
     },
+    "archfeypatron-steps-of-the-fey": {
+      "name": "Steps of the Fey",
+      "description": "Misty Step is always prepared for you. When you cast it, you can also choose one of two rider effects: Refreshing Step (you or an ally within 30 feet regains hit points equal to a roll of your Warlock spell slot die) or Taunting Step (one creature of your choice within 5 feet of the space you left must succeed on a Wisdom saving throw or have Disadvantage on attack rolls against creatures other than you until the start of your next turn). You can cast Misty Step a number of times equal to your Proficiency Bonus per Long Rest without expending a spell slot."
+    },
+    "archfeypatron-patron-spells": {
+      "name": "Archfey Patron Spells",
+      "description": "Your Archfey patron grants you access to additional spells that are always prepared and don't count against your Spells Prepared total. (Spell grants modeled as a feature stub — see issue #93.)"
+    },
+    "archfeypatron-misty-escape": {
+      "name": "Misty Escape",
+      "description": "When you take damage, you can use your Reaction to cast Misty Step without expending a spell slot. You then have the Invisible condition until the end of your next turn. You can use this feature a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest."
+    },
+    "archfeypatron-beguiling-defenses": {
+      "name": "Beguiling Defenses",
+      "description": "Your patron teaches you how to guard your mind and turn another's charms back on them. You are immune to the Charmed condition. If a creature attempts to Charm you, you can use your Reaction to force the creature to make a Wisdom saving throw against your spell save DC. On a failed save, the creature has the Charmed condition for 1 minute or until it takes any damage."
+    },
+    "celestialpatron-bonus-cantrip": {
+      "name": "Bonus Cantrips",
+      "description": "You know the Light and Sacred Flame cantrips. They count as Warlock cantrips for you, but they don't count against the number of cantrips you know."
+    },
+    "celestialpatron-healing-light": {
+      "name": "Healing Light",
+      "description": "You gain the ability to channel celestial energy to heal wounds. You have a pool of d6s that you spend to fuel this healing. The number of dice in the pool equals 1 + your Warlock level. As a Bonus Action, you can heal one creature you can see within 60 feet by spending dice from the pool. The maximum number of dice you can spend at once equals your Charisma modifier (minimum 1). Roll the spent dice and restore a number of hit points equal to the total. Your pool regains all expended dice when you finish a Long Rest."
+    },
+    "celestialpatron-patron-spells": {
+      "name": "Celestial Patron Spells",
+      "description": "Your Celestial patron grants you access to additional spells that are always prepared and don't count against your Spells Prepared total. (Spell grants modeled as a feature stub — see issue #93.)"
+    },
+    "celestialpatron-radiant-soul": {
+      "name": "Radiant Soul",
+      "description": "Your link to the Celestial allows you to serve as a conduit for radiant energy. You have Resistance to Radiant damage. In addition, when you cast a spell that deals Radiant or Fire damage, you can add your Charisma modifier to one radiant or fire damage roll of that spell against one of its targets."
+    },
+    "celestialpatron-celestial-resilience": {
+      "name": "Celestial Resilience",
+      "description": "You gain the ability to infuse yourself and your allies with the energy of the Upper Planes. When you finish a Short or Long Rest, you gain Temporary Hit Points equal to your Warlock level plus your Charisma modifier. Additionally, choose up to five creatures you can see at the end of the rest. Those creatures each gain Temporary Hit Points equal to half your Warlock level."
+    },
+    "fiendpatron-dark-ones-blessing": {
+      "name": "Dark One's Blessing",
+      "description": "When you reduce a hostile creature to 0 hit points, you gain Temporary Hit Points equal to your Charisma modifier plus your Warlock level (minimum 1)."
+    },
+    "fiendpatron-patron-spells": {
+      "name": "Fiend Patron Spells",
+      "description": "Your Fiend patron grants you access to additional spells that are always prepared and don't count against your Spells Prepared total. (Spell grants modeled as a feature stub — see issue #93.)"
+    },
+    "fiendpatron-dark-ones-own-luck": {
+      "name": "Dark One's Own Luck",
+      "description": "You can call on your patron to alter fate in your favor. When you make an ability check or a saving throw, you can use this feature to add a d10 to your roll. You can do so after seeing the initial roll but before any of the roll's effects occur. You can use this feature a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest. It also replenishes when you finish a Short Rest."
+    },
+    "fiendpatron-fiendish-resilience": {
+      "name": "Fiendish Resilience",
+      "description": "You can choose one damage type when you finish a Short or Long Rest. You gain Resistance to that damage type until you choose a different one with this feature. Damage from magical weapons and silver weapons ignores this resistance."
+    },
+    "greatoldonepatron-awakened-mind": {
+      "name": "Awakened Mind",
+      "description": "Your patron's knowledge invades your very being. You can communicate telepathically with any creature you can see within 30 feet of you. You don't need to share a language with the creature for it to understand your telepathic communications, but the creature must be able to understand at least one language."
+    },
+    "greatoldonepatron-psychic-spells": {
+      "name": "Psychic Spells",
+      "description": "Your Great Old One patron grants you access to additional spells that deal Psychic damage and are always prepared, not counting against your Spells Prepared total. (Spell grants modeled as a feature stub — see issue #93.)"
+    },
+    "greatoldonepatron-clairvoyant-combatant": {
+      "name": "Clairvoyant Combatant",
+      "description": "Your alien patron grants you the ability to read your opponents' minds. When you force a creature within 60 feet of you to make a Wisdom saving throw, you can choose to peer into its mind. On a failed save, for 1 minute your attack rolls against that creature have Advantage and it can't see you. You can use this feature a number of times equal to your Proficiency Bonus, and you regain all expended uses when you finish a Long Rest."
+    },
+    "greatoldonepatron-eldritch-hex": {
+      "name": "Eldritch Hex",
+      "description": "Your patron grants you a powerful hex. As a Bonus Action, you can magically hex one creature you can see within 60 feet. Until the hex ends, whenever that creature deals damage to you, you deal Psychic damage to it equal to your Proficiency Bonus. The hex ends early if you die, or after 24 hours. Once you use this feature, you can't do so again until you finish a Long Rest."
+    },
     "soulknife-psionic-power": {
       "name": "Psionic Power",
       "description": "You have a pool of Psionic Energy dice that fuel your psionic abilities. The die size scales with your proficiency bonus: d6 (PB +2), d8 (PB +3), d10 (PB +4), d12 (PB +5 or +6). You start each Long Rest with 4 dice; a Short Rest replenishes 1. Two options enabled at L3: Psi-Bolstered Knack — when you fail an ability check using a skill or tool you are proficient in, you can roll one Psionic Energy die and add it to the check; if this causes the check to succeed, the die is not expended; Psychic Whispers — as an Action, choose a number of creatures equal to your Proficiency Bonus that you can see within 1 mile; those creatures can communicate telepathically with you in a language you both know for up to 1 hour; this uses 1 Psionic Energy die."


### PR DESCRIPTION
Closes #122. Part of meta-issue #111.

## Summary

- Populates `features` for the 4 Warlock patrons (`archfeypatron`, `celestialpatron`, `fiendpatron`, `greatoldonepatron`) at levels 3, 6, and 10 in `src/lib/sources/subclasses.ts`
- **celestialpatron L3**: `proficiency` (skill: religion)
- **celestialpatron L6**: `resistance` (radiant) + feature for Radiant Soul
- **greatoldonepatron L3**: `proficiency-choice` (skill, 1 of arcana/history/intimidation/nature/religion/survival)
- Adds 17 new feature i18n entries to `src/locales/en/gamedata.json`
- Adds per-subclass behavioral tests

## Rules ambiguities (follow-up issue will be filed)

1. **Patron spell lists (all 4 patrons)** — Tagged `// TODO #93`.
2. **celestialpatron Bonus Cantrips (Light + Sacred Flame)** — Inert feature grant pending spell system.
3. **fiendpatron Fiendish Resilience (L10)** — Inert feature grant; damage type is a per-rest runtime choice.
4. **Use-pool resources** — Healing Light d6 pool, PB-per-long-rest features (Misty Escape, Dark One's Own Luck, Clairvoyant Combatant), Eldritch Hex 1/day — all in description text only.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1488 tests pass (21 new Warlock tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)