### PR TITLE
feat(subclasses): implement Wizard schools through level 10 (#123)

### DIFF
--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -1902,6 +1902,218 @@ describe('getSubclassSource — Great Old One Patron', () => {
   });
 });
 
+describe('getSubclassSource — Abjurer', () => {
+  it('returns defined for abjurer', () => {
+    expect(getSubclassSource('abjurer')).toBeDefined();
+  });
+
+  it('abjurer has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('abjurer');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('abjurer level 3 grants 2 features: abjuration-savant and arcane-ward', () => {
+    const source = getSubclassSource('abjurer');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'abjurer-abjuration-savant' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'abjurer-arcane-ward' }),
+        }),
+      ])
+    );
+  });
+
+  it('abjurer level 6 grants 1 feature: projected-ward', () => {
+    const source = getSubclassSource('abjurer');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'abjurer-projected-ward' },
+    });
+  });
+
+  it('abjurer level 10 grants 1 feature: improved-abjuration', () => {
+    const source = getSubclassSource('abjurer');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'abjurer-improved-abjuration' },
+    });
+  });
+});
+
+describe('getSubclassSource — Diviner', () => {
+  it('returns defined for diviner', () => {
+    expect(getSubclassSource('diviner')).toBeDefined();
+  });
+
+  it('diviner has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('diviner');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('diviner level 3 grants 2 features: divination-savant and portent', () => {
+    const source = getSubclassSource('diviner');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'diviner-divination-savant' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'diviner-portent' }),
+        }),
+      ])
+    );
+  });
+
+  it('diviner level 6 grants 1 feature: expert-divination', () => {
+    const source = getSubclassSource('diviner');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'diviner-expert-divination' },
+    });
+  });
+
+  it('diviner level 10 grants 1 feature: the-third-eye', () => {
+    const source = getSubclassSource('diviner');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'diviner-the-third-eye' },
+    });
+  });
+});
+
+describe('getSubclassSource — Evoker', () => {
+  it('returns defined for evoker', () => {
+    expect(getSubclassSource('evoker')).toBeDefined();
+  });
+
+  it('evoker has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('evoker');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('evoker level 3 grants 2 features: evocation-savant and sculpt-spells', () => {
+    const source = getSubclassSource('evoker');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'evoker-evocation-savant' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'evoker-sculpt-spells' }),
+        }),
+      ])
+    );
+  });
+
+  it('evoker level 6 grants 1 feature: potent-cantrip', () => {
+    const source = getSubclassSource('evoker');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'evoker-potent-cantrip' },
+    });
+  });
+
+  it('evoker level 10 grants 1 feature: empowered-evocation', () => {
+    const source = getSubclassSource('evoker');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'evoker-empowered-evocation' },
+    });
+  });
+});
+
+describe('getSubclassSource — Illusionist', () => {
+  it('returns defined for illusionist', () => {
+    expect(getSubclassSource('illusionist')).toBeDefined();
+  });
+
+  it('illusionist has 3 feature levels (L3, L6, L10)', () => {
+    const source = getSubclassSource('illusionist');
+    expect(source?.features).toHaveLength(3);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
+  });
+
+  it('illusionist level 3 grants 2 features: illusion-savant and improved-illusions', () => {
+    const source = getSubclassSource('illusionist');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'illusionist-illusion-savant' }),
+        }),
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'illusionist-improved-illusions' }),
+        }),
+      ])
+    );
+  });
+
+  it('illusionist level 6 grants 1 feature: phantasmal-creatures', () => {
+    const source = getSubclassSource('illusionist');
+    const level6 = source?.features.find((f) => f.classLevel === 6);
+    expect(level6).toBeDefined();
+    expect(level6?.grants).toHaveLength(1);
+    expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'illusionist-phantasmal-creatures' },
+    });
+  });
+
+  it('illusionist level 10 grants 1 feature: illusory-self', () => {
+    const source = getSubclassSource('illusionist');
+    const level10 = source?.features.find((f) => f.classLevel === 10);
+    expect(level10).toBeDefined();
+    expect(level10?.grants).toHaveLength(1);
+    expect(level10?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'illusionist-illusory-self' },
+    });
+  });
+});
+
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -1018,10 +1018,123 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
     ] satisfies readonly SubclassFeature[],
   },
   // Wizard
-  abjurer: { features: [] },
-  diviner: { features: [] },
-  evoker: { features: [] },
-  illusionist: { features: [] },
+  abjurer: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Abjuration Savant: copy/inscribe Abjuration spells into spellbook at half the usual cost
+          { type: 'feature', feature: { id: 'abjurer-abjuration-savant' } },
+          // Arcane Ward: casting a L1+ Abjuration spell creates or repairs a ward with HP = 2× Wizard level + INT mod;
+          // ward absorbs damage; casting more Abjuration spells (L1+) repairs the ward
+          { type: 'feature', feature: { id: 'abjurer-arcane-ward' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Projected Ward: Reaction — when a creature within 30 ft takes damage, your Arcane Ward absorbs that damage instead
+          { type: 'feature', feature: { id: 'abjurer-projected-ward' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // Improved Abjuration: when you cast Counterspell or Dispel Magic, add your PB to the ability check
+          { type: 'feature', feature: { id: 'abjurer-improved-abjuration' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  diviner: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Divination Savant: copy/inscribe Divination spells into spellbook at half the usual cost
+          { type: 'feature', feature: { id: 'diviner-divination-savant' } },
+          // Portent: after each long rest, roll 2 d20s; replace any attack roll, ability check, or saving throw
+          // you can see with one of these rolls; each pre-rolled die can be used once
+          { type: 'feature', feature: { id: 'diviner-portent' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Expert Divination: when you cast a Divination spell of L2+, regain one expended spell slot of a
+          // level lower than the spell cast (max L5)
+          { type: 'feature', feature: { id: 'diviner-expert-divination' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // The Third Eye: Bonus Action — gain one of: Darkvision 120 ft, Ethereal Sight,
+          // Greater Comprehension, or See Invisibility; lasts until incapacitated or until used again
+          { type: 'feature', feature: { id: 'diviner-the-third-eye' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  evoker: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Evocation Savant: copy/inscribe Evocation spells into spellbook at half the usual cost
+          { type: 'feature', feature: { id: 'evoker-evocation-savant' } },
+          // Sculpt Spells: when you cast an Evocation spell that affects other creatures you can see,
+          // choose up to 1 + spell level allies; chosen creatures automatically succeed their saves and take no damage
+          { type: 'feature', feature: { id: 'evoker-sculpt-spells' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Potent Cantrip: when a creature succeeds on a saving throw against a cantrip you cast,
+          // it takes half damage and any non-damage effects only partially apply
+          { type: 'feature', feature: { id: 'evoker-potent-cantrip' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // Empowered Evocation: add your INT modifier to one damage roll of any Wizard Evocation spell you cast
+          { type: 'feature', feature: { id: 'evoker-empowered-evocation' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
+  illusionist: {
+    features: [
+      {
+        classLevel: 3,
+        grants: [
+          // Illusion Savant: copy/inscribe Illusion spells into spellbook at half the usual cost
+          { type: 'feature', feature: { id: 'illusionist-illusion-savant' } },
+          // Improved Illusions: when you cast an Illusion spell of L1+, you can alter one feature of the
+          // illusion as a Bonus Action
+          { type: 'feature', feature: { id: 'illusionist-improved-illusions' } },
+        ],
+      },
+      {
+        classLevel: 6,
+        grants: [
+          // Phantasmal Creatures: Phantasmal Force and Phantasmal Killer are always prepared and can be cast
+          // at their minimum slot levels without expending a spell slot; uses = PB per long rest
+          { type: 'feature', feature: { id: 'illusionist-phantasmal-creatures' } },
+        ],
+      },
+      {
+        classLevel: 10,
+        grants: [
+          // Illusory Self: Reaction — when a creature makes an attack roll against you, interpose an illusion
+          // that causes the attack to automatically miss; 1 use per short rest
+          { type: 'feature', feature: { id: 'illusionist-illusory-self' } },
+        ],
+      },
+    ] satisfies readonly SubclassFeature[],
+  },
 };
 
 export const isSubclassId = (id: string): id is SubclassId =>

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1654,6 +1654,70 @@
     "wizard-signature-spells": {
       "name": "Signature Spells",
       "description": "You gain mastery over two powerful spells and can cast them with little effort. Choose two 3rd-level wizard spells in your spellbook as your signature spells."
+    },
+    "abjurer-abjuration-savant": {
+      "name": "Abjuration Savant",
+      "description": "The gold and time you must spend to copy an Abjuration spell into your spellbook is halved."
+    },
+    "abjurer-arcane-ward": {
+      "name": "Arcane Ward",
+      "description": "When you cast an Abjuration spell of 1st level or higher, you can simultaneously use a strand of the spell's magic to create a magical ward on yourself that lasts until you finish a Long Rest. The ward has a Hit Point maximum equal to twice your Wizard level plus your Intelligence modifier. When you take damage, the ward takes the damage instead. If this damage reduces the ward to 0 Hit Points, you take any remaining damage. When you cast an Abjuration spell of 1st level or higher while the ward is active, the ward regains Hit Points equal to twice the level of the spell slot used."
+    },
+    "abjurer-projected-ward": {
+      "name": "Projected Ward",
+      "description": "When a creature that you can see within 30 feet of you takes damage, you can use your Reaction to cause your Arcane Ward to absorb that damage. If this damage reduces the ward to 0 Hit Points, the warded creature takes any remaining damage."
+    },
+    "abjurer-improved-abjuration": {
+      "name": "Improved Abjuration",
+      "description": "When you cast Counterspell or Dispel Magic, you can add your Proficiency Bonus to the ability check made as part of casting those spells."
+    },
+    "diviner-divination-savant": {
+      "name": "Divination Savant",
+      "description": "The gold and time you must spend to copy a Divination spell into your spellbook is halved."
+    },
+    "diviner-portent": {
+      "name": "Portent",
+      "description": "Glimpses of the future begin to press in on your awareness. When you finish a Long Rest, roll two d20s and record the numbers rolled. You can replace any attack roll, ability check, or saving throw made by you or a creature that you can see with one of these foretelling rolls. You must choose to do so before the roll, and you can replace a roll in this way only once per turn. Each foretelling roll can be used only once. When you finish a Long Rest, you lose any unused foretelling rolls."
+    },
+    "diviner-expert-divination": {
+      "name": "Expert Divination",
+      "description": "Casting Divination spells comes so easily to you that it expends only a fraction of your spellcasting efforts. When you cast a Divination spell using a spell slot of 2nd level or higher, you regain one expended spell slot. The slot you regain must be of a level lower than the spell you cast and can't be higher than 5th level."
+    },
+    "diviner-the-third-eye": {
+      "name": "The Third Eye",
+      "description": "You can use a Bonus Action to increase your powers of perception. When you do so, choose one of the following benefits, which lasts until you are Incapacitated or until you use this feature again: Darkvision (60 ft. extended to 120 ft.), Ethereal Sight (see into the Ethereal Plane up to 60 ft.), Greater Comprehension (read any language), or See Invisibility (see Invisible creatures and objects within 10 ft.)."
+    },
+    "evoker-evocation-savant": {
+      "name": "Evocation Savant",
+      "description": "The gold and time you must spend to copy an Evocation spell into your spellbook is halved."
+    },
+    "evoker-sculpt-spells": {
+      "name": "Sculpt Spells",
+      "description": "You can create pockets of relative safety within the effects of your Evocation spells. When you cast an Evocation spell that affects other creatures that you can see, you can choose a number of them equal to 1 plus the spell's level. The chosen creatures automatically succeed on their saving throws against the spell, and they take no damage if they would normally take half damage on a successful save."
+    },
+    "evoker-potent-cantrip": {
+      "name": "Potent Cantrip",
+      "description": "Your damaging cantrips affect even creatures that avoid the brunt of the effect. When a creature succeeds on a saving throw against a cantrip you cast that deals damage, the creature takes half the cantrip's damage (if any) but suffers no additional effects from the cantrip."
+    },
+    "evoker-empowered-evocation": {
+      "name": "Empowered Evocation",
+      "description": "Whenever you cast a Wizard spell from the Evocation school, you can add your Intelligence modifier to one damage roll of that spell."
+    },
+    "illusionist-illusion-savant": {
+      "name": "Illusion Savant",
+      "description": "The gold and time you must spend to copy an Illusion spell into your spellbook is halved."
+    },
+    "illusionist-improved-illusions": {
+      "name": "Improved Illusions",
+      "description": "When you cast an Illusion spell of 1st level or higher, you can alter one of the illusion's sensory elements as a Bonus Action on your turn, even while concentrating on the spell."
+    },
+    "illusionist-phantasmal-creatures": {
+      "name": "Phantasmal Creatures",
+      "description": "You can cast Phantasmal Force and Phantasmal Killer without expending a spell slot. When you cast these spells in this way, you cast them at their lowest possible levels. Once you cast either spell in this way, you can't do so again until you finish a Long Rest, unless you expend a spell slot to cast it. You can use each spell a number of times equal to your Proficiency Bonus before you must use a spell slot."
+    },
+    "illusionist-illusory-self": {
+      "name": "Illusory Self",
+      "description": "When a creature makes an attack roll against you, you can use your Reaction to interpose an illusory duplicate of yourself between the attacker and yourself. The attack automatically misses you, then the illusion dissipates. Once you use this feature, you can't use it again until you finish a Short or Long Rest."
     }
   },
   "subclasses": {


### PR DESCRIPTION
Closes #123. Final child of meta-issue #111 — completes PHB-2024 subclass migration through level 10 across all 12 classes.

## Summary

- Populates `features` for the 4 Wizard schools (`abjurer`, `diviner`, `evoker`, `illusionist`) at levels 3, 6, and 10 in `src/lib/sources/subclasses.ts`
- All features modeled as `feature` grants
- L3 per school: Savant + the school-defining feature (Arcane Ward / Portent / Sculpt Spells / Improved Illusions)
- Adds 16 new feature i18n entries to `src/locales/en/gamedata.json`
- Adds per-school behavioral tests

## Rules ambiguities (follow-up issue will be filed)

1. **Savant features (all 4 schools)** — Spellbook cost halving has no grant type; pure `feature` grants.
2. **Spell-system-dependent mechanics**:
   - diviner Expert Divination (L6) slot-regain on Divination cast
   - illusionist Phantasmal Creatures (L6) always-prepared Phantasmal Force + Phantasmal Killer with PB-per-long-rest free uses
3. **Per-rest use counts** — Portent 2/long, Phantasmal Creatures PB/long, Illusory Self 1/short — all in description text.
4. **Runtime conditional effects** — Diviner The Third Eye (Bonus Action choice), Illusionist Illusory Self (Reaction attack miss), Evoker Potent Cantrip (save-half on cantrips) — all in description text.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1508 tests pass (20 new Wizard tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)