### PR TITLE
[5.5e] walk-equivalent SpeedGrant + Druid/Thief/Ranger 2024 PHB fixes

### DIFF
--- a/src/lib/resolver/combat.test.ts
+++ b/src/lib/resolver/combat.test.ts
@@ -120,6 +120,81 @@ describe('resolveSpeed', () => {
     expect(result.walk!.value).toBe(30);
     expect(result.swim!.value).toBe(30);
   });
+
+  it('resolves walk-equivalent swim to the walk speed (human druid, 30 ft)', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'species', id: 'human' },
+        grants: [{ type: 'speed', mode: 'walk', value: 30 }],
+      },
+      {
+        source: { origin: 'subclass', id: 'circlesea', classId: 'druid', level: 6 },
+        grants: [{ type: 'speed', mode: 'swim', value: 'walk-equivalent' }],
+      },
+    ];
+    const result = resolveSpeed(bundles);
+    expect(result.swim!.value).toBe(30);
+  });
+
+  it('resolves walk-equivalent swim to a faster walk speed (wood elf druid, 35 ft)', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'species', id: 'elf' },
+        grants: [{ type: 'speed', mode: 'walk', value: 35 }],
+      },
+      {
+        source: { origin: 'subclass', id: 'circlesea', classId: 'druid', level: 6 },
+        grants: [{ type: 'speed', mode: 'swim', value: 'walk-equivalent' }],
+      },
+    ];
+    const result = resolveSpeed(bundles);
+    expect(result.swim!.value).toBe(35);
+  });
+
+  it('walk-equivalent never lowers an existing higher fixed swim speed', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'species', id: 'human' },
+        grants: [{ type: 'speed', mode: 'walk', value: 30 }],
+      },
+      {
+        source: { origin: 'item', id: 'cap-of-water-breathing' },
+        grants: [{ type: 'speed', mode: 'swim', value: 40 }],
+      },
+      {
+        source: { origin: 'subclass', id: 'circlesea', classId: 'druid', level: 6 },
+        grants: [{ type: 'speed', mode: 'swim', value: 'walk-equivalent' }],
+      },
+    ];
+    const result = resolveSpeed(bundles);
+    expect(result.swim!.value).toBe(40);
+  });
+
+  it('walk-equivalent is dropped silently when no walk grant exists', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'subclass', id: 'circlesea', classId: 'druid', level: 6 },
+        grants: [{ type: 'speed', mode: 'swim', value: 'walk-equivalent' }],
+      },
+    ];
+    const result = resolveSpeed(bundles);
+    expect(result.swim).toBeUndefined();
+  });
+
+  it('records the walk-equivalent grant source on the resolved swim speed', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'species', id: 'human' },
+        grants: [{ type: 'speed', mode: 'walk', value: 30 }],
+      },
+      {
+        source: { origin: 'subclass', id: 'circlesea', classId: 'druid', level: 6 },
+        grants: [{ type: 'speed', mode: 'swim', value: 'walk-equivalent' }],
+      },
+    ];
+    const result = resolveSpeed(bundles);
+    expect(result.swim!.sources).toEqual([{ origin: 'subclass', id: 'circlesea', classId: 'druid', level: 6 }]);
+  });
 });
 
 describe('resolveAc', () => {

--- a/src/lib/resolver/combat.ts
+++ b/src/lib/resolver/combat.ts
@@ -36,10 +36,22 @@ export function resolveHp(
 export function resolveSpeed(bundles: readonly GrantBundle[]): Readonly<Partial<Record<SpeedMode, Sourced<number>>>> {
   const speedGrants = collectGrantsByType(bundles, 'speed');
 
-  // Group by mode, taking highest value per mode
+  // First pass: resolve all fixed-value grants, taking the highest per mode.
+  // 'walk-equivalent' grants are deferred to a second pass once the walk
+  // speed is known.
   const bestPerMode = new Map<SpeedMode, { value: number; sources: SourceTag[] }>();
+  const walkEquivalent = new Map<SpeedMode, SourceTag[]>();
 
   for (const { grant, source } of speedGrants) {
+    if (grant.value === 'walk-equivalent') {
+      const existing = walkEquivalent.get(grant.mode);
+      if (existing) {
+        existing.push(source);
+      } else {
+        walkEquivalent.set(grant.mode, [source]);
+      }
+      continue;
+    }
     const existing = bestPerMode.get(grant.mode);
     if (!existing) {
       bestPerMode.set(grant.mode, { value: grant.value, sources: [source] });
@@ -47,6 +59,24 @@ export function resolveSpeed(bundles: readonly GrantBundle[]): Readonly<Partial<
       bestPerMode.set(grant.mode, { value: grant.value, sources: [source] });
     } else if (grant.value === existing.value) {
       existing.sources.push(source);
+    }
+  }
+
+  // Second pass: resolve walk-equivalent grants against the resolved walk speed.
+  // If no walk speed exists, the walk-equivalent grant is silently dropped —
+  // a character with no walk speed can't have a walk-derived speed anyway.
+  const walkSpeed = bestPerMode.get('walk');
+  if (walkSpeed) {
+    for (const [mode, sources] of walkEquivalent) {
+      if (mode === 'walk') continue;
+      const existing = bestPerMode.get(mode);
+      if (!existing) {
+        bestPerMode.set(mode, { value: walkSpeed.value, sources });
+      } else if (walkSpeed.value > existing.value) {
+        bestPerMode.set(mode, { value: walkSpeed.value, sources });
+      } else if (walkSpeed.value === existing.value) {
+        existing.sources.push(...sources);
+      }
     }
   }
 

--- a/src/lib/sources/classes.test.ts
+++ b/src/lib/sources/classes.test.ts
@@ -807,13 +807,16 @@ describe('Ranger class grant structures', () => {
     }
   });
 
-  it('level 3 has subclass grant and roving feature', () => {
+  it('level 3 has subclass grant', () => {
     const grants = source?.levels[2].grants ?? [];
     expect(grants.find((g) => g.type === 'subclass')).toBeDefined();
-    const featureIds = grants
+  });
+
+  it('level 3 does not contain ranger-roving (2024 PHB places Roving at L6)', () => {
+    const featureIds = (source?.levels[2].grants ?? [])
       .filter((g) => g.type === 'feature')
       .map((g) => (g.type === 'feature' ? g.feature.id : ''));
-    expect(featureIds).toContain('ranger-roving');
+    expect(featureIds).not.toContain('ranger-roving');
   });
 
   it('level 4 has ASI (index 0)', () => {
@@ -831,6 +834,20 @@ describe('Ranger class grant structures', () => {
     if (grant?.type === 'expertise-choice') {
       expect(grant.key).toBe(createChoiceKey('expertise-choice', 'class', 'ranger', 0));
     }
+  });
+
+  it('level 6 has ranger-roving feature + walk-equivalent climb + swim grants', () => {
+    const grants = source?.levels[5].grants ?? [];
+    const featureIds = grants
+      .filter((g) => g.type === 'feature')
+      .map((g) => (g.type === 'feature' ? g.feature.id : ''));
+    expect(featureIds).toContain('ranger-roving');
+    expect(grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'speed', mode: 'climb', value: 'walk-equivalent' }),
+        expect.objectContaining({ type: 'speed', mode: 'swim', value: 'walk-equivalent' }),
+      ])
+    );
   });
 });
 

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -677,10 +677,7 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
         ],
       },
       {
-        grants: [
-          { type: 'subclass', classId: 'ranger', key: createChoiceKey('subclass', 'class', 'ranger', 0) },
-          { type: 'feature', feature: { id: 'ranger-roving' } },
-        ],
+        grants: [{ type: 'subclass', classId: 'ranger', key: createChoiceKey('subclass', 'class', 'ranger', 0) }],
       },
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'ranger', 0), points: 2, from: null }] },
       { grants: [{ type: 'feature', feature: { id: 'ranger-extra-attack' } }] },
@@ -693,6 +690,15 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
             from: null,
             fromTools: [],
           },
+          // Roving (L6, 2024 PHB): climb + swim equal to walking speed. The +10
+          // walking-speed bump (and its heavy-armor restriction) stays in feature
+          // text — needs additive-speed and conditional-grant infrastructure
+          // that don't exist yet. The co-located expertise-choice is itself
+          // misplaced in 2024 (PHB has Expertise at L9, not L6) — see issue
+          // tracker for the full Ranger feature-placement audit.
+          { type: 'feature', feature: { id: 'ranger-roving' } },
+          { type: 'speed', mode: 'climb', value: 'walk-equivalent' },
+          { type: 'speed', mode: 'swim', value: 'walk-equivalent' },
         ],
       },
       EMPTY_LEVEL,

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -34,6 +34,21 @@ describe('thief skill-expertise grant', () => {
       ])
     );
   });
+
+  it('thief level 3 has Second-Story Work walk-equivalent climb grant (2024 PHB)', () => {
+    const source = getSubclassSource('thief');
+    const level3 = source?.features.find((f) => f.classLevel === 3);
+    expect(level3).toBeDefined();
+    expect(level3!.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'thief-second-story-work' }),
+        }),
+        expect.objectContaining({ type: 'speed', mode: 'climb', value: 'walk-equivalent' }),
+      ])
+    );
+  });
 });
 
 describe('getSubclassSource — Champion', () => {

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -802,14 +802,14 @@ describe('getSubclassSource — Circle of the Sea', () => {
     });
   });
 
-  it('circlesea level 6 grants 2 items: swim speed grant and aquatic-affinity feature', () => {
+  it('circlesea level 6 grants 2 items: walk-equivalent swim speed grant and aquatic-affinity feature', () => {
     const source = getSubclassSource('circlesea');
     const level6 = source?.features.find((f) => f.classLevel === 6);
     expect(level6).toBeDefined();
     expect(level6?.grants).toHaveLength(2);
     expect(level6?.grants).toEqual(
       expect.arrayContaining([
-        expect.objectContaining({ type: 'speed', mode: 'swim', value: 30 }),
+        expect.objectContaining({ type: 'speed', mode: 'swim', value: 'walk-equivalent' }),
         expect.objectContaining({
           type: 'feature',
           feature: expect.objectContaining({ id: 'circlesea-aquatic-affinity' }),

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -281,9 +281,10 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
           // Bonus Cantrip: gain one additional Druid cantrip of choice; modeled as inert feature grant
           // TODO #93: replace with a cantrip-choice spell grant when spell id system supports it
           { type: 'feature', feature: { id: 'circleland-bonus-cantrip' } },
-          // Land's Bonus Spells: bonus prepared spells keyed to chosen Land type (Arctic/Coast/etc.)
-          // Land type is a free-form choice with no pending-choice mechanism; collapsed to inert feature grant
-          // TODO #93: model as spell grants per Land type when spell id system is available
+          // Land's Bonus Spells (2024 PHB): per Long Rest, choose one of Arid/Polar/Temperate/Tropical and
+          // gain that land's prepared spells; list scales at Druid 3/5/7/9. Blocked on two things: (a) per-rest
+          // gameplay-state tracking is not modeled (same shape as #138 Gaps 1-2), and (b) spell-id catalog.
+          // See #144 close-out for full deferral reasoning.
           { type: 'feature', feature: { id: 'circleland-bonus-spells' } },
         ],
       },
@@ -337,8 +338,8 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 6,
         grants: [
-          // Swim speed approximated as 30 ft (equal to typical walking speed); see implementation note
-          { type: 'speed', mode: 'swim', value: 30 },
+          // Aquatic Affinity: swim speed equals the Druid's walking speed (resolved from species walk).
+          { type: 'speed', mode: 'swim', value: 'walk-equivalent' },
           // Underwater breathing is a distinct feature; both grants are required for full Aquatic Affinity
           { type: 'feature', feature: { id: 'circlesea-aquatic-affinity' } },
         ],

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -739,6 +739,9 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
         grants: [
           { type: 'feature', feature: { id: 'thief-fast-hands' } },
           { type: 'feature', feature: { id: 'thief-second-story-work' } },
+          // Second-Story Work (2024 PHB): Climb Speed equals walking speed; jump
+          // bonus stays in feature text.
+          { type: 'speed', mode: 'climb', value: 'walk-equivalent' },
         ],
       },
       {

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1221,7 +1221,7 @@
     },
     "circleland-bonus-spells": {
       "name": "Land's Bonus Spells",
-      "description": "Your connection to the land grants you bonus prepared spells based on your chosen Land type: Arctic, Coast, Desert, Forest, Grassland, Mountain, Swamp, or Underdark. (Land type selection and associated spells are modeled as a descriptive feature pending spell system support.)"
+      "description": "Whenever you finish a Long Rest, choose one type of land — Arid, Polar, Temperate, or Tropical — and gain that land's prepared spells in addition to your usual prepared spells. The list expands at Druid levels 3, 5, 7, and 9. (Per-rest Land selection and associated spells are modeled as a descriptive feature pending gameplay-state tracking and spell-id catalog support.)"
     },
     "circleland-natural-recovery": {
       "name": "Natural Recovery",
@@ -1253,7 +1253,7 @@
     },
     "circlesea-aquatic-affinity": {
       "name": "Aquatic Affinity",
-      "description": "You can breathe underwater, and you gain a Swim speed equal to your walking speed. (Swim speed is approximated as 30 ft in this implementation; actual value equals walking speed.)"
+      "description": "You can breathe underwater, and you gain a Swim speed equal to your walking speed."
     },
     "circlesea-stormborn": {
       "name": "Stormborn",

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -445,7 +445,7 @@
     },
     "thief-second-story-work": {
       "name": "Second-Story Work",
-      "description": "Climbing no longer costs extra movement. When you make a running jump, the distance increases by a number of feet equal to your DEX modifier."
+      "description": "You gain a Climb Speed equal to your Speed. In addition, when you make a running jump, the distance you cover increases by a number of feet equal to your DEX modifier."
     },
     "thief-supreme-sneak": {
       "name": "Supreme Sneak",

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -132,7 +132,9 @@ export type SpeedMode = 'walk' | 'fly' | 'swim' | 'climb' | 'burrow';
 export interface SpeedGrant {
   readonly type: 'speed';
   readonly mode: SpeedMode;
-  readonly value: number;
+  // `'walk-equivalent'` resolves to the character's resolved walking speed
+  // (e.g. Circle of the Sea L6 Aquatic Affinity). Only meaningful on non-walk modes.
+  readonly value: number | 'walk-equivalent';
 }
 
 export type HitDie = 4 | 6 | 8 | 10 | 12;


### PR DESCRIPTION
## Summary

Follow-up to #115 / PR #143, addressing the actionable subset of #144 — plus two adjacent 2024 PHB walk-equivalent features and one Ranger feature-placement bug found during verification. Three commits, three classes, no new abstractions besides the `'walk-equivalent'` SpeedGrant value.

### New grant value: `SpeedGrant.value: number | 'walk-equivalent'`

Widened the type in `src/types/grants.ts`. `resolveSpeed` now runs in two passes — fixed-value grants first, then walk-equivalent grants resolved against the resolved walk speed. Walk-equivalent never lowers an existing higher fixed speed; silently drops if no walk grant exists.

### Wired walk-equivalent into three features

- **Druid Circle of the Sea L6 (Aquatic Affinity)** — was hard-coded `value: 30`; now derives swim from walking speed. Wood Elf Druid (35 ft walk) correctly gets 35 ft swim instead of 30.
- **Rogue Thief L3 (Second-Story Work)** — 2024 PHB grants Climb Speed equal to walking speed; codebase had no mechanical grant and 2014 i18n wording (climb-cost reduction). Added the grant + rewrote the description.
- **Ranger L6 (Roving)** — 2024 PHB grants climb + swim equal to walking speed. Added both grants. The +10 walking-speed bump (with its Heavy Armor restriction) remains as feature text — needs additive-speed and conditional-grant infrastructure that don't exist yet.

### Ranger feature placement: fixed Roving (L3 → L6)

Verifying Roving against the 2024 PHB surfaced a pre-existing placement bug: `ranger-roving` was at `levels[2]` (class level 3); the 2024 PHB places Roving at level 6. Moved the feature grant to `levels[5]` and updated the affected test. The walk-equivalent grants for Ranger are at the correct L6 location.

A broader Ranger feature-placement audit is still needed (Spellcasting L2→L1, Expertise L6→L9, `ranger-conjure-barrage` L9 may not be a 2024 base class feature). Documented in the #144 follow-up comment; out of scope for this PR.

### Circle of the Land L3 Bonus Spells: i18n bug fix

While in the Druid sources, fixed an i18n drift bug: the description listed the 2014 PHB's 8 land types (Arctic/Coast/.../Underdark). The 2024 PHB rule is *"Whenever you finish a Long Rest, choose one type of land: Arid, Polar, Temperate, or Tropical."* — only 4 lands, and per-Long-Rest selection rather than persistent L3 choice. Updated the description; replaced the stale `TODO #93` comment with the correct dual blocker (per-rest gameplay-state tracking + spell-id catalog).

### Gaps from #144 deferred

| Gap | Reason |
|---|---|
| 1 — Land type choice | Per-rest gameplay state; premise in issue body was wrong |
| 2 — Wild Shape resource pool | Gameplay state; large feature |
| 4 — Stormborn conditional fly | Accept as descriptive-only |
| 5 — Starry Form constellation | Per-activation gameplay state |
| 6 — Cosmic Omen Weal/Woe | Per-rest gameplay state |

All parallel to deferrals in #138. Full reasoning in the close-out comment on #144.

Refs: #144, #115, #143, #138 (parallel deferrals), #161 (always-prepared-spells UI).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean on touched files (pre-existing `src/lib/class-icons.tsx` error in main is unrelated)
- [x] `npm run test` — 1555/1555 pass (8 new tests: 5 resolver tests for walk-equivalent edge cases, 1 Thief L3 grant assertion, 2 Ranger L3-vs-L6 placement assertions)
- [ ] Manual: build a Wood Elf Druid → Circle of the Sea at L6 in the character builder, confirm Swim = 35 ft
- [ ] Manual: build a Thief Rogue at L3, confirm Climb = walking speed
- [ ] Manual: build a Ranger at L6, confirm Climb + Swim = walking speed (no longer shows Roving at L3)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
