### PR TITLE
feat(grants): add DamageTypeChoiceGrant; wire Zealot Divine Fury (#138)

### DIFF
--- a/src/components/character-sheet/DamageTypePicker.tsx
+++ b/src/components/character-sheet/DamageTypePicker.tsx
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import type { PendingChoice } from '@/types/resolved';
+import type { ChoiceKey, ChoiceDecision } from '@/types/choices';
+import type { DamageTypeId } from '@/types/grants';
+import { useTranslation } from 'react-i18next';
+
+interface DamageTypePickerProps {
+  readonly choice: Extract<PendingChoice, { type: 'damage-choice' }>;
+  readonly currentDecision?: ChoiceDecision | undefined;
+  readonly onDecide: (choiceKey: ChoiceKey, decision: ChoiceDecision) => void;
+  readonly onClear?: (key: ChoiceKey) => void;
+}
+
+export function DamageTypePicker({ choice, currentDecision, onDecide, onClear }: DamageTypePickerProps) {
+  const { t } = useTranslation('gamedata');
+  const { t: tc } = useTranslation('common');
+
+  const existingTypeId = currentDecision?.type === 'damage-choice' ? (currentDecision.damageTypes[0] ?? null) : null;
+  const [selected, setSelected] = useState<DamageTypeId | null>(existingTypeId);
+  const hasExistingDecision = existingTypeId !== null;
+
+  const handleConfirm = () => {
+    if (!selected) return;
+    onDecide(choice.choiceKey, { type: 'damage-choice', damageTypes: [selected] });
+  };
+
+  const handleClear = () => {
+    setSelected(null);
+    onClear?.(choice.choiceKey);
+  };
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>{tc('characterSheet.damageTypePicker.title')}</CardTitle>
+        <p className="text-sm text-muted-foreground">{tc('characterSheet.damageTypePicker.description')}</p>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        {choice.from.map((damageType) => {
+          const isSelected = selected === damageType;
+          const featureId = `${choice.featureIdPrefix}-${damageType}`;
+          const featureName = t(`features.${featureId}.name`, { defaultValue: '' });
+          const featureDescription = t(`features.${featureId}.description`, { defaultValue: '' });
+          return (
+            <button
+              key={damageType}
+              type="button"
+              onClick={() => setSelected(damageType)}
+              className={`w-full rounded-lg border p-4 text-left transition-colors hover:bg-muted/50 ${
+                isSelected ? 'border-primary bg-primary/5' : 'border-border bg-muted/20'
+              }`}
+            >
+              <div className={`text-sm text-foreground ${isSelected ? 'font-semibold' : ''}`}>
+                {featureName || t(`damageTypes.${damageType}`)}
+              </div>
+              {featureDescription && <p className="text-xs text-muted-foreground mt-1">{featureDescription}</p>}
+            </button>
+          );
+        })}
+
+        <div className="flex gap-2 mt-4">
+          {hasExistingDecision && (
+            <Button variant="ghost" size="sm" onClick={handleClear} className="flex-1">
+              {tc('buttons.clearSelection')}
+            </Button>
+          )}
+          <Button className="flex-1" disabled={!selected} onClick={handleConfirm}>
+            {tc('buttons.confirm')}
+          </Button>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/components/character-sheet/LevelUpDialog.tsx
+++ b/src/components/character-sheet/LevelUpDialog.tsx
@@ -1,5 +1,6 @@
 import { AsiAllocator } from '@/components/character-sheet/AsiAllocator';
 import { FightingStylePicker } from '@/components/character-sheet/FightingStylePicker';
+import { DamageTypePicker } from '@/components/character-sheet/DamageTypePicker';
 import { SubclassPicker } from '@/components/character-sheet/SubclassPicker';
 import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
@@ -7,7 +8,13 @@ import { RollingNumber } from '@/components/ui/rolling-number';
 import type { ClassId } from '@/lib/dnd-helpers';
 import { getGrantsForLevel } from '@/lib/sources/level-grants';
 import type { ChoiceDecision, ChoiceKey } from '@/types/choices';
-import type { AsiGrant, FeatureGrant, FightingStyleChoiceGrant, SubclassGrant } from '@/types/grants';
+import type {
+  AsiGrant,
+  DamageTypeChoiceGrant,
+  FeatureGrant,
+  FightingStyleChoiceGrant,
+  SubclassGrant,
+} from '@/types/grants';
 import type { PendingChoice, ResolvedCharacter } from '@/types/resolved';
 import type { SubclassId } from '@/types/sources';
 import type { FightingStyleId } from '@/lib/dnd-helpers';
@@ -89,6 +96,11 @@ export function LevelUpDialog({
     return allGrants.filter((g): g is FightingStyleChoiceGrant => g.type === 'fighting-style-choice');
   }, [preview]);
 
+  const damageChoiceGrants = useMemo(() => {
+    const allGrants = [...preview.classGrants, ...preview.subclassGrants];
+    return allGrants.filter((g): g is DamageTypeChoiceGrant => g.type === 'damage-choice');
+  }, [preview]);
+
   // Check if all required choices are made
   const allChoicesMade = useMemo(() => {
     for (const grant of asiGrants) {
@@ -105,8 +117,12 @@ export function LevelUpDialog({
       const decision = decisions.get(grant.key);
       if (!decision || decision.type !== 'fighting-style-choice' || decision.styles.length < grant.count) return false;
     }
+    for (const grant of damageChoiceGrants) {
+      const decision = decisions.get(grant.key);
+      if (!decision || decision.type !== 'damage-choice' || decision.damageTypes.length < grant.count) return false;
+    }
     return true;
-  }, [asiGrants, subclassGrants, fightingStyleGrants, decisions]);
+  }, [asiGrants, subclassGrants, fightingStyleGrants, damageChoiceGrants, decisions]);
 
   const canConfirm = hpSelection !== null && allChoicesMade;
 
@@ -288,6 +304,30 @@ export function LevelUpDialog({
                 from: grant.from,
                 alreadyChosen: alreadyChosenStyles,
               } satisfies Extract<PendingChoice, { type: 'fighting-style-choice' }>
+            }
+            onDecide={(choiceKey, decision) => {
+              setDecisions((prev) => {
+                const next = new Map(prev);
+                next.set(choiceKey, decision);
+                return next;
+              });
+            }}
+          />
+        ))}
+
+        {/* Damage-type choice */}
+        {damageChoiceGrants.map((grant) => (
+          <DamageTypePicker
+            key={grant.key}
+            choice={
+              {
+                type: 'damage-choice',
+                choiceKey: grant.key,
+                source: { origin: 'class', id: classId, level: targetLevel },
+                count: grant.count,
+                from: grant.from,
+                featureIdPrefix: grant.featureIdPrefix,
+              } satisfies Extract<PendingChoice, { type: 'damage-choice' }>
             }
             onDecide={(choiceKey, decision) => {
               setDecisions((prev) => {

--- a/src/components/character-sheet/PendingChoicesPanel.tsx
+++ b/src/components/character-sheet/PendingChoicesPanel.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { AsiAllocator } from '@/components/character-sheet/AsiAllocator';
 import { ExpertiseChoicePicker } from '@/components/character-sheet/ExpertiseChoicePicker';
 import { FightingStylePicker } from '@/components/character-sheet/FightingStylePicker';
+import { DamageTypePicker } from '@/components/character-sheet/DamageTypePicker';
 import { SubclassPicker } from '@/components/character-sheet/SubclassPicker';
 import { ChoicePicker } from '@/components/character-builder/ChoicePicker';
 import { useCharacterContext } from '@/hooks/useCharacterContext';
@@ -93,6 +94,18 @@ function useAllChoiceGrants() {
         });
         for (const id of validWeaponIds) claimed.add(id);
       }
+    }
+
+    // damage-choice grants
+    for (const { grant, source } of collectGrantsByType(bundles, 'damage-choice')) {
+      allGrants.push({
+        type: 'damage-choice',
+        choiceKey: grant.key,
+        source,
+        count: grant.count,
+        from: grant.from,
+        featureIdPrefix: grant.featureIdPrefix,
+      });
     }
 
     // subclass grants
@@ -215,6 +228,10 @@ function PendingChoiceRow({
     return (
       <FightingStylePicker choice={choice} currentDecision={currentDecision} onDecide={onDecide} onClear={onClear} />
     );
+  }
+
+  if (choice.type === 'damage-choice') {
+    return <DamageTypePicker choice={choice} currentDecision={currentDecision} onDecide={onDecide} onClear={onClear} />;
   }
 
   if (choice.type === 'asi') {

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -1907,3 +1907,49 @@ describe('Weapon mastery resolver', () => {
     expect(weaponIds).toContain('shortsword');
   });
 });
+
+describe('Damage-type choice resolver', () => {
+  const damageKey = createChoiceKey('damage-choice', 'class', 'barbarian', 0);
+  const bundles: readonly GrantBundle[] = [
+    {
+      source: { origin: 'subclass', id: 'zealot' as SubclassId, classId: 'barbarian' as ClassId, level: 3 },
+      grants: [
+        {
+          type: 'damage-choice',
+          key: damageKey,
+          count: 1,
+          from: ['radiant', 'necrotic'],
+          featureIdPrefix: 'zealot-divine-fury',
+        },
+      ],
+    },
+  ];
+
+  it('emits a pending damage-choice when no decision is recorded', () => {
+    const result = resolveCharacter({ ...baseInput, bundles });
+    const pending = result.pendingChoices.filter((c) => c.type === 'damage-choice');
+    expect(pending).toHaveLength(1);
+    expect(pending[0]).toMatchObject({
+      choiceKey: damageKey,
+      count: 1,
+      from: ['radiant', 'necrotic'],
+      featureIdPrefix: 'zealot-divine-fury',
+    });
+  });
+
+  it('clears the pending damage-choice when a valid decision is recorded', () => {
+    const decision: ChoiceDecision = { type: 'damage-choice', damageTypes: ['radiant'] };
+    const choices: Record<ChoiceKey, ChoiceDecision> = { [damageKey]: decision };
+    const result = resolveCharacter({ ...baseInput, bundles, choices });
+    const pending = result.pendingChoices.filter((c) => c.type === 'damage-choice');
+    expect(pending).toHaveLength(0);
+  });
+
+  it('re-emits the pending damage-choice when the recorded decision is outside grant.from', () => {
+    const decision: ChoiceDecision = { type: 'damage-choice', damageTypes: ['fire'] };
+    const choices: Record<ChoiceKey, ChoiceDecision> = { [damageKey]: decision };
+    const result = resolveCharacter({ ...baseInput, bundles, choices });
+    const pending = result.pendingChoices.filter((c) => c.type === 'damage-choice');
+    expect(pending).toHaveLength(1);
+  });
+});

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -204,6 +204,23 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
     }
   }
 
+  // Unresolved or invalid damage-choice grants
+  for (const { grant, source } of collectGrantsByType(bundles, 'damage-choice')) {
+    const decision = choices[grant.key];
+    const validTypes =
+      decision?.type === 'damage-choice' ? decision.damageTypes.filter((t) => grant.from.includes(t)) : [];
+    if (!decision || decision.type !== 'damage-choice' || validTypes.length < grant.count) {
+      pendingChoices.push({
+        type: 'damage-choice',
+        choiceKey: grant.key,
+        source,
+        count: grant.count,
+        from: grant.from,
+        featureIdPrefix: grant.featureIdPrefix,
+      });
+    }
+  }
+
   // Aggregate weapon mastery choices — eligible weapons are those the character is proficient with that have a mastery
   const weaponProfSet = new Set(proficiencies.weapon.map((p) => p.value));
   const eligibleMasteryWeapons = WEAPON_CATALOG.filter(

--- a/src/lib/schemas/character-build.test.ts
+++ b/src/lib/schemas/character-build.test.ts
@@ -201,6 +201,21 @@ describe('ChoiceDecisionSchema', () => {
     });
   });
 
+  describe('damage-choice', () => {
+    it('accepts valid damage-choice', () => {
+      const result = ChoiceDecisionSchema.safeParse({
+        type: 'damage-choice',
+        damageTypes: ['radiant'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing damageTypes field', () => {
+      const result = ChoiceDecisionSchema.safeParse({ type: 'damage-choice' });
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe('lineage-choice', () => {
     it('accepts a lineage-choice decision', () => {
       const result = ChoiceDecisionSchema.safeParse({ type: 'lineage-choice', lineageId: 'high' });

--- a/src/lib/schemas/character-build.ts
+++ b/src/lib/schemas/character-build.ts
@@ -43,6 +43,7 @@ export const ChoiceDecisionSchema = z.discriminatedUnion('type', [
     type: z.literal('weapon-mastery-choice'),
     weaponIds: z.array(z.string()).readonly(),
   }),
+  z.object({ type: z.literal('damage-choice'), damageTypes: z.array(z.string()).readonly() }),
   z.object({
     type: z.literal('bundle-choice'),
     bundleId: z.string().min(1),

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -298,4 +298,87 @@ describe('collectBundles', () => {
       mockFeatSources.value = null;
     }
   });
+
+  it('damage-choice: expands chosen damage type into a feature grant with id `${prefix}-${type}`', () => {
+    const subclassKey = createChoiceKey('subclass', 'class', 'barbarian', 0);
+    const damageKey = createChoiceKey('damage-choice', 'class', 'barbarian', 0);
+    const zealotL3Build: CharacterBuild = {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'soldier' as BackgroundId,
+      baseAbilities: { str: 15, dex: 13, con: 14, int: 8, wis: 12, cha: 10 },
+      abilityMethod: 'standard-array',
+      levels: [
+        { classId: 'barbarian' as ClassId, classLevel: 1, hpRoll: null },
+        { classId: 'barbarian' as ClassId, classLevel: 2, hpRoll: 7 },
+        { classId: 'barbarian' as ClassId, classLevel: 3, hpRoll: 7 },
+      ],
+      choices: {
+        [subclassKey]: { type: 'subclass' as const, subclassId: 'zealot' as SubclassId },
+        [damageKey]: { type: 'damage-choice' as const, damageTypes: ['radiant'] as const },
+      },
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(zealotL3Build);
+    const expandedFeature = bundles
+      .flatMap((b) => b.grants)
+      .find((g) => g.type === 'feature' && g.feature.id === 'zealot-divine-fury-radiant');
+    expect(expandedFeature).toBeDefined();
+  });
+
+  it('damage-choice: emits no expansion when the decision is missing', () => {
+    const subclassKey = createChoiceKey('subclass', 'class', 'barbarian', 0);
+    const zealotL3BuildNoDecision: CharacterBuild = {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'soldier' as BackgroundId,
+      baseAbilities: { str: 15, dex: 13, con: 14, int: 8, wis: 12, cha: 10 },
+      abilityMethod: 'standard-array',
+      levels: [
+        { classId: 'barbarian' as ClassId, classLevel: 1, hpRoll: null },
+        { classId: 'barbarian' as ClassId, classLevel: 2, hpRoll: 7 },
+        { classId: 'barbarian' as ClassId, classLevel: 3, hpRoll: 7 },
+      ],
+      choices: {
+        [subclassKey]: { type: 'subclass' as const, subclassId: 'zealot' as SubclassId },
+      },
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(zealotL3BuildNoDecision);
+    const radiantFeature = bundles
+      .flatMap((b) => b.grants)
+      .find((g) => g.type === 'feature' && g.feature.id === 'zealot-divine-fury-radiant');
+    const necroticFeature = bundles
+      .flatMap((b) => b.grants)
+      .find((g) => g.type === 'feature' && g.feature.id === 'zealot-divine-fury-necrotic');
+    expect(radiantFeature).toBeUndefined();
+    expect(necroticFeature).toBeUndefined();
+  });
+
+  it('damage-choice: ignores decisions for damage types outside the grant.from list', () => {
+    const subclassKey = createChoiceKey('subclass', 'class', 'barbarian', 0);
+    const damageKey = createChoiceKey('damage-choice', 'class', 'barbarian', 0);
+    const zealotL3BuildInvalid: CharacterBuild = {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'soldier' as BackgroundId,
+      baseAbilities: { str: 15, dex: 13, con: 14, int: 8, wis: 12, cha: 10 },
+      abilityMethod: 'standard-array',
+      levels: [
+        { classId: 'barbarian' as ClassId, classLevel: 1, hpRoll: null },
+        { classId: 'barbarian' as ClassId, classLevel: 2, hpRoll: 7 },
+        { classId: 'barbarian' as ClassId, classLevel: 3, hpRoll: 7 },
+      ],
+      choices: {
+        [subclassKey]: { type: 'subclass' as const, subclassId: 'zealot' as SubclassId },
+        [damageKey]: { type: 'damage-choice' as const, damageTypes: ['fire'] as const },
+      },
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(zealotL3BuildInvalid);
+    const fireFeature = bundles
+      .flatMap((b) => b.grants)
+      .find((g) => g.type === 'feature' && g.feature.id === 'zealot-divine-fury-fire');
+    expect(fireFeature).toBeUndefined();
+  });
 });

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -13,7 +13,12 @@ import type {
   SourceTag,
 } from '@/types/sources';
 import type { SubclassId } from '@/lib/sources/subclasses';
-import type { SubclassGrant, FightingStyleChoiceGrant, LineageChoiceGrant } from '@/types/grants';
+import type {
+  SubclassGrant,
+  FightingStyleChoiceGrant,
+  LineageChoiceGrant,
+  DamageTypeChoiceGrant,
+} from '@/types/grants';
 import type { CharacterBuild } from '@/types/choices';
 import { SPECIES_SOURCES, LINEAGE_GRANTS_REGISTRY } from '@/lib/sources/species';
 import { CLASS_SOURCES } from '@/lib/sources/classes';
@@ -182,6 +187,30 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
           warnings.push(msg);
           logger.warn(msg);
         }
+      }
+    }
+  }
+
+  // Damage-type choices — expand chosen damage type into a feature grant whose id
+  // is `${featureIdPrefix}-${chosenDamageType}` (e.g. zealot-divine-fury-radiant).
+  const allDamageChoiceGrants: { grant: DamageTypeChoiceGrant; source: SourceTag }[] = [];
+  for (const bundle of bundles) {
+    for (const grant of bundle.grants) {
+      if (grant.type === 'damage-choice') {
+        allDamageChoiceGrants.push({ grant: grant as DamageTypeChoiceGrant, source: bundle.source });
+      }
+    }
+  }
+
+  for (const { grant, source } of allDamageChoiceGrants) {
+    const decision = build.choices[grant.key];
+    if (decision?.type === 'damage-choice') {
+      for (const damageType of decision.damageTypes) {
+        if (!grant.from.includes(damageType)) continue;
+        bundles.push({
+          source,
+          grants: [{ type: 'feature', feature: { id: `${grant.featureIdPrefix}-${damageType}` } }],
+        });
       }
     }
   }

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -247,7 +247,7 @@ describe('getSubclassSource — Zealot', () => {
     expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
   });
 
-  it('zealot level 3 grants 2 features: divine-fury and warrior-of-the-gods', () => {
+  it('zealot level 3 grants a damage-choice for Divine Fury and the Warrior of the Gods feature', () => {
     const source = getSubclassSource('zealot');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
@@ -255,8 +255,10 @@ describe('getSubclassSource — Zealot', () => {
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          type: 'feature',
-          feature: expect.objectContaining({ id: 'zealot-divine-fury' }),
+          type: 'damage-choice',
+          count: 1,
+          from: ['radiant', 'necrotic'],
+          featureIdPrefix: 'zealot-divine-fury',
         }),
         expect.objectContaining({
           type: 'feature',

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -91,8 +91,13 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 3,
         grants: [
-          // Damage type (radiant vs necrotic) chosen at L3 selection; collapsed to inert feature grant
-          { type: 'feature', feature: { id: 'zealot-divine-fury' } },
+          {
+            type: 'damage-choice',
+            key: createChoiceKey('damage-choice', 'class', 'barbarian', 0),
+            count: 1,
+            from: ['radiant', 'necrotic'],
+            featureIdPrefix: 'zealot-divine-fury',
+          },
           { type: 'feature', feature: { id: 'zealot-warrior-of-the-gods' } },
         ],
       },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -154,6 +154,7 @@
       "expertiseChoice": "Choose {{count}} expertise",
       "fightingStyleChoice": "Choose {{count}} fighting style(s)",
       "weaponMasteryChoice": "Choose {{count}} weapon mastery",
+      "damageChoice": "Choose {{count}} damage type(s)",
       "lineageChoice": "Choose your lineage",
       "unsupported": "Choice not yet supported: {{type}}",
       "remaining": "remaining",
@@ -496,6 +497,10 @@
     "fightingStylePicker": {
       "title": "Choose a Fighting Style",
       "description": "Select a fighting style to specialize in."
+    },
+    "damageTypePicker": {
+      "title": "Choose a Damage Type",
+      "description": "This choice is permanent for the character."
     },
     "warnings": {
       "buildIncomplete": "Some source data is missing — character may be incomplete: {{message}}"

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -651,9 +651,13 @@
       "name": "Battering Roots",
       "description": "Your reach increases by 10 feet for melee weapon attacks. When you hit a creature with a melee weapon attack while raging, you can knock the target Prone, push it up to 15 feet away from you, or grapple it."
     },
-    "zealot-divine-fury": {
-      "name": "Divine Fury",
-      "description": "While raging, the first creature you hit on each of your turns takes an extra 1d6 + half your Barbarian level (rounded down) radiant or necrotic damage (your choice when you first gain this feature)."
+    "zealot-divine-fury-radiant": {
+      "name": "Divine Fury (Radiant)",
+      "description": "While raging, the first creature you hit on each of your turns takes an extra 1d6 + half your Barbarian level (rounded down) radiant damage."
+    },
+    "zealot-divine-fury-necrotic": {
+      "name": "Divine Fury (Necrotic)",
+      "description": "While raging, the first creature you hit on each of your turns takes an extra 1d6 + half your Barbarian level (rounded down) necrotic damage."
     },
     "zealot-warrior-of-the-gods": {
       "name": "Warrior of the Gods",

--- a/src/types/choices.ts
+++ b/src/types/choices.ts
@@ -11,6 +11,7 @@ import type {
 } from '@/lib/dnd-helpers';
 import type { SubclassId } from '@/types/sources';
 import type { AbilityScores } from '@/types/database';
+import type { DamageTypeId } from '@/types/grants';
 
 /**
  * Choice key format: `category:origin:id:index`
@@ -31,6 +32,7 @@ const CHOICE_CATEGORIES = [
   'subclass',
   'fighting-style-choice',
   'weapon-mastery-choice',
+  'damage-choice',
   'bundle-choice',
   'lineage-choice',
 ] as const;
@@ -91,6 +93,7 @@ export type ChoiceDecision =
   | { readonly type: 'subclass'; readonly subclassId: SubclassId }
   | { readonly type: 'fighting-style-choice'; readonly styles: readonly FightingStyleId[] }
   | { readonly type: 'weapon-mastery-choice'; readonly weaponIds: readonly string[] }
+  | { readonly type: 'damage-choice'; readonly damageTypes: readonly DamageTypeId[] }
   | {
       readonly type: 'bundle-choice';
       readonly bundleId: string;

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -219,6 +219,19 @@ export interface WeaponMasteryChoiceGrant {
   readonly count: number;
 }
 
+export interface DamageTypeChoiceGrant {
+  readonly type: 'damage-choice';
+  readonly key: ChoiceKey;
+  readonly count: number;
+  readonly from: readonly DamageTypeId[];
+  /**
+   * When a decision is recorded, the chosen damage type expands into a feature grant
+   * with id `${featureIdPrefix}-${chosenDamageType}`. One i18n entry must exist per
+   * variant (e.g. `zealot-divine-fury-radiant`, `zealot-divine-fury-necrotic`).
+   */
+  readonly featureIdPrefix: string;
+}
+
 export interface BundleChoiceGrant {
   readonly type: 'bundle-choice';
   readonly key: ChoiceKey;
@@ -254,6 +267,7 @@ export type Grant =
   | AbilityCheckBonusGrant
   | FightingStyleChoiceGrant
   | WeaponMasteryChoiceGrant
+  | DamageTypeChoiceGrant
   | EquipmentGrant
   | BundleChoiceGrant
   | LineageChoiceGrant

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -178,6 +178,14 @@ export type PendingChoice =
       readonly alreadyChosen: readonly string[];
     }
   | {
+      readonly type: 'damage-choice';
+      readonly choiceKey: ChoiceKey;
+      readonly source: SourceTag;
+      readonly count: number;
+      readonly from: readonly DamageTypeId[];
+      readonly featureIdPrefix: string;
+    }
+  | {
       readonly type: 'bundle-choice';
       readonly choiceKey: ChoiceKey;
       readonly source: SourceTag;


### PR DESCRIPTION
## Summary
- Adds a `DamageTypeChoiceGrant` variant mirroring `fighting-style-choice` — the player picks a damage type at level-up; resolver expands the choice into a feature grant with id `${featureIdPrefix}-${chosenDamageType}`.
- Wires Zealot's L3 Divine Fury to the new grant, splitting the i18n entry into `-radiant` / `-necrotic` variants.
- New `DamageTypePicker` component, integrated in `PendingChoicesPanel` (character sheet) and `LevelUpDialog` (level-up).

## Scope
This PR addresses **Gap 4** from #138 only. The other gaps:
- **Gap 3 (Wildheart ritual spells):** turned out to need more than a `SpellGrant`. `resolveSpellcasting` returns `null` when no `SpellcastingGrant` is present, and nothing in the UI renders `alwaysPreparedSpells` (only `cantrips`). Filed as a separate follow-up.
- **Gaps 1 + 2 (Wild Heart Beast Spirit / Aspect):** confirmed deferrable — these are session/gameplay state, not character-sheet state.

## UX note for reviewers
The LevelUpDialog's "Features gained" section at Zealot L3 shows only "Warrior of the Gods" — not "Divine Fury" — because the Divine Fury feature is materialized **post-decision** via the expansion in `sources/index.ts`. The new `DamageTypePicker` compensates by previewing each variant's description inline (so the player sees what Divine Fury does while choosing the damage type).

## Test plan
- [x] `npm run typecheck` — clean
- [x] `npm run lint` — 0 warnings
- [x] `npm run test` — 1516 tests pass (8 new)
  - New: damage-choice schema validation, resolver pending-choice (3 cases), `sources/index.ts` expansion (3 cases), zealot L3 grant shape
- [x] Manual: open the character sheet for a barbarian about to advance to L3, pick Zealot, confirm the damage-type picker appears in the level-up dialog and the chosen variant ("Divine Fury (Radiant)" or "Divine Fury (Necrotic)") shows on the resolved character sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)