### PR TITLE
feat(grants): add FeatureChoiceGrant; wire Cleric Divine Order & Blessed Strikes (#142)

### DIFF
--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -245,8 +245,8 @@ const FEATURE_CHOICE: PendingChoice & { type: 'feature-choice' } = {
   choiceKey: 'feature-choice:class:cleric:0' as ChoiceKey,
   source: CLERIC_SOURCE,
   options: [
-    { id: 'protector', featureId: 'cleric-divine-order-protector' },
-    { id: 'thaumaturge', featureId: 'cleric-divine-order-thaumaturge' },
+    { optionId: 'protector', featureId: 'cleric-divine-order-protector' },
+    { optionId: 'thaumaturge', featureId: 'cleric-divine-order-thaumaturge' },
   ],
 };
 

--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -233,3 +233,77 @@ describe('ChoicePicker bundle-choice', () => {
     expect(container.querySelectorAll('[data-slot="select-trigger"]').length).toBe(2);
   });
 });
+
+// ---------------------------------------------------------------------------
+// ChoicePicker — feature-choice branch
+// ---------------------------------------------------------------------------
+
+const CLERIC_SOURCE = { origin: 'class' as const, id: 'cleric' as const, level: 1 };
+
+const FEATURE_CHOICE: PendingChoice & { type: 'feature-choice' } = {
+  type: 'feature-choice',
+  choiceKey: 'feature-choice:class:cleric:0' as ChoiceKey,
+  source: CLERIC_SOURCE,
+  options: [
+    { id: 'protector', featureId: 'cleric-divine-order-protector' },
+    { id: 'thaumaturge', featureId: 'cleric-divine-order-thaumaturge' },
+  ],
+};
+
+describe('ChoicePicker feature-choice', () => {
+  it('renders one radio per option', () => {
+    render(<ChoicePicker choice={FEATURE_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />);
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(2);
+  });
+
+  it('no radio is checked when currentDecision is undefined', () => {
+    render(<ChoicePicker choice={FEATURE_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />);
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios.every((r) => !r.checked)).toBe(true);
+  });
+
+  it('clicking an option calls onDecide with the optionId', () => {
+    const onDecide = vi.fn();
+    render(<ChoicePicker choice={FEATURE_CHOICE} currentDecision={undefined} onDecide={onDecide} onClear={vi.fn()} />);
+    const radios = screen.getAllByRole('radio');
+    fireEvent.click(radios[0]);
+    expect(onDecide).toHaveBeenCalledWith(FEATURE_CHOICE.choiceKey, {
+      type: 'feature-choice',
+      optionId: 'protector',
+    });
+  });
+
+  it('selected radio reflects currentDecision.optionId', () => {
+    const currentDecision: ChoiceDecision = { type: 'feature-choice', optionId: 'thaumaturge' };
+    render(
+      <ChoicePicker choice={FEATURE_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios[0].checked).toBe(false);
+    expect(radios[1].checked).toBe(true);
+  });
+
+  it('Clear button appears only when an option is selected', () => {
+    const { rerender } = render(
+      <ChoicePicker choice={FEATURE_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    expect(screen.queryByRole('button', { name: /clear/i })).toBeNull();
+
+    const currentDecision: ChoiceDecision = { type: 'feature-choice', optionId: 'protector' };
+    rerender(
+      <ChoicePicker choice={FEATURE_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    expect(screen.getByRole('button', { name: /clear/i })).toBeTruthy();
+  });
+
+  it('clicking Clear calls onClear with the correct choiceKey', () => {
+    const onClear = vi.fn();
+    const currentDecision: ChoiceDecision = { type: 'feature-choice', optionId: 'protector' };
+    render(
+      <ChoicePicker choice={FEATURE_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={onClear} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+    expect(onClear).toHaveBeenCalledWith(FEATURE_CHOICE.choiceKey);
+  });
+});

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -239,22 +239,22 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear }: Cho
         <p className="text-sm text-muted-foreground">{tc('characterBuilder.pendingChoices.featureChoice')}</p>
         <div className="space-y-1">
           {choice.options.map((option) => {
-            const radioId = `choice-feature-${choice.choiceKey}-${option.id}`;
+            const radioId = `choice-feature-${choice.choiceKey}-${option.optionId}`;
             const labelKey = `features.${option.featureId}.name` as `features.${string}.name`;
             const descKey = `features.${option.featureId}.description` as `features.${string}.description`;
             const label = t(labelKey, { defaultValue: option.featureId });
             const description = t(descKey, { defaultValue: '' });
             return (
               <div
-                key={option.id}
+                key={option.optionId}
                 className="flex items-start gap-3 px-2 py-1.5 rounded-md transition-colors hover:bg-muted/50"
               >
                 <input
                   type="radio"
                   id={radioId}
                   name={`choice-feature-${choice.choiceKey}`}
-                  checked={currentOptionId === option.id}
-                  onChange={() => onDecide(choice.choiceKey, { type: 'feature-choice', optionId: option.id })}
+                  checked={currentOptionId === option.optionId}
+                  onChange={() => onDecide(choice.choiceKey, { type: 'feature-choice', optionId: option.optionId })}
                   className="mt-1 size-4 text-primary"
                 />
                 <Label htmlFor={radioId} className="flex-1 cursor-pointer">

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -231,6 +231,51 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear }: Cho
     );
   }
 
+  if (choice.type === 'feature-choice') {
+    const currentOptionId = currentDecision?.type === 'feature-choice' ? currentDecision.optionId : undefined;
+
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">{tc('characterBuilder.pendingChoices.featureChoice')}</p>
+        <div className="space-y-1">
+          {choice.options.map((option) => {
+            const radioId = `choice-feature-${choice.choiceKey}-${option.id}`;
+            const labelKey = `features.${option.featureId}.name` as `features.${string}.name`;
+            const descKey = `features.${option.featureId}.description` as `features.${string}.description`;
+            const label = t(labelKey, { defaultValue: option.featureId });
+            const description = t(descKey, { defaultValue: '' });
+            return (
+              <div
+                key={option.id}
+                className="flex items-start gap-3 px-2 py-1.5 rounded-md transition-colors hover:bg-muted/50"
+              >
+                <input
+                  type="radio"
+                  id={radioId}
+                  name={`choice-feature-${choice.choiceKey}`}
+                  checked={currentOptionId === option.id}
+                  onChange={() => onDecide(choice.choiceKey, { type: 'feature-choice', optionId: option.id })}
+                  className="mt-1 size-4 text-primary"
+                />
+                <Label htmlFor={radioId} className="flex-1 cursor-pointer">
+                  <span className="font-medium">{label}</span>
+                  {description ? (
+                    <span className="block text-xs text-muted-foreground mt-0.5">{description}</span>
+                  ) : null}
+                </Label>
+              </div>
+            );
+          })}
+        </div>
+        {currentOptionId !== undefined && (
+          <Button variant="ghost" size="sm" onClick={() => onClear(choice.choiceKey)}>
+            {tc('characterBuilder.equipment.clearSelection')}
+          </Button>
+        )}
+      </div>
+    );
+  }
+
   if (choice.type === 'bundle-choice') {
     const currentBundleId = currentDecision?.type === 'bundle-choice' ? currentDecision.bundleId : undefined;
     const currentSlotPicks = currentDecision?.type === 'bundle-choice' ? currentDecision.slotPicks : {};

--- a/src/components/character-builder/ClassStep.test.tsx
+++ b/src/components/character-builder/ClassStep.test.tsx
@@ -306,4 +306,83 @@ describe('ClassStep', () => {
 
     expect(screen.queryByText('noClassChoices')).toBeNull();
   });
+
+  it('renders a feature-choice picker for class-origin pending choices', () => {
+    const CLERIC_FEATURE_CHOICE_KEY = 'feature-choice:class:cleric:0' as ChoiceKey;
+    mockContextValue.resolved = {
+      spellcasting: null,
+      features: [],
+      pendingChoices: [
+        {
+          type: 'feature-choice',
+          choiceKey: CLERIC_FEATURE_CHOICE_KEY,
+          source: { origin: 'class', id: 'cleric', level: 1 },
+          options: [
+            { optionId: 'protector', featureId: 'cleric-divine-order-protector' },
+            { optionId: 'thaumaturge', featureId: 'cleric-divine-order-thaumaturge' },
+          ],
+        },
+      ],
+    } as Partial<ResolvedCharacter>;
+
+    render(<ClassStep />);
+
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(2);
+  });
+
+  it('does NOT render feature-choice pickers from non-class origins (regression guard)', () => {
+    const SPECIES_FEATURE_CHOICE_KEY = 'feature-choice:species:human:0' as ChoiceKey;
+    mockContextValue.resolved = {
+      spellcasting: null,
+      features: [],
+      pendingChoices: [
+        {
+          type: 'feature-choice',
+          choiceKey: SPECIES_FEATURE_CHOICE_KEY,
+          source: { origin: 'species', id: 'human' },
+          options: [
+            { optionId: 'a', featureId: 'human-foo' },
+            { optionId: 'b', featureId: 'human-bar' },
+          ],
+        },
+      ],
+    } as Partial<ResolvedCharacter>;
+
+    render(<ClassStep />);
+
+    expect(screen.queryAllByRole('radio')).toHaveLength(0);
+  });
+
+  it('dispatches makeChoice with the optionId when a feature-choice radio is clicked', () => {
+    const CLERIC_FEATURE_CHOICE_KEY = 'feature-choice:class:cleric:0' as ChoiceKey;
+    mockContextValue.resolved = {
+      spellcasting: null,
+      features: [],
+      pendingChoices: [
+        {
+          type: 'feature-choice',
+          choiceKey: CLERIC_FEATURE_CHOICE_KEY,
+          source: { origin: 'class', id: 'cleric', level: 1 },
+          options: [
+            { optionId: 'protector', featureId: 'cleric-divine-order-protector' },
+            { optionId: 'thaumaturge', featureId: 'cleric-divine-order-thaumaturge' },
+          ],
+        },
+      ],
+    } as Partial<ResolvedCharacter>;
+
+    render(<ClassStep />);
+
+    const protectorRadio = document.getElementById(
+      `choice-feature-${CLERIC_FEATURE_CHOICE_KEY}-protector`
+    ) as HTMLInputElement;
+    expect(protectorRadio).toBeTruthy();
+    fireEvent.click(protectorRadio);
+
+    expect(mockMakeChoice).toHaveBeenCalledWith(CLERIC_FEATURE_CHOICE_KEY, {
+      type: 'feature-choice',
+      optionId: 'protector',
+    });
+  });
 });

--- a/src/components/character-builder/ClassStep.tsx
+++ b/src/components/character-builder/ClassStep.tsx
@@ -1,6 +1,7 @@
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
 import { SubclassPicker } from '@/components/character-sheet/SubclassPicker';
+import { ChoicePicker } from '@/components/character-builder/ChoicePicker';
 import { useCharacterContext } from '@/hooks/useCharacterContext';
 import { type ChoiceKey } from '@/types/choices';
 import { type FightingStyleId } from '@/lib/dnd-helpers';
@@ -55,13 +56,24 @@ export function ClassStep() {
   }, [resolved]);
   const hasSubclassChoices = subclassChoices.length > 0;
 
+  // Pending class-feature variant choices (e.g. Cleric L1 Divine Order, L7 Blessed Strikes).
+  // Filter to class-origin so we don't render species/background feature-choices here.
+  const featureChoices = useMemo<readonly Extract<PendingChoice, { type: 'feature-choice' }>[]>(() => {
+    return (resolved?.pendingChoices ?? []).filter(
+      (c): c is Extract<PendingChoice, { type: 'feature-choice' }> =>
+        c.type === 'feature-choice' && c.source.origin === 'class'
+    );
+  }, [resolved]);
+  const hasFeatureChoices = featureChoices.length > 0;
+
   const levelOneClassFeatures = useMemo(() => {
     if (!resolved?.features) return [];
     return resolved.features.filter((f) => f.source.origin === 'class' && f.source.level === 1);
   }, [resolved]);
   const hasLevelOneFeatures = levelOneClassFeatures.length > 0;
 
-  const hasAnyContent = hasFightingStyles || hasSpellcasting || hasLevelOneFeatures || hasSubclassChoices;
+  const hasAnyContent =
+    hasFightingStyles || hasSpellcasting || hasLevelOneFeatures || hasSubclassChoices || hasFeatureChoices;
 
   return (
     <div className="space-y-6">
@@ -172,6 +184,26 @@ export function ClassStep() {
               onClear={(choiceKey) => context.clearChoice(choiceKey)}
               autoCommit
             />
+          ))}
+        </div>
+      )}
+
+      {hasFeatureChoices && (
+        <div className="space-y-4">
+          {featureChoices.map((choice) => (
+            <div key={choice.choiceKey}>
+              <p className="text-xs text-muted-foreground mb-1">
+                {tc('characterBuilder.pendingChoices.fromSource', {
+                  source: getChoiceSourceName(choice.choiceKey, t),
+                })}
+              </p>
+              <ChoicePicker
+                choice={choice}
+                currentDecision={build?.choices[choice.choiceKey]}
+                onDecide={(choiceKey, decision) => context.makeChoice(choiceKey, decision)}
+                onClear={(choiceKey) => context.clearChoice(choiceKey)}
+              />
+            </div>
           ))}
         </div>
       )}

--- a/src/components/character-builder/ClassStep.tsx
+++ b/src/components/character-builder/ClassStep.tsx
@@ -6,10 +6,13 @@ import { useCharacterContext } from '@/hooks/useCharacterContext';
 import { type ChoiceKey } from '@/types/choices';
 import { type FightingStyleId } from '@/lib/dnd-helpers';
 import { getChoiceSourceName } from '@/lib/character-builder/choice-source-name';
+import { getLogger } from '@/lib/logger';
 import { FIGHTING_STYLE_SOURCES } from '@/lib/sources/fighting-styles';
 import type { PendingChoice } from '@/types/resolved';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+
+const logger = getLogger('class-step');
 
 interface FightingStyleChoiceInfo {
   readonly choiceKey: ChoiceKey;
@@ -59,10 +62,17 @@ export function ClassStep() {
   // Pending class-feature variant choices (e.g. Cleric L1 Divine Order, L7 Blessed Strikes).
   // Filter to class-origin so we don't render species/background feature-choices here.
   const featureChoices = useMemo<readonly Extract<PendingChoice, { type: 'feature-choice' }>[]>(() => {
-    return (resolved?.pendingChoices ?? []).filter(
-      (c): c is Extract<PendingChoice, { type: 'feature-choice' }> =>
-        c.type === 'feature-choice' && c.source.origin === 'class'
+    const all = (resolved?.pendingChoices ?? []).filter(
+      (c): c is Extract<PendingChoice, { type: 'feature-choice' }> => c.type === 'feature-choice'
     );
+    for (const choice of all) {
+      if (choice.source.origin !== 'class') {
+        logger.error(
+          `feature-choice grant with non-class origin reached ClassStep — UI dispatch missing for origin "${choice.source.origin}", choice "${choice.choiceKey}" will be invisible`
+        );
+      }
+    }
+    return all.filter((c) => c.source.origin === 'class');
   }, [resolved]);
   const hasFeatureChoices = featureChoices.length > 0;
 

--- a/src/components/character-builder/ClassStep.tsx
+++ b/src/components/character-builder/ClassStep.tsx
@@ -6,13 +6,10 @@ import { useCharacterContext } from '@/hooks/useCharacterContext';
 import { type ChoiceKey } from '@/types/choices';
 import { type FightingStyleId } from '@/lib/dnd-helpers';
 import { getChoiceSourceName } from '@/lib/character-builder/choice-source-name';
-import { getLogger } from '@/lib/logger';
 import { FIGHTING_STYLE_SOURCES } from '@/lib/sources/fighting-styles';
 import type { PendingChoice } from '@/types/resolved';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
-
-const logger = getLogger('class-step');
 
 interface FightingStyleChoiceInfo {
   readonly choiceKey: ChoiceKey;
@@ -60,19 +57,13 @@ export function ClassStep() {
   const hasSubclassChoices = subclassChoices.length > 0;
 
   // Pending class-feature variant choices (e.g. Cleric L1 Divine Order, L7 Blessed Strikes).
-  // Filter to class-origin so we don't render species/background feature-choices here.
+  // Non-class-origin feature-choices are surfaced via buildWarnings at the collectBundles layer
+  // (src/lib/sources/index.ts), so the filter here is purely a UI dispatch concern.
   const featureChoices = useMemo<readonly Extract<PendingChoice, { type: 'feature-choice' }>[]>(() => {
-    const all = (resolved?.pendingChoices ?? []).filter(
-      (c): c is Extract<PendingChoice, { type: 'feature-choice' }> => c.type === 'feature-choice'
+    return (resolved?.pendingChoices ?? []).filter(
+      (c): c is Extract<PendingChoice, { type: 'feature-choice' }> =>
+        c.type === 'feature-choice' && c.source.origin === 'class'
     );
-    for (const choice of all) {
-      if (choice.source.origin !== 'class') {
-        logger.error(
-          `feature-choice grant with non-class origin reached ClassStep — UI dispatch missing for origin "${choice.source.origin}", choice "${choice.choiceKey}" will be invisible`
-        );
-      }
-    }
-    return all.filter((c) => c.source.origin === 'class');
   }, [resolved]);
   const hasFeatureChoices = featureChoices.length > 0;
 

--- a/src/components/character-sheet/PendingChoicesPanel.tsx
+++ b/src/components/character-sheet/PendingChoicesPanel.tsx
@@ -8,6 +8,7 @@ import { SubclassPicker } from '@/components/character-sheet/SubclassPicker';
 import { ChoicePicker } from '@/components/character-builder/ChoicePicker';
 import { useCharacterContext } from '@/hooks/useCharacterContext';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
+import { mapNonEmpty } from '@/lib/non-empty';
 import { WEAPON_CATALOG } from '@/lib/sources/items';
 import type { PendingChoice, ResolvedCharacter } from '@/types/resolved';
 import type { ChoiceDecision, ChoiceKey } from '@/types/choices';
@@ -201,13 +202,7 @@ function useAllChoiceGrants() {
         type: 'feature-choice',
         choiceKey: grant.key,
         source,
-        options: grant.options.map((o) => ({
-          optionId: o.optionId,
-          featureId: o.featureId,
-        })) as unknown as readonly [
-          { readonly optionId: string; readonly featureId: string },
-          ...{ readonly optionId: string; readonly featureId: string }[],
-        ],
+        options: mapNonEmpty(grant.options, (o) => ({ optionId: o.optionId, featureId: o.featureId })),
       });
     }
 

--- a/src/components/character-sheet/PendingChoicesPanel.tsx
+++ b/src/components/character-sheet/PendingChoicesPanel.tsx
@@ -195,6 +195,16 @@ function useAllChoiceGrants() {
       });
     }
 
+    // feature-choice grants
+    for (const { grant, source } of collectGrantsByType(bundles, 'feature-choice')) {
+      allGrants.push({
+        type: 'feature-choice',
+        choiceKey: grant.key,
+        source,
+        options: grant.options.map((o) => ({ id: o.id, featureId: o.featureId })),
+      });
+    }
+
     return allGrants;
   }, [bundles, buildChoices, resolvedWeaponProficiencies]);
 }

--- a/src/components/character-sheet/PendingChoicesPanel.tsx
+++ b/src/components/character-sheet/PendingChoicesPanel.tsx
@@ -201,7 +201,13 @@ function useAllChoiceGrants() {
         type: 'feature-choice',
         choiceKey: grant.key,
         source,
-        options: grant.options.map((o) => ({ id: o.id, featureId: o.featureId })),
+        options: grant.options.map((o) => ({
+          optionId: o.optionId,
+          featureId: o.featureId,
+        })) as unknown as readonly [
+          { readonly optionId: string; readonly featureId: string },
+          ...{ readonly optionId: string; readonly featureId: string }[],
+        ],
       });
     }
 

--- a/src/hooks/useCharacterContext.tsx
+++ b/src/hooks/useCharacterContext.tsx
@@ -275,11 +275,13 @@ function tryDeriveAndResolve(
   }
 
   let build: CharacterBuild;
+  const reconstructionWarnings: string[] = [];
   try {
     build = reconstructBuild(
       { species: character.species, background: character.background },
       activeRows,
-      equippedItems
+      equippedItems,
+      (message) => reconstructionWarnings.push(message)
     );
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Unknown build error';
@@ -287,10 +289,11 @@ function tryDeriveAndResolve(
     return { status: 'build-error', build: null, bundles: [], resolved: null, error: message, warnings: [] };
   }
 
-  const { bundles, warnings, expandedFeats } = collectBundles(build);
-  if (warnings.length > 0) {
-    logger.warn('collectBundles warnings:', warnings);
+  const { bundles, warnings: bundleWarnings, expandedFeats } = collectBundles(build);
+  if (bundleWarnings.length > 0) {
+    logger.warn('collectBundles warnings:', bundleWarnings);
   }
+  const warnings: readonly string[] = [...reconstructionWarnings, ...bundleWarnings];
 
   try {
     const levelRows = activeRows.filter((r) => r.sequence !== 0);

--- a/src/lib/build-reconstruction.test.ts
+++ b/src/lib/build-reconstruction.test.ts
@@ -311,6 +311,19 @@ describe('reconstructBuild', () => {
     expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('bad'), expect.any(Error));
   });
 
+  it('forwards skipped-choice messages to the onWarning callback for UI surfacing', () => {
+    const creationWithBadChoices: BuildLevelRow = {
+      ...creationRow,
+      choices: { bad: { type: 'unknown' } } as unknown as BuildLevelRow['choices'],
+    };
+    const buildReconstructionLogger = getLogger('build-reconstruction');
+    vi.spyOn(buildReconstructionLogger, 'warn').mockImplementation(() => {});
+    const surfaced: string[] = [];
+    reconstructBuild(identity, [creationWithBadChoices], [], (msg) => surfaced.push(msg));
+    expect(surfaced).toHaveLength(1);
+    expect(surfaced[0]).toContain('bad');
+  });
+
   it('throws when level row is missing class_id', () => {
     const levelMissingClassId = {
       sequence: 1,

--- a/src/lib/build-reconstruction.test.ts
+++ b/src/lib/build-reconstruction.test.ts
@@ -284,6 +284,21 @@ describe('reconstructBuild', () => {
     });
   });
 
+  it('round-trips a feature-choice decision from creation-row JSONB', () => {
+    const featureChoiceKey = createChoiceKey('feature-choice', 'class', 'cleric', 0);
+    const creationWithFeatureChoice: BuildLevelRow = {
+      ...creationRow,
+      choices: {
+        [featureChoiceKey]: { type: 'feature-choice', optionId: 'protector' },
+      } as BuildLevelRow['choices'],
+    };
+    const buildReconstructionLogger = getLogger('build-reconstruction');
+    const warnSpy = vi.spyOn(buildReconstructionLogger, 'warn').mockImplementation(() => {});
+    const result = reconstructBuild(identity, [creationWithFeatureChoice], []);
+    expect(result.choices[featureChoiceKey]).toEqual({ type: 'feature-choice', optionId: 'protector' });
+    expect(warnSpy).not.toHaveBeenCalled();
+  });
+
   it('skips malformed choice keys in JSONB without crashing', () => {
     const creationWithBadChoices: BuildLevelRow = {
       ...creationRow,

--- a/src/lib/build-reconstruction.ts
+++ b/src/lib/build-reconstruction.ts
@@ -74,8 +74,14 @@ type AbilityMethod = (typeof VALID_ABILITY_METHODS)[number];
 export function reconstructBuild(
   character: CharacterIdentity,
   rows: readonly BuildLevelRow[],
-  equippedItems: readonly string[]
+  equippedItems: readonly string[],
+  onWarning?: (message: string) => void
 ): CharacterBuild {
+  const warn = (message: string, cause?: unknown): void => {
+    logger.warn(message, cause);
+    onWarning?.(message);
+  };
+
   if (!character.species) throw new Error('Character is missing required species');
   if (!isSpeciesId(character.species)) throw new Error(`Character has invalid species ID: "${character.species}"`);
 
@@ -150,7 +156,7 @@ export function reconstructBuild(
       try {
         mergeChoiceEntry(validateChoiceKey(key), value);
       } catch (err) {
-        logger.warn(`Skipping malformed choice key "${key}" in creation row:`, err);
+        warn(`Skipping malformed choice key "${key}" in creation row`, err);
       }
     }
   }
@@ -159,7 +165,7 @@ export function reconstructBuild(
   for (const row of levelRows) {
     if (row.subclass_id !== null) {
       if (!isSubclassId(row.subclass_id)) {
-        logger.warn(`Skipping unknown subclass_id "${row.subclass_id}" in build level row sequence ${row.sequence}`);
+        warn(`Skipping unknown subclass_id "${row.subclass_id}" in build level row sequence ${row.sequence}`);
       } else {
         const key = createChoiceKey('subclass', 'class', row.class_id, 0);
         choices[key] = { type: 'subclass', subclassId: row.subclass_id };
@@ -191,7 +197,7 @@ export function reconstructBuild(
         try {
           mergeChoiceEntry(validateChoiceKey(key), value);
         } catch (err) {
-          logger.warn(`Skipping malformed choice key "${key}" in level row sequence ${row.sequence}:`, err);
+          warn(`Skipping malformed choice key "${key}" in level row sequence ${row.sequence}`, err);
         }
       }
     }

--- a/src/lib/non-empty.test.ts
+++ b/src/lib/non-empty.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { mapNonEmpty } from '@/lib/non-empty';
+
+describe('mapNonEmpty', () => {
+  it('maps every element and preserves the non-empty tuple shape at the type level', () => {
+    const result = mapNonEmpty([1, 2, 3] as const, (x) => x * 2);
+    expect(result).toEqual([2, 4, 6]);
+    // Compile-time: result is `readonly [number, ...number[]]`, so result[0] is non-optional.
+    const first: number = result[0];
+    expect(first).toBe(2);
+  });
+
+  it('handles a single-element tuple', () => {
+    const result = mapNonEmpty(['a'] as const, (s) => s.toUpperCase());
+    expect(result).toEqual(['A']);
+  });
+
+  it('does not mutate the input', () => {
+    const input = [1, 2] as const;
+    mapNonEmpty(input, (x) => x + 100);
+    expect(input).toEqual([1, 2]);
+  });
+});

--- a/src/lib/non-empty.ts
+++ b/src/lib/non-empty.ts
@@ -1,0 +1,6 @@
+export type NonEmptyArray<T> = readonly [T, ...T[]];
+
+export function mapNonEmpty<A, B>(xs: NonEmptyArray<A>, f: (a: A) => B): NonEmptyArray<B> {
+  const [first, ...rest] = xs;
+  return [f(first), ...rest.map(f)] as const;
+}

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -2141,4 +2141,47 @@ describe('Cleric feature-choice integration (Divine Order)', () => {
     const featureIds = result.features.map((f) => f.feature.id);
     expect(featureIds).toContain('cleric-divine-order-protector');
   });
+
+  it('re-emits a pending feature-choice when the decision references an unknown optionId', () => {
+    const build: CharacterBuild = {
+      ...baseBuild,
+      choices: { [divineOrderKey]: { type: 'feature-choice' as const, optionId: 'unknown' } },
+    };
+    const { bundles } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 1,
+      bundles,
+      choices: build.choices,
+    });
+    const pending = result.pendingChoices.find((c) => c.type === 'feature-choice');
+    expect(pending).toBeDefined();
+    if (pending?.type === 'feature-choice') {
+      expect(pending.choiceKey).toBe(divineOrderKey);
+      const optionIds = pending.options.map((o) => o.optionId);
+      expect(optionIds).toEqual(['protector', 'thaumaturge']);
+    }
+    const featureIds = result.features.map((f) => f.feature.id);
+    expect(featureIds).not.toContain('cleric-divine-order-protector');
+    expect(featureIds).not.toContain('cleric-divine-order-thaumaturge');
+  });
+
+  it('re-emits pending when the decision under the feature-choice key has a wrong type', () => {
+    const build: CharacterBuild = {
+      ...baseBuild,
+      choices: { [divineOrderKey]: { type: 'skill-choice' as const, skills: [] } },
+    };
+    const { bundles } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 1,
+      bundles,
+      choices: build.choices,
+    });
+    const pending = result.pendingChoices.find((c) => c.type === 'feature-choice');
+    expect(pending).toBeDefined();
+    const featureIds = result.features.map((f) => f.feature.id);
+    expect(featureIds).not.toContain('cleric-divine-order-protector');
+    expect(featureIds).not.toContain('cleric-divine-order-thaumaturge');
+  });
 });

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -2042,3 +2042,103 @@ describe('bardicInspiration resolver integration', () => {
     expect(result.armorClass.effective).toBe(18); // dance (18) > unequipped armored (12)
   });
 });
+
+describe('Cleric feature-choice integration (Divine Order)', () => {
+  const divineOrderKey = createChoiceKey('feature-choice', 'class', 'cleric', 0);
+
+  const baseBuild: CharacterBuild = {
+    speciesId: 'human' as const,
+    backgroundId: 'acolyte',
+    baseAbilities: { str: 13, dex: 10, con: 14, int: 8, wis: 15, cha: 12 },
+    abilityMethod: 'standard-array',
+    levels: [{ classId: 'cleric' as ClassId, classLevel: 1, hpRoll: null }],
+    choices: {},
+    feats: [],
+    activeItems: [],
+  };
+
+  it('emits a pending feature-choice with both options when no decision is recorded', () => {
+    const { bundles } = collectBundles(baseBuild);
+    const result = resolveCharacter({
+      baseAbilities: baseBuild.baseAbilities,
+      level: 1,
+      bundles,
+      choices: baseBuild.choices,
+    });
+    const pending = result.pendingChoices.find((c) => c.type === 'feature-choice');
+    expect(pending).toBeDefined();
+    if (pending?.type === 'feature-choice') {
+      expect(pending.choiceKey).toBe(divineOrderKey);
+      const optionIds = pending.options.map((o) => o.id);
+      expect(optionIds).toEqual(['protector', 'thaumaturge']);
+      const protectorOption = pending.options.find((o) => o.id === 'protector');
+      expect(protectorOption?.featureId).toBe('cleric-divine-order-protector');
+    }
+  });
+
+  it('does not emit a pending choice once a valid option is selected', () => {
+    const build: CharacterBuild = {
+      ...baseBuild,
+      choices: { [divineOrderKey]: { type: 'feature-choice' as const, optionId: 'protector' } },
+    };
+    const { bundles } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 1,
+      bundles,
+      choices: build.choices,
+    });
+    const pending = result.pendingChoices.find((c) => c.type === 'feature-choice');
+    expect(pending).toBeUndefined();
+  });
+
+  it('Protector grants martial weapon + heavy armor proficiencies on the resolved character', () => {
+    const build: CharacterBuild = {
+      ...baseBuild,
+      choices: { [divineOrderKey]: { type: 'feature-choice' as const, optionId: 'protector' } },
+    };
+    const { bundles } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 1,
+      bundles,
+      choices: build.choices,
+    });
+    const weaponProfValues = result.weaponProficiencies.map((p) => p.value);
+    expect(weaponProfValues).toContain('martial');
+    const armorProfValues = result.armorProficiencies.map((p) => p.value);
+    expect(armorProfValues).toContain('heavy');
+  });
+
+  it('Thaumaturge does NOT grant Protector’s martial weapon proficiency', () => {
+    const build: CharacterBuild = {
+      ...baseBuild,
+      choices: { [divineOrderKey]: { type: 'feature-choice' as const, optionId: 'thaumaturge' } },
+    };
+    const { bundles } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 1,
+      bundles,
+      choices: build.choices,
+    });
+    const weaponProfValues = result.weaponProficiencies.map((p) => p.value);
+    expect(weaponProfValues).not.toContain('martial');
+  });
+
+  it('chosen variant feature appears in the resolved features list', () => {
+    const build: CharacterBuild = {
+      ...baseBuild,
+      choices: { [divineOrderKey]: { type: 'feature-choice' as const, optionId: 'protector' } },
+    };
+    const { bundles } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 1,
+      bundles,
+      choices: build.choices,
+    });
+    const featureIds = result.features.map((f) => f.feature.id);
+    expect(featureIds).toContain('cleric-divine-order-protector');
+  });
+});

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -2069,9 +2069,9 @@ describe('Cleric feature-choice integration (Divine Order)', () => {
     expect(pending).toBeDefined();
     if (pending?.type === 'feature-choice') {
       expect(pending.choiceKey).toBe(divineOrderKey);
-      const optionIds = pending.options.map((o) => o.id);
+      const optionIds = pending.options.map((o) => o.optionId);
       expect(optionIds).toEqual(['protector', 'thaumaturge']);
-      const protectorOption = pending.options.find((o) => o.id === 'protector');
+      const protectorOption = pending.options.find((o) => o.optionId === 'protector');
       expect(protectorOption?.featureId).toBe('cleric-divine-order-protector');
     }
   });

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -9,6 +9,7 @@ import type { GrantBundle, SourceTag } from '@/types/sources';
 import type { ChoiceKey, ChoiceDecision } from '@/types/choices';
 import type { ResolvedCharacter, PendingChoice, ResolvedSkill } from '@/types/resolved';
 import type { HitDie, ExpertiseChoiceGrant } from '@/types/grants';
+import { mapNonEmpty } from '@/lib/non-empty';
 import type { WeaponMasteryId } from '@/types/items';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
 import { resolveAbilities } from '@/lib/resolver/abilities';
@@ -288,10 +289,7 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
         type: 'feature-choice',
         choiceKey: grant.key,
         source,
-        options: grant.options.map((o) => ({ optionId: o.optionId, featureId: o.featureId })) as unknown as readonly [
-          { readonly optionId: string; readonly featureId: string },
-          ...{ readonly optionId: string; readonly featureId: string }[],
-        ],
+        options: mapNonEmpty(grant.options, (o) => ({ optionId: o.optionId, featureId: o.featureId })),
       });
     }
   }

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -278,6 +278,23 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
     weaponMasteriesMap.entries()
   ).map(([weaponId, masteryId]) => ({ weaponId, masteryId }));
 
+  // Unresolved or invalid feature-choice grants. Emits the option list so the UI
+  // can render labels (via `features.${featureId}.name`) without re-traversing
+  // the grant.
+  for (const { grant, source } of collectGrantsByType(bundles, 'feature-choice')) {
+    const decision = choices[grant.key];
+    const validOption =
+      decision?.type === 'feature-choice' ? grant.options.find((o) => o.id === decision.optionId) : undefined;
+    if (!validOption) {
+      pendingChoices.push({
+        type: 'feature-choice',
+        choiceKey: grant.key,
+        source,
+        options: grant.options.map((o) => ({ id: o.id, featureId: o.featureId })),
+      });
+    }
+  }
+
   // Unresolved lineage-choice grants
   for (const { grant, source } of collectGrantsByType(bundles, 'lineage-choice')) {
     const decision = choices[grant.key];

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -278,19 +278,20 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
     weaponMasteriesMap.entries()
   ).map(([weaponId, masteryId]) => ({ weaponId, masteryId }));
 
-  // Unresolved or invalid feature-choice grants. Emits the option list so the UI
-  // can render labels (via `features.${featureId}.name`) without re-traversing
-  // the grant.
+  // Unresolved feature-choice grants
   for (const { grant, source } of collectGrantsByType(bundles, 'feature-choice')) {
     const decision = choices[grant.key];
     const validOption =
-      decision?.type === 'feature-choice' ? grant.options.find((o) => o.id === decision.optionId) : undefined;
+      decision?.type === 'feature-choice' ? grant.options.find((o) => o.optionId === decision.optionId) : undefined;
     if (!validOption) {
       pendingChoices.push({
         type: 'feature-choice',
         choiceKey: grant.key,
         source,
-        options: grant.options.map((o) => ({ id: o.id, featureId: o.featureId })),
+        options: grant.options.map((o) => ({ optionId: o.optionId, featureId: o.featureId })) as unknown as readonly [
+          { readonly optionId: string; readonly featureId: string },
+          ...{ readonly optionId: string; readonly featureId: string }[],
+        ],
       });
     }
   }

--- a/src/lib/schemas/character-build.test.ts
+++ b/src/lib/schemas/character-build.test.ts
@@ -222,6 +222,26 @@ describe('ChoiceDecisionSchema', () => {
       expect(result.success).toBe(true);
     });
   });
+
+  describe('feature-choice', () => {
+    it('accepts a feature-choice decision with a valid optionId', () => {
+      const result = ChoiceDecisionSchema.safeParse({ type: 'feature-choice', optionId: 'protector' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ type: 'feature-choice', optionId: 'protector' });
+      }
+    });
+
+    it('rejects feature-choice with empty optionId', () => {
+      const result = ChoiceDecisionSchema.safeParse({ type: 'feature-choice', optionId: '' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects feature-choice missing optionId', () => {
+      const result = ChoiceDecisionSchema.safeParse({ type: 'feature-choice' });
+      expect(result.success).toBe(false);
+    });
+  });
 });
 
 describe('CharacterBuildSchemaStrict', () => {

--- a/src/lib/schemas/character-build.ts
+++ b/src/lib/schemas/character-build.ts
@@ -52,6 +52,7 @@ export const ChoiceDecisionSchema = z.discriminatedUnion('type', [
     slotPicks: z.record(z.string(), z.string()).default({}),
   }),
   z.object({ type: z.literal('lineage-choice'), lineageId: z.string().min(1) }),
+  z.object({ type: z.literal('feature-choice'), optionId: z.string().min(1) }),
 ]);
 
 export const CharacterBuildSchema = z.object({

--- a/src/lib/sources/classes.test.ts
+++ b/src/lib/sources/classes.test.ts
@@ -2,7 +2,10 @@ import { describe, it, expect } from 'vitest';
 import { getClassSource } from '@/lib/sources';
 import { createChoiceKey } from '@/types/choices';
 import { CLASS_SOURCES } from '@/lib/sources/classes';
+import { SUBCLASS_SOURCES } from '@/lib/sources/subclasses';
 import type { ClassId } from '@/lib/dnd-helpers';
+import type { Grant, FeatureChoiceGrant } from '@/types/grants';
+import gamedata from '@/locales/en/gamedata.json';
 
 describe('Fighter class levels 2–10 grant structures', () => {
   const source = getClassSource('fighter' as ClassId);
@@ -553,13 +556,6 @@ describe('Cleric class grant structures', () => {
     }
   });
 
-  it('level 2 does not include the legacy holy-order feature (removed; not in 2024 PHB)', () => {
-    const featureIds = source?.levels[1].grants
-      .filter((g) => g.type === 'feature')
-      .map((g) => (g.type === 'feature' ? g.feature.id : ''));
-    expect(featureIds).not.toContain('cleric-holy-order');
-  });
-
   it('level 3 has subclass grant for cleric', () => {
     const grant = source?.levels[2].grants.find((g) => g.type === 'subclass');
     expect(grant?.type).toBe('subclass');
@@ -1039,5 +1035,38 @@ describe('Wizard class grant structures', () => {
       .filter((g) => g.type === 'feature')
       .map((g) => (g.type === 'feature' ? g.feature.id : ''));
     expect(featureIds).toContain('wizard-signature-spells');
+  });
+});
+
+describe('FeatureChoiceGrant i18n coverage', () => {
+  function collectFeatureChoices(grants: readonly Grant[]): FeatureChoiceGrant[] {
+    return grants.filter((g): g is FeatureChoiceGrant => g.type === 'feature-choice');
+  }
+
+  it('every FeatureChoiceOption.featureId has a non-empty name and description in gamedata.json', () => {
+    const featureIds = new Set<string>();
+    for (const classSource of CLASS_SOURCES) {
+      for (const level of classSource.levels) {
+        for (const choice of collectFeatureChoices(level.grants)) {
+          for (const option of choice.options) featureIds.add(option.featureId);
+        }
+      }
+    }
+    for (const subclassSource of Object.values(SUBCLASS_SOURCES)) {
+      for (const feature of subclassSource.features) {
+        for (const choice of collectFeatureChoices(feature.grants)) {
+          for (const option of choice.options) featureIds.add(option.featureId);
+        }
+      }
+    }
+
+    const missing: string[] = [];
+    const features = gamedata.features as Record<string, { name?: string; description?: string }>;
+    for (const featureId of featureIds) {
+      const entry = features[featureId];
+      if (!entry?.name || entry.name.length === 0) missing.push(`${featureId}.name`);
+      if (!entry?.description || entry.description.length === 0) missing.push(`${featureId}.description`);
+    }
+    expect(missing).toEqual([]);
   });
 });

--- a/src/lib/sources/classes.test.ts
+++ b/src/lib/sources/classes.test.ts
@@ -529,11 +529,35 @@ describe('Cleric class grant structures', () => {
     }
   });
 
-  it('level 1 has divine-order feature', () => {
-    const featureIds = source?.levels[0].grants
+  it('level 1 has a divine-order feature-choice between Protector and Thaumaturge', () => {
+    const grant = source?.levels[0].grants.find((g) => g.type === 'feature-choice');
+    expect(grant?.type).toBe('feature-choice');
+    if (grant?.type === 'feature-choice') {
+      expect(grant.key).toBe(createChoiceKey('feature-choice', 'class', 'cleric', 0));
+      const optionIds = grant.options.map((o) => o.id);
+      expect(optionIds).toEqual(['protector', 'thaumaturge']);
+      const protector = grant.options.find((o) => o.id === 'protector');
+      expect(protector?.featureId).toBe('cleric-divine-order-protector');
+      const protectorProfs = protector?.grants.filter((g) => g.type === 'proficiency') ?? [];
+      expect(protectorProfs).toHaveLength(2);
+    }
+  });
+
+  it('level 7 has a blessed-strikes feature-choice between Divine Strike and Potent Spellcasting', () => {
+    const grant = source?.levels[6].grants.find((g) => g.type === 'feature-choice');
+    expect(grant?.type).toBe('feature-choice');
+    if (grant?.type === 'feature-choice') {
+      expect(grant.key).toBe(createChoiceKey('feature-choice', 'class', 'cleric', 1));
+      const optionIds = grant.options.map((o) => o.id);
+      expect(optionIds).toEqual(['divine-strike', 'potent-spellcasting']);
+    }
+  });
+
+  it('level 2 does not include the legacy holy-order feature (removed; not in 2024 PHB)', () => {
+    const featureIds = source?.levels[1].grants
       .filter((g) => g.type === 'feature')
       .map((g) => (g.type === 'feature' ? g.feature.id : ''));
-    expect(featureIds).toContain('cleric-divine-order');
+    expect(featureIds).not.toContain('cleric-holy-order');
   });
 
   it('level 3 has subclass grant for cleric', () => {

--- a/src/lib/sources/classes.test.ts
+++ b/src/lib/sources/classes.test.ts
@@ -534,9 +534,9 @@ describe('Cleric class grant structures', () => {
     expect(grant?.type).toBe('feature-choice');
     if (grant?.type === 'feature-choice') {
       expect(grant.key).toBe(createChoiceKey('feature-choice', 'class', 'cleric', 0));
-      const optionIds = grant.options.map((o) => o.id);
+      const optionIds = grant.options.map((o) => o.optionId);
       expect(optionIds).toEqual(['protector', 'thaumaturge']);
-      const protector = grant.options.find((o) => o.id === 'protector');
+      const protector = grant.options.find((o) => o.optionId === 'protector');
       expect(protector?.featureId).toBe('cleric-divine-order-protector');
       const protectorProfs = protector?.grants.filter((g) => g.type === 'proficiency') ?? [];
       expect(protectorProfs).toHaveLength(2);
@@ -548,7 +548,7 @@ describe('Cleric class grant structures', () => {
     expect(grant?.type).toBe('feature-choice');
     if (grant?.type === 'feature-choice') {
       expect(grant.key).toBe(createChoiceKey('feature-choice', 'class', 'cleric', 1));
-      const optionIds = grant.options.map((o) => o.id);
+      const optionIds = grant.options.map((o) => o.optionId);
       expect(optionIds).toEqual(['divine-strike', 'potent-spellcasting']);
     }
   });

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -228,21 +228,60 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
             from: ['history', 'insight', 'medicine', 'persuasion', 'religion'],
           },
           { type: 'spellcasting', ability: 'wis', source: 'class' },
-          { type: 'feature', feature: { id: 'cleric-divine-order' } },
+          {
+            type: 'feature-choice',
+            key: createChoiceKey('feature-choice', 'class', 'cleric', 0),
+            options: [
+              {
+                id: 'protector',
+                featureId: 'cleric-divine-order-protector',
+                grants: [
+                  { type: 'proficiency', category: 'weapon', id: 'martial' },
+                  { type: 'proficiency', category: 'armor', id: 'heavy' },
+                ],
+              },
+              {
+                id: 'thaumaturge',
+                featureId: 'cleric-divine-order-thaumaturge',
+                // Mechanical effects (extra cantrip; Wis-mod bonus to Arcana/Religion checks) are
+                // inert pending a cantrip-grant system and an ability-check-bonus value beyond
+                // 'half-proficiency'.
+                grants: [],
+              },
+            ],
+          },
           { type: 'armor-class', calculation: { mode: 'armored' } },
         ],
       },
       {
-        grants: [
-          { type: 'feature', feature: { id: 'cleric-channel-divinity' } },
-          { type: 'feature', feature: { id: 'cleric-holy-order' } },
-        ],
+        grants: [{ type: 'feature', feature: { id: 'cleric-channel-divinity' } }],
       },
       { grants: [{ type: 'subclass', classId: 'cleric', key: createChoiceKey('subclass', 'class', 'cleric', 0) }] },
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'cleric', 0), points: 2, from: null }] },
       { grants: [{ type: 'feature', feature: { id: 'cleric-smite-undead' } }] },
       EMPTY_LEVEL,
-      { grants: [{ type: 'feature', feature: { id: 'cleric-blessed-strikes' } }] },
+      {
+        grants: [
+          {
+            type: 'feature-choice',
+            key: createChoiceKey('feature-choice', 'class', 'cleric', 1),
+            options: [
+              {
+                id: 'divine-strike',
+                featureId: 'cleric-blessed-strikes-divine-strike',
+                // On-hit damage rider (+1d8 necrotic/radiant on weapon hits) has no grant model yet.
+                grants: [],
+              },
+              {
+                id: 'potent-spellcasting',
+                featureId: 'cleric-blessed-strikes-potent-spellcasting',
+                // Cantrip-damage modifier (+Wis mod) has no grant model yet.
+                grants: [],
+              },
+            ],
+          },
+        ],
+      },
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'cleric', 1), points: 2, from: null }] },
       EMPTY_LEVEL,
       { grants: [{ type: 'feature', feature: { id: 'cleric-divine-intervention' } }] },

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -233,7 +233,7 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
             key: createChoiceKey('feature-choice', 'class', 'cleric', 0),
             options: [
               {
-                id: 'protector',
+                optionId: 'protector',
                 featureId: 'cleric-divine-order-protector',
                 grants: [
                   { type: 'proficiency', category: 'weapon', id: 'martial' },
@@ -241,7 +241,7 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
                 ],
               },
               {
-                id: 'thaumaturge',
+                optionId: 'thaumaturge',
                 featureId: 'cleric-divine-order-thaumaturge',
                 // Mechanical effects (extra cantrip; Wis-mod bonus to Arcana/Religion checks) are
                 // inert pending a cantrip-grant system and an ability-check-bonus value beyond
@@ -267,13 +267,13 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
             key: createChoiceKey('feature-choice', 'class', 'cleric', 1),
             options: [
               {
-                id: 'divine-strike',
+                optionId: 'divine-strike',
                 featureId: 'cleric-blessed-strikes-divine-strike',
                 // On-hit damage rider (+1d8 necrotic/radiant on weapon hits) has no grant model yet.
                 grants: [],
               },
               {
-                id: 'potent-spellcasting',
+                optionId: 'potent-spellcasting',
                 featureId: 'cleric-blessed-strikes-potent-spellcasting',
                 // Cantrip-damage modifier (+Wis mod) has no grant model yet.
                 grants: [],

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -355,6 +355,104 @@ describe('collectBundles', () => {
     expect(necroticFeature).toBeUndefined();
   });
 
+  it('feature-choice: cleric L1 Protector inlines the option grants (martial weapons + heavy armor)', () => {
+    const featureKey = createChoiceKey('feature-choice', 'class', 'cleric', 0);
+    const build: CharacterBuild = {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'acolyte' as BackgroundId,
+      baseAbilities: { str: 13, dex: 10, con: 14, int: 8, wis: 15, cha: 12 },
+      abilityMethod: 'standard-array',
+      levels: [{ classId: 'cleric' as ClassId, classLevel: 1, hpRoll: null }],
+      choices: {
+        [featureKey]: { type: 'feature-choice' as const, optionId: 'protector' },
+      },
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(build);
+    const allGrants = bundles.flatMap((b) => b.grants);
+    const protectorFeature = allGrants.find(
+      (g) => g.type === 'feature' && g.feature.id === 'cleric-divine-order-protector'
+    );
+    expect(protectorFeature).toBeDefined();
+    const martialWeapon = allGrants.find(
+      (g) => g.type === 'proficiency' && g.category === 'weapon' && g.id === 'martial'
+    );
+    expect(martialWeapon).toBeDefined();
+    const heavyArmor = allGrants.find((g) => g.type === 'proficiency' && g.category === 'armor' && g.id === 'heavy');
+    expect(heavyArmor).toBeDefined();
+  });
+
+  it('feature-choice: cleric L1 Thaumaturge inlines only the variant feature (no extra grants today)', () => {
+    const featureKey = createChoiceKey('feature-choice', 'class', 'cleric', 0);
+    const build: CharacterBuild = {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'acolyte' as BackgroundId,
+      baseAbilities: { str: 13, dex: 10, con: 14, int: 8, wis: 15, cha: 12 },
+      abilityMethod: 'standard-array',
+      levels: [{ classId: 'cleric' as ClassId, classLevel: 1, hpRoll: null }],
+      choices: {
+        [featureKey]: { type: 'feature-choice' as const, optionId: 'thaumaturge' },
+      },
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(build);
+    const allGrants = bundles.flatMap((b) => b.grants);
+    const thaumaturgeFeature = allGrants.find(
+      (g) => g.type === 'feature' && g.feature.id === 'cleric-divine-order-thaumaturge'
+    );
+    expect(thaumaturgeFeature).toBeDefined();
+    const protectorFeature = allGrants.find(
+      (g) => g.type === 'feature' && g.feature.id === 'cleric-divine-order-protector'
+    );
+    expect(protectorFeature).toBeUndefined();
+  });
+
+  it('feature-choice: emits no expansion when the decision is missing', () => {
+    const build: CharacterBuild = {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'acolyte' as BackgroundId,
+      baseAbilities: { str: 13, dex: 10, con: 14, int: 8, wis: 15, cha: 12 },
+      abilityMethod: 'standard-array',
+      levels: [{ classId: 'cleric' as ClassId, classLevel: 1, hpRoll: null }],
+      choices: {},
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles, warnings } = collectBundles(build);
+    const allGrants = bundles.flatMap((b) => b.grants);
+    expect(
+      allGrants.find((g) => g.type === 'feature' && g.feature.id === 'cleric-divine-order-protector')
+    ).toBeUndefined();
+    expect(
+      allGrants.find((g) => g.type === 'feature' && g.feature.id === 'cleric-divine-order-thaumaturge')
+    ).toBeUndefined();
+    expect(warnings).toHaveLength(0);
+  });
+
+  it('feature-choice: warns when the decision references an unknown option id', () => {
+    const featureKey = createChoiceKey('feature-choice', 'class', 'cleric', 0);
+    const build: CharacterBuild = {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'acolyte' as BackgroundId,
+      baseAbilities: { str: 13, dex: 10, con: 14, int: 8, wis: 15, cha: 12 },
+      abilityMethod: 'standard-array',
+      levels: [{ classId: 'cleric' as ClassId, classLevel: 1, hpRoll: null }],
+      choices: {
+        [featureKey]: { type: 'feature-choice' as const, optionId: 'unknown-option' },
+      },
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles, warnings } = collectBundles(build);
+    const allGrants = bundles.flatMap((b) => b.grants);
+    expect(
+      allGrants.find((g) => g.type === 'feature' && g.feature.id === 'cleric-divine-order-protector')
+    ).toBeUndefined();
+    expect(warnings.some((w) => w.includes('unknown-option'))).toBe(true);
+  });
+
   it('damage-choice: ignores decisions for damage types outside the grant.from list', () => {
     const subclassKey = createChoiceKey('subclass', 'class', 'barbarian', 0);
     const damageKey = createChoiceKey('damage-choice', 'class', 'barbarian', 0);

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -216,9 +216,7 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
     }
   }
 
-  // Feature-choice grants — expand the chosen option's grants (plus a feature grant
-  // for the variant id) into the source bundle. Unresolved grants surface in the
-  // resolver as a `feature-choice` pending choice.
+  // Feature-choice grants
   const allFeatureChoiceGrants: { grant: FeatureChoiceGrant; source: SourceTag }[] = [];
   for (const bundle of bundles) {
     for (const grant of bundle.grants) {
@@ -231,7 +229,7 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
   for (const { grant, source } of allFeatureChoiceGrants) {
     const decision = build.choices[grant.key];
     if (decision?.type === 'feature-choice') {
-      const option = grant.options.find((o) => o.id === decision.optionId);
+      const option = grant.options.find((o) => o.optionId === decision.optionId);
       if (option) {
         bundles.push({
           source,

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -227,6 +227,15 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
   }
 
   for (const { grant, source } of allFeatureChoiceGrants) {
+    // Today only ClassStep dispatches feature-choice pending choices through the builder UI.
+    // A non-class origin would silently strand the user on an undisplayable pending choice;
+    // surface as a warning so the CharacterBuilder amber banner shows it instead of failing silently.
+    if (source.origin !== 'class') {
+      const msg = `feature-choice "${grant.key}" has non-class origin "${source.origin}" — no builder UI exists for this origin, choice will be invisible`;
+      warnings.push(msg);
+      logger.warn(msg);
+    }
+
     const decision = build.choices[grant.key];
     if (decision?.type === 'feature-choice') {
       const option = grant.options.find((o) => o.optionId === decision.optionId);

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -18,6 +18,7 @@ import type {
   FightingStyleChoiceGrant,
   LineageChoiceGrant,
   DamageTypeChoiceGrant,
+  FeatureChoiceGrant,
 } from '@/types/grants';
 import type { CharacterBuild } from '@/types/choices';
 import { SPECIES_SOURCES, LINEAGE_GRANTS_REGISTRY } from '@/lib/sources/species';
@@ -211,6 +212,35 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
           source,
           grants: [{ type: 'feature', feature: { id: `${grant.featureIdPrefix}-${damageType}` } }],
         });
+      }
+    }
+  }
+
+  // Feature-choice grants — expand the chosen option's grants (plus a feature grant
+  // for the variant id) into the source bundle. Unresolved grants surface in the
+  // resolver as a `feature-choice` pending choice.
+  const allFeatureChoiceGrants: { grant: FeatureChoiceGrant; source: SourceTag }[] = [];
+  for (const bundle of bundles) {
+    for (const grant of bundle.grants) {
+      if (grant.type === 'feature-choice') {
+        allFeatureChoiceGrants.push({ grant: grant as FeatureChoiceGrant, source: bundle.source });
+      }
+    }
+  }
+
+  for (const { grant, source } of allFeatureChoiceGrants) {
+    const decision = build.choices[grant.key];
+    if (decision?.type === 'feature-choice') {
+      const option = grant.options.find((o) => o.id === decision.optionId);
+      if (option) {
+        bundles.push({
+          source,
+          grants: [{ type: 'feature', feature: { id: option.featureId } }, ...option.grants],
+        });
+      } else {
+        const msg = `feature-choice "${grant.key}" decision references unknown option "${decision.optionId}"`;
+        warnings.push(msg);
+        logger.warn(msg);
       }
     }
   }

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -520,14 +520,14 @@ describe('getSubclassSource — Life Domain', () => {
     );
   });
 
-  it('lifedomain level 6 grants blessed-strikes feature', () => {
+  it('lifedomain level 6 grants the Blessed Healer feature (not Blessed Strikes; 2024 PHB)', () => {
     const source = getSubclassSource('lifedomain');
     const level6 = source?.features.find((f) => f.classLevel === 6);
     expect(level6).toBeDefined();
     expect(level6?.grants).toHaveLength(1);
     expect(level6?.grants[0]).toMatchObject({
       type: 'feature',
-      feature: { id: 'lifedomain-blessed-strikes' },
+      feature: { id: 'lifedomain-blessed-healer' },
     });
   });
 });

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -207,11 +207,7 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       },
       {
         classLevel: 6,
-        // Blessed Strikes: once per turn, a weapon or cantrip hit deals +1d8 necrotic or radiant damage
-        // Per 2024 PHB, Blessed Strikes is the canonical Life Domain L6 feature.
-        // NOTE: The 2024 PHB class table also lists Blessed Strikes as a class-wide Cleric feature at L7
-        // in some printings; this implementation treats the domain entry as authoritative for Life Domain.
-        grants: [{ type: 'feature', feature: { id: 'lifedomain-blessed-strikes' } }],
+        grants: [{ type: 'feature', feature: { id: 'lifedomain-blessed-healer' } }],
       },
     ] satisfies readonly SubclassFeature[],
   },

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -158,6 +158,7 @@
       "weaponMasteryChoice": "Choose {{count}} weapon mastery",
       "damageChoice": "Choose {{count}} damage type(s)",
       "lineageChoice": "Choose your lineage",
+      "featureChoice": "Choose an option",
       "unsupported": "Choice not yet supported: {{type}}",
       "remaining": "remaining",
       "fromSource": "from {{source}}"

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1071,25 +1071,29 @@
       "name": "Epic Boon",
       "description": "You gain an Epic Boon feat or another feat of your choice."
     },
-    "cleric-divine-order": {
-      "name": "Divine Order",
-      "description": "You have dedicated yourself to one of two divine orders: Protector or Thaumaturge."
+    "cleric-divine-order-protector": {
+      "name": "Divine Order: Protector",
+      "description": "Trained for battle, you gain proficiency with Martial weapons and training with Heavy armor."
+    },
+    "cleric-divine-order-thaumaturge": {
+      "name": "Divine Order: Thaumaturge",
+      "description": "You know one extra Cleric cantrip of your choice, and your mystical connection grants you a bonus to Intelligence (Arcana) and Intelligence (Religion) checks equal to your Wisdom modifier (minimum +1)."
     },
     "cleric-channel-divinity": {
       "name": "Channel Divinity",
       "description": "You gain the ability to channel divine energy directly from your deity, using that energy to fuel magical effects."
     },
-    "cleric-holy-order": {
-      "name": "Holy Order",
-      "description": "You gain one of the following options of your choice: Protector, Thaumaturge, or War Priest."
-    },
     "cleric-smite-undead": {
       "name": "Smite Undead",
       "description": "You can cause your Turn Undead feature to smite the undead. When you use Turn Undead, you can expend a spell slot to deal Radiant damage to undead that fail their saving throws."
     },
-    "cleric-blessed-strikes": {
-      "name": "Blessed Strikes",
-      "description": "Divine power infuses you in battle. When you deal damage to a creature, you can also deal 1d8 Radiant damage to that creature."
+    "cleric-blessed-strikes-divine-strike": {
+      "name": "Blessed Strikes: Divine Strike",
+      "description": "Once on each of your turns when you hit a creature with an attack roll using a weapon, you can cause the target to take an extra 1d8 Necrotic or Radiant damage (your choice)."
+    },
+    "cleric-blessed-strikes-potent-spellcasting": {
+      "name": "Blessed Strikes: Potent Spellcasting",
+      "description": "Add your Wisdom modifier to the damage you deal with any Cleric cantrip."
     },
     "cleric-divine-intervention": {
       "name": "Divine Intervention",

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1119,9 +1119,9 @@
       "name": "Preserve Life",
       "description": "As a Magic action, you present your holy symbol and evoke healing energy that can restore a number of Hit Points equal to five times your Cleric level. Choose any creatures within 30 feet of you, and divide those Hit Points among them. This feature can restore a creature to no more than half its Hit Point maximum. You can use this feature a number of times equal to your Wisdom modifier (minimum once), and you regain all expended uses when you finish a Long Rest."
     },
-    "lifedomain-blessed-strikes": {
-      "name": "Blessed Strikes (Life Domain)",
-      "description": "Divine power infuses you in battle. Once on each of your turns when you hit a creature with a weapon attack or deal damage to a creature with a Cleric cantrip, you can deal extra 1d8 Necrotic or Radiant damage (your choice) to that creature."
+    "lifedomain-blessed-healer": {
+      "name": "Blessed Healer",
+      "description": "The healing spells you cast on others heal you as well. When you cast a spell with a spell slot of 1st level or higher that restores Hit Points to a creature other than you, you regain Hit Points equal to 2 + the spell's level."
     },
     "lightdomain-domain-spells": {
       "name": "Light Domain Spells",

--- a/src/pages/CharacterBuilder.tsx
+++ b/src/pages/CharacterBuilder.tsx
@@ -125,7 +125,7 @@ function CharacterBuilderInner() {
   const { saveStatus, saveDraft, finalize, clearStatus, abandon, markSaveError } = useBuilderAutosave();
 
   const context = useCharacterContext();
-  const { character, rows, resolved, buildError, isDirty, markSaved } = context;
+  const { character, rows, resolved, buildError, buildWarnings, isDirty, markSaved } = context;
 
   usePageTitle(t('characterBuilder.title'));
 
@@ -323,6 +323,12 @@ function CharacterBuilderInner() {
         {buildError && (
           <div className="mb-4 p-4 bg-destructive/10 border border-destructive/50 rounded-lg text-destructive text-sm">
             {t('characterSheet.errors.buildFailed', { message: buildError })}
+          </div>
+        )}
+
+        {buildWarnings.length > 0 && (
+          <div className="mb-4 p-4 bg-amber-50/50 dark:bg-amber-950/20 border border-amber-500/40 rounded-lg text-amber-700 dark:text-amber-400 text-sm">
+            {t('characterSheet.warnings.buildIncomplete', { message: buildWarnings.join('; ') })}
           </div>
         )}
 

--- a/src/types/choices.ts
+++ b/src/types/choices.ts
@@ -35,6 +35,7 @@ const CHOICE_CATEGORIES = [
   'damage-choice',
   'bundle-choice',
   'lineage-choice',
+  'feature-choice',
 ] as const;
 export type ChoiceCategory = (typeof CHOICE_CATEGORIES)[number];
 
@@ -100,7 +101,8 @@ export type ChoiceDecision =
       /** Map of slotKey → chosen itemId. Empty object when the bundle has no slots. */
       readonly slotPicks: Readonly<Record<string, string>>;
     }
-  | { readonly type: 'lineage-choice'; readonly lineageId: string };
+  | { readonly type: 'lineage-choice'; readonly lineageId: string }
+  | { readonly type: 'feature-choice'; readonly optionId: string };
 
 export interface BuildLevel {
   readonly classId: ClassId;

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -239,31 +239,17 @@ export interface BundleChoiceGrant {
   readonly bundleIds: readonly string[];
 }
 
-/**
- * One branch of a {@link FeatureChoiceGrant}. When the player selects this option,
- * a `feature` grant for `featureId` is added (so it appears on the character sheet)
- * plus every grant in `grants` is inlined into the same source bundle.
- *
- * `id` is the persisted decision discriminator and must be unique within its parent
- * grant. `featureId` doubles as the i18n key (`features.${featureId}.name` /
- * `.description`), so each option needs an entry in `gamedata.json`.
- */
+/** `featureId` must have matching `features.${featureId}.name`/`.description` keys in gamedata.json. */
 export interface FeatureChoiceOption {
-  readonly id: string;
+  readonly optionId: string;
   readonly featureId: string;
   readonly grants: readonly Grant[];
 }
 
-/**
- * Player picks exactly one of several class-feature variants (e.g. Cleric L1
- * Divine Order → Protector / Thaumaturge). The chosen option's `grants` are
- * inlined into the source bundle by `collectBundles`; unresolved grants surface
- * as a `feature-choice` pending choice.
- */
 export interface FeatureChoiceGrant {
   readonly type: 'feature-choice';
   readonly key: ChoiceKey;
-  readonly options: readonly FeatureChoiceOption[];
+  readonly options: readonly [FeatureChoiceOption, ...FeatureChoiceOption[]];
 }
 
 export interface LineageChoiceGrant {

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -239,6 +239,33 @@ export interface BundleChoiceGrant {
   readonly bundleIds: readonly string[];
 }
 
+/**
+ * One branch of a {@link FeatureChoiceGrant}. When the player selects this option,
+ * a `feature` grant for `featureId` is added (so it appears on the character sheet)
+ * plus every grant in `grants` is inlined into the same source bundle.
+ *
+ * `id` is the persisted decision discriminator and must be unique within its parent
+ * grant. `featureId` doubles as the i18n key (`features.${featureId}.name` /
+ * `.description`), so each option needs an entry in `gamedata.json`.
+ */
+export interface FeatureChoiceOption {
+  readonly id: string;
+  readonly featureId: string;
+  readonly grants: readonly Grant[];
+}
+
+/**
+ * Player picks exactly one of several class-feature variants (e.g. Cleric L1
+ * Divine Order → Protector / Thaumaturge). The chosen option's `grants` are
+ * inlined into the source bundle by `collectBundles`; unresolved grants surface
+ * as a `feature-choice` pending choice.
+ */
+export interface FeatureChoiceGrant {
+  readonly type: 'feature-choice';
+  readonly key: ChoiceKey;
+  readonly options: readonly FeatureChoiceOption[];
+}
+
 export interface LineageChoiceGrant {
   readonly type: 'lineage-choice';
   readonly key: ChoiceKey;
@@ -271,4 +298,5 @@ export type Grant =
   | EquipmentGrant
   | BundleChoiceGrant
   | LineageChoiceGrant
+  | FeatureChoiceGrant
   | FeatGrant;

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -198,6 +198,12 @@ export type PendingChoice =
       readonly source: SourceTag;
       readonly speciesId: SpeciesId;
       readonly from: readonly string[];
+    }
+  | {
+      readonly type: 'feature-choice';
+      readonly choiceKey: ChoiceKey;
+      readonly source: SourceTag;
+      readonly options: readonly { readonly id: string; readonly featureId: string }[];
     };
 
 export interface ResolvedCharacter {

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -203,7 +203,10 @@ export type PendingChoice =
       readonly type: 'feature-choice';
       readonly choiceKey: ChoiceKey;
       readonly source: SourceTag;
-      readonly options: readonly { readonly id: string; readonly featureId: string }[];
+      readonly options: readonly [
+        { readonly optionId: string; readonly featureId: string },
+        ...{ readonly optionId: string; readonly featureId: string }[],
+      ];
     };
 
 export interface ResolvedCharacter {


### PR DESCRIPTION
Addresses parts of #142 with a new generic choice-grant primitive.

## Summary

- New `FeatureChoiceGrant` grant type lets a player pick exactly one of several class-feature variants during character creation / level-up. The chosen option carries its own bundle of grants (proficiencies, features, etc.) that get inlined into the source bundle.
- Cleric L1 **Divine Order** (Protector / Thaumaturge) is now a real mechanical choice.
- Cleric L7 **Blessed Strikes** (Divine Strike / Potent Spellcasting) is now a real mechanical choice.
- Removed the fabricated L2 `cleric-holy-order` feature (not in the 2024 PHB; its option set collided with Divine Order at L1).

## End-to-end pipeline changes

- `src/types/grants.ts` — `FeatureChoiceGrant` + `FeatureChoiceOption`, added to `Grant` union
- `src/types/choices.ts` — `'feature-choice'` added to `CHOICE_CATEGORIES` + decision variant
- `src/types/resolved.ts` — `PendingChoice` variant
- `src/lib/sources/index.ts` — `collectBundles` expands the chosen option's grants into a new bundle
- `src/lib/resolver/index.ts` — emits pending feature-choices for unresolved/invalid decisions
- `src/lib/schemas/character-build.ts` — Zod discriminator for DB serialization roundtrip
- `src/components/character-builder/ChoicePicker.tsx` — radio-list UI branch with rich descriptions
- `src/components/character-builder/ClassStep.tsx` — dispatch class-origin feature-choices through ChoicePicker
- `src/components/character-sheet/PendingChoicesPanel.tsx` — synthesize feature-choice grants for the post-finalize sheet
- `src/lib/sources/classes.ts` — Cleric L1 and L7 converted; L2 Holy Order removed
- `src/locales/en/gamedata.json` — variant entries (`cleric-divine-order-protector`, `-thaumaturge`, `cleric-blessed-strikes-divine-strike`, `-potent-spellcasting`); legacy keys removed
- `src/locales/en/common.json` — `pendingChoices.featureChoice` prompt string

## Mechanical encoding status

Only Protector currently expands to real grants (martial weapons + heavy armor proficiencies). The other three options are inert features pending separate infrastructure:

| Option | Status | Blocked on |
|---|---|---|
| Divine Order: Protector | ✅ Real grants | — |
| Divine Order: Thaumaturge | Inert | Cantrip-grant system; `AbilityCheckBonusGrant` extension for Wis-mod bonuses |
| Blessed Strikes: Divine Strike | Inert | On-hit weapon damage rider |
| Blessed Strikes: Potent Spellcasting | Inert | Cantrip-damage modifier |

The infrastructure win is that the choice gets recorded, surfaces in the builder, and the variant feature appears on the sheet.

## Out of scope

- Gap 1 (domain spells) and Gap 2 (Light cantrip) from #142 — still blocked on #161 (always-prepared spell rendering) and a separate cantrip-grant design.
- Other 2024 PHB compliance issues found while verifying #142 (L5 Sear Undead naming, L14 Improved Blessed Strikes, L19 Epic Boon → Epic Boon choice, Life Domain L6 should be Blessed Healer not Blessed Strikes). To be filed as follow-up issues.

## Test plan

- [x] `npm run typecheck` — 0 errors
- [x] `npm run test` — 1564 passed (+17 new across `classes.test.ts`, `sources/index.test.ts`, `resolver/index.test.ts`, `ChoicePicker.test.tsx`)
- [x] `npm run build` — clean
- [x] Browser smoke test: created a Random Cleric NPC → Divine Order choice rendered with Protector/Thaumaturge options + descriptions → clicked Protector → variant feature appeared in Class Features section, no pending choice left

Refs #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)