### PR TITLE
fix(monk): correct 2024 PHB warrior placements + add ResourcePoolGrant/saveDC infra (#148)

### DIFF
--- a/src/components/character-sheet/ProficienciesPanel.test.tsx
+++ b/src/components/character-sheet/ProficienciesPanel.test.tsx
@@ -37,6 +37,7 @@ function buildMinimalResolved(overrides: Partial<ResolvedCharacter> = {}): Resol
     bardicInspiration: null,
     pendingChoices: [],
     weaponMasteries: [],
+    resourcePools: [],
     ...overrides,
   };
 }

--- a/src/lib/resolver/features.test.ts
+++ b/src/lib/resolver/features.test.ts
@@ -39,6 +39,29 @@ describe('resolveFeatures saveDC', () => {
     expect(features[0].saveDC).toBe(8 + 3 + 4);
   });
 
+  it('uses the declared dcAbility (cha) — not a hard-coded wis lookup', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'subclass', id: 'warriorofmercy', classId: 'monk', level: 6 },
+        grants: [
+          {
+            type: 'feature',
+            feature: { id: 'some-cha-feature', saveDC: { dcAbility: 'cha' } },
+          },
+        ],
+      },
+    ];
+    // CHA mod = +3, PB = 2 → DC = 8 + 2 + 3 = 13
+    const features = resolveFeatures(bundles, abilityMap({ cha: 3 }), 2);
+    expect(features[0].saveDC).toBe(13);
+  });
+
+  it('computes saveDC correctly with a negative ability modifier', () => {
+    // WIS mod = -1, PB = 2 → DC = 8 + 2 + (-1) = 9
+    const features = resolveFeatures(monkLevel5, abilityMap({ wis: -1 }), 2);
+    expect(features[0].saveDC).toBe(9);
+  });
+
   it('omits saveDC for features that do not declare one', () => {
     const bundles: GrantBundle[] = [
       {

--- a/src/lib/resolver/features.test.ts
+++ b/src/lib/resolver/features.test.ts
@@ -49,9 +49,4 @@ describe('resolveFeatures saveDC', () => {
     const features = resolveFeatures(bundles, abilityMap({ wis: 4 }), 3);
     expect(features[0].saveDC).toBeUndefined();
   });
-
-  it('omits saveDC when ability data is not provided', () => {
-    const features = resolveFeatures(monkLevel5);
-    expect(features[0].saveDC).toBeUndefined();
-  });
 });

--- a/src/lib/resolver/features.test.ts
+++ b/src/lib/resolver/features.test.ts
@@ -1,0 +1,57 @@
+import { describe, it, expect } from 'vitest';
+import type { GrantBundle } from '@/types/sources';
+import type { ResolvedAbility } from '@/types/resolved';
+import type { AbilityKey } from '@/lib/dnd-helpers';
+import { resolveFeatures } from '@/lib/resolver/features';
+
+function abilityMap(modifiers: Partial<Record<AbilityKey, number>>): Readonly<Record<AbilityKey, ResolvedAbility>> {
+  const make = (mod: number): ResolvedAbility => ({
+    base: 10 + mod * 2,
+    bonuses: [],
+    total: 10 + mod * 2,
+    modifier: mod,
+  });
+  return {
+    str: make(modifiers.str ?? 0),
+    dex: make(modifiers.dex ?? 0),
+    con: make(modifiers.con ?? 0),
+    int: make(modifiers.int ?? 0),
+    wis: make(modifiers.wis ?? 0),
+    cha: make(modifiers.cha ?? 0),
+  };
+}
+
+describe('resolveFeatures saveDC', () => {
+  const monkLevel5: GrantBundle[] = [
+    {
+      source: { origin: 'subclass', id: 'warriorofelements', classId: 'monk', level: 6 },
+      grants: [
+        {
+          type: 'feature',
+          feature: { id: 'warriorofelements-elemental-burst', saveDC: { dcAbility: 'wis' } },
+        },
+      ],
+    },
+  ];
+
+  it('computes saveDC as 8 + PB + ability modifier when feature declares saveDC', () => {
+    const features = resolveFeatures(monkLevel5, abilityMap({ wis: 4 }), 3);
+    expect(features[0].saveDC).toBe(8 + 3 + 4);
+  });
+
+  it('omits saveDC for features that do not declare one', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'monk', level: 1 },
+        grants: [{ type: 'feature', feature: { id: 'monk-martial-arts' } }],
+      },
+    ];
+    const features = resolveFeatures(bundles, abilityMap({ wis: 4 }), 3);
+    expect(features[0].saveDC).toBeUndefined();
+  });
+
+  it('omits saveDC when ability data is not provided', () => {
+    const features = resolveFeatures(monkLevel5);
+    expect(features[0].saveDC).toBeUndefined();
+  });
+});

--- a/src/lib/resolver/features.ts
+++ b/src/lib/resolver/features.ts
@@ -5,12 +5,12 @@ import { collectGrantsByType } from '@/lib/resolver/helpers';
 
 export function resolveFeatures(
   bundles: readonly GrantBundle[],
-  abilities?: Readonly<Record<AbilityKey, ResolvedAbility>>,
-  proficiencyBonus?: number
+  abilities: Readonly<Record<AbilityKey, ResolvedAbility>>,
+  proficiencyBonus: number
 ): readonly ResolvedFeature[] {
   return collectGrantsByType(bundles, 'feature').map(({ grant, source }) => {
     const { feature } = grant;
-    if (feature.saveDC && abilities && proficiencyBonus !== undefined) {
+    if (feature.saveDC) {
       return {
         feature,
         source,

--- a/src/lib/resolver/features.ts
+++ b/src/lib/resolver/features.ts
@@ -1,10 +1,22 @@
 import type { GrantBundle } from '@/types/sources';
-import type { ResolvedFeature } from '@/types/resolved';
+import type { ResolvedAbility, ResolvedFeature } from '@/types/resolved';
+import type { AbilityKey } from '@/lib/dnd-helpers';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
 
-export function resolveFeatures(bundles: readonly GrantBundle[]): readonly ResolvedFeature[] {
-  return collectGrantsByType(bundles, 'feature').map(({ grant, source }) => ({
-    feature: grant.feature,
-    source,
-  }));
+export function resolveFeatures(
+  bundles: readonly GrantBundle[],
+  abilities?: Readonly<Record<AbilityKey, ResolvedAbility>>,
+  proficiencyBonus?: number
+): readonly ResolvedFeature[] {
+  return collectGrantsByType(bundles, 'feature').map(({ grant, source }) => {
+    const { feature } = grant;
+    if (feature.saveDC && abilities && proficiencyBonus !== undefined) {
+      return {
+        feature,
+        source,
+        saveDC: 8 + proficiencyBonus + abilities[feature.saveDC.dcAbility].modifier,
+      };
+    }
+    return { feature, source };
+  });
 }

--- a/src/lib/resolver/helpers.ts
+++ b/src/lib/resolver/helpers.ts
@@ -1,10 +1,16 @@
 import type { Grant } from '@/types/grants';
 import type { GrantBundle, SourceTag } from '@/types/sources';
+import type { ClassId } from '@/lib/dnd-helpers';
 
 export type TaggedGrant<G extends Grant> = {
   readonly grant: G;
   readonly source: SourceTag;
 };
+
+// Counts class-origin bundles; relies on collectBundles emitting one per class level.
+export function getClassLevel(bundles: readonly GrantBundle[], classId: ClassId): number {
+  return bundles.filter((b) => b.source.origin === 'class' && b.source.id === classId).length;
+}
 
 type GrantByType = { [G in Grant as G['type']]: G };
 

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -2185,3 +2185,57 @@ describe('Cleric feature-choice integration (Divine Order)', () => {
     expect(featureIds).not.toContain('cleric-divine-order-thaumaturge');
   });
 });
+
+describe('Monk L6 + Warrior of Mercy integration', () => {
+  const subclassKey = createChoiceKey('subclass', 'class', 'monk', 0);
+  const asiKey = createChoiceKey('asi', 'class', 'monk', 0);
+
+  // WIS 16 → mod +3; PB at L6 = 3; physicians-touch DC = 8 + 3 + 3 = 14
+  const monkL6Build: CharacterBuild = {
+    speciesId: 'human',
+    backgroundId: null,
+    baseAbilities: { str: 10, dex: 16, con: 12, int: 10, wis: 16, cha: 10 },
+    abilityMethod: 'standard-array',
+    levels: [
+      { classId: 'monk' as ClassId, classLevel: 1, hpRoll: null },
+      { classId: 'monk' as ClassId, classLevel: 2, hpRoll: 5 },
+      { classId: 'monk' as ClassId, classLevel: 3, hpRoll: 5 },
+      { classId: 'monk' as ClassId, classLevel: 4, hpRoll: 5 },
+      { classId: 'monk' as ClassId, classLevel: 5, hpRoll: 5 },
+      { classId: 'monk' as ClassId, classLevel: 6, hpRoll: 5 },
+    ],
+    choices: {
+      'skill-choice:class:monk:0': { type: 'skill-choice', skills: ['acrobatics', 'history'] },
+      'language-choice:species:human:0': { type: 'language-choice', languages: ['elvish'] },
+      [subclassKey]: { type: 'subclass' as const, subclassId: 'warriorofmercy' as SubclassId },
+      [asiKey]: { type: 'asi' as const, allocation: { dex: 2 } },
+    } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    feats: [],
+    activeItems: [],
+  };
+
+  const { bundles } = collectBundles(monkL6Build);
+  const input: ResolverInput = {
+    baseAbilities: monkL6Build.baseAbilities,
+    level: 6,
+    bundles,
+    choices: monkL6Build.choices,
+    levels: monkL6Build.levels,
+  };
+
+  it('resourcePools contains exactly one focus-points entry with max=6 and regen=short-rest', () => {
+    const result = resolveCharacter(input);
+    const focusPool = result.resourcePools.filter((p) => p.poolId === 'focus-points');
+    expect(focusPool).toHaveLength(1);
+    expect(focusPool[0].max).toBe(6);
+    expect(focusPool[0].regen).toBe('short-rest');
+  });
+
+  it('features contains warriorofmercy-physicians-touch with saveDC = 8 + PB(3) + wisMod(3) = 14', () => {
+    const result = resolveCharacter(input);
+    const physicians = result.features.find((f) => f.feature.id === 'warriorofmercy-physicians-touch');
+    expect(physicians).toBeDefined();
+    // WIS 16 → mod +3; PB at L6 = 3; DC = 8 + 3 + 3 = 14
+    expect(physicians!.saveDC).toBe(14);
+  });
+});

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -18,6 +18,7 @@ import { resolveFeatures } from '@/lib/resolver/features';
 import { resolveHp, resolveSpeed, resolveAc, resolveBardicInspiration } from '@/lib/resolver/combat';
 import { resolveSpellcasting } from '@/lib/resolver/spellcasting';
 import { resolveEquipment, resolveAttacks, resolveEquippedArmorAc } from '@/lib/resolver/equipment';
+import { resolveResourcePools } from '@/lib/resolver/resource-pools';
 import { getItemDef, WEAPON_CATALOG } from '@/lib/sources/items';
 
 export interface PersistedItem {
@@ -64,7 +65,7 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
   const savingThrows = resolveSavingThrows(abilities, bundles, proficiencyBonus);
   const skills = resolveSkills(abilities, bundles, proficiencyBonus, choices);
   const proficiencies = resolveProficiencies(bundles, choices);
-  const features = resolveFeatures(bundles);
+  const features = resolveFeatures(bundles, abilities, proficiencyBonus);
   const hitPoints = resolveHp(bundles, hpRolls, conModifier, level);
   const speed = resolveSpeed(bundles);
   const spellcasting = resolveSpellcasting(bundles, abilities, proficiencyBonus, level);
@@ -382,6 +383,7 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
     bardicInspiration,
     pendingChoices,
     weaponMasteries,
+    resourcePools: resolveResourcePools(bundles),
   };
 }
 

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -11,7 +11,7 @@ import type { ResolvedCharacter, PendingChoice, ResolvedSkill } from '@/types/re
 import type { HitDie, ExpertiseChoiceGrant } from '@/types/grants';
 import { mapNonEmpty } from '@/lib/non-empty';
 import type { WeaponMasteryId } from '@/types/items';
-import { collectGrantsByType } from '@/lib/resolver/helpers';
+import { collectGrantsByType, getClassLevel } from '@/lib/resolver/helpers';
 import { resolveAbilities } from '@/lib/resolver/abilities';
 import { resolveSavingThrows, resolveSkills, resolveProficiencies } from '@/lib/resolver/proficiencies';
 import { resolveFeatures } from '@/lib/resolver/features';
@@ -76,8 +76,7 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
       ? resolveEquipmentFromPersisted(input.persistedItems)
       : resolveEquipment(bundles, choices, equippedItemIds);
   const equippedArmorAc = resolveEquippedArmorAc(equipmentResult.items, dexModifier);
-  const BARD_CLASS_ID = 'bard' satisfies ClassId;
-  const bardLevel = bundles.filter((b) => b.source.origin === 'class' && b.source.id === BARD_CLASS_ID).length;
+  const bardLevel = getClassLevel(bundles, 'bard' satisfies ClassId);
   const chaModifier = abilities.cha.modifier;
   const bardicInspiration = resolveBardicInspiration(bundles, bardLevel, chaModifier);
   const bardicDieSize = bardicInspiration?.dieSize ?? null;

--- a/src/lib/resolver/materialize.test.ts
+++ b/src/lib/resolver/materialize.test.ts
@@ -44,6 +44,7 @@ function makeResolved(equipment: readonly ResolvedEquipmentItem[]): ResolvedChar
     bardicInspiration: null,
     pendingChoices: [],
     weaponMasteries: [],
+    resourcePools: [],
   };
 }
 

--- a/src/lib/resolver/proficiencies.test.ts
+++ b/src/lib/resolver/proficiencies.test.ts
@@ -315,6 +315,42 @@ describe('resolveSkills', () => {
     });
   });
 
+  it('insight is proficient via Implements of Mercy alone when player picks two non-insight skills at L1', () => {
+    // Same bundle setup as the de-dupe test, but choices pick acrobatics + history (not insight)
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'monk', level: 1 },
+        grants: [
+          {
+            type: 'proficiency-choice',
+            category: 'skill',
+            key: 'skill-choice:class:monk:0',
+            count: 2,
+            from: ['acrobatics', 'athletics', 'history', 'insight', 'religion', 'stealth'],
+          },
+        ],
+      },
+      {
+        source: { origin: 'subclass', id: 'warriorofmercy', classId: 'monk', level: 3 },
+        grants: [
+          { type: 'proficiency', category: 'skill', id: 'insight' },
+          { type: 'proficiency', category: 'skill', id: 'medicine' },
+        ],
+      },
+    ];
+    const choices: Readonly<Record<ChoiceKey, ChoiceDecision>> = {
+      'skill-choice:class:monk:0': { type: 'skill-choice', skills: ['acrobatics', 'history'] },
+    };
+    const result = resolveSkills(ZERO_ABILITIES, bundles, 2, choices);
+
+    // insight comes solely from Implements of Mercy
+    expect(result.insight.proficient).toBe(true);
+    // ZERO_ABILITIES: modifier 0, so bonus === proficiencyBonus (2)
+    expect(result.insight.bonus).toBe(2);
+    // exactly one proficiency component in the breakdown
+    expect(result.insight.breakdown.filter((c) => c.type === 'proficiency')).toHaveLength(1);
+  });
+
   it('de-dupes insight when granted by both Monk L1 skill-choice and Warrior of Mercy L3 direct proficiency', () => {
     // Monk L1: skill-choice that can include insight
     // Warrior of Mercy L3: direct proficiency grant for insight (Implements of Mercy)

--- a/src/lib/resolver/proficiencies.test.ts
+++ b/src/lib/resolver/proficiencies.test.ts
@@ -314,6 +314,43 @@ describe('resolveSkills', () => {
       label: 'champion-remarkable-athlete',
     });
   });
+
+  it('de-dupes insight when granted by both Monk L1 skill-choice and Warrior of Mercy L3 direct proficiency', () => {
+    // Monk L1: skill-choice that can include insight
+    // Warrior of Mercy L3: direct proficiency grant for insight (Implements of Mercy)
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'monk', level: 1 },
+        grants: [
+          {
+            type: 'proficiency-choice',
+            category: 'skill',
+            key: 'skill-choice:class:monk:0',
+            count: 2,
+            from: ['acrobatics', 'athletics', 'history', 'insight', 'religion', 'stealth'],
+          },
+        ],
+      },
+      {
+        source: { origin: 'subclass', id: 'warriorofmercy', classId: 'monk', level: 3 },
+        grants: [
+          { type: 'proficiency', category: 'skill', id: 'insight' },
+          { type: 'proficiency', category: 'skill', id: 'medicine' },
+        ],
+      },
+    ];
+    const choices: Readonly<Record<ChoiceKey, ChoiceDecision>> = {
+      'skill-choice:class:monk:0': { type: 'skill-choice', skills: ['insight', 'history'] },
+    };
+    const result = resolveSkills(ZERO_ABILITIES, bundles, 2, choices);
+
+    // insight must be proficient
+    expect(result.insight.proficient).toBe(true);
+    // proficiency bonus applied exactly once (ZERO_ABILITIES → modifier 0, so bonus === proficiencyBonus)
+    expect(result.insight.bonus).toBe(2);
+    // breakdown has exactly one proficiency component — proves no double-counting
+    expect(result.insight.breakdown.filter((c) => c.type === 'proficiency')).toHaveLength(1);
+  });
 });
 
 describe('resolveProficiencies', () => {

--- a/src/lib/resolver/resource-pools.test.ts
+++ b/src/lib/resolver/resource-pools.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from 'vitest';
+import type { GrantBundle } from '@/types/sources';
+import { resolveResourcePools } from '@/lib/resolver/resource-pools';
+
+function classBundles(
+  classId: 'monk' | 'sorcerer',
+  count: number,
+  extraGrants: GrantBundle['grants'] = []
+): GrantBundle[] {
+  const bundles: GrantBundle[] = [];
+  for (let level = 1; level <= count; level++) {
+    bundles.push({
+      source: { origin: 'class', id: classId, level },
+      grants: level === 2 ? extraGrants : [],
+    });
+  }
+  return bundles;
+}
+
+describe('resolveResourcePools', () => {
+  it('returns empty when no resource-pool grants exist', () => {
+    expect(resolveResourcePools(classBundles('monk', 5))).toEqual([]);
+  });
+
+  it('computes class-level pool max equal to the count of class bundles', () => {
+    const bundles = classBundles('monk', 5, [
+      {
+        type: 'resource-pool',
+        poolId: 'focus-points',
+        max: { mode: 'class-level', classId: 'monk' },
+        regen: 'short-rest',
+      },
+    ]);
+    const pools = resolveResourcePools(bundles);
+    expect(pools).toHaveLength(1);
+    expect(pools[0]).toMatchObject({ poolId: 'focus-points', max: 5, regen: 'short-rest' });
+  });
+
+  it('uses fixed value when max mode is fixed', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'feat', id: 'magic-initiate-wizard' },
+        grants: [{ type: 'resource-pool', poolId: 'example', max: { mode: 'fixed', value: 3 }, regen: 'long-rest' }],
+      },
+    ];
+    const pools = resolveResourcePools(bundles);
+    expect(pools).toHaveLength(1);
+    expect(pools[0].max).toBe(3);
+    expect(pools[0].regen).toBe('long-rest');
+  });
+
+  it('counts only bundles for the named class when computing class-level max', () => {
+    const monkBundles = classBundles('monk', 3, [
+      {
+        type: 'resource-pool',
+        poolId: 'focus-points',
+        max: { mode: 'class-level', classId: 'monk' },
+        regen: 'short-rest',
+      },
+    ]);
+    const sorcererBundles = classBundles('sorcerer', 2);
+    const pools = resolveResourcePools([...monkBundles, ...sorcererBundles]);
+    expect(pools[0].max).toBe(3);
+  });
+
+  it('tags pool with its source bundle', () => {
+    const bundles = classBundles('monk', 4, [
+      {
+        type: 'resource-pool',
+        poolId: 'focus-points',
+        max: { mode: 'class-level', classId: 'monk' },
+        regen: 'short-rest',
+      },
+    ]);
+    const pools = resolveResourcePools(bundles);
+    expect(pools[0].source).toEqual({ origin: 'class', id: 'monk', level: 2 });
+  });
+});

--- a/src/lib/resolver/resource-pools.ts
+++ b/src/lib/resolver/resource-pools.ts
@@ -1,12 +1,25 @@
 import type { GrantBundle } from '@/types/sources';
 import type { ResolvedResourcePool } from '@/types/resolved';
 import { collectGrantsByType, getClassLevel } from '@/lib/resolver/helpers';
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('resolver');
 
 export function resolveResourcePools(bundles: readonly GrantBundle[]): readonly ResolvedResourcePool[] {
   const pools: ResolvedResourcePool[] = [];
   for (const { grant, source } of collectGrantsByType(bundles, 'resource-pool')) {
     const { max: maxSpec } = grant;
-    const max = maxSpec.mode === 'fixed' ? maxSpec.value : getClassLevel(bundles, maxSpec.classId);
+    let max: number;
+    if (maxSpec.mode === 'fixed') {
+      max = maxSpec.value;
+    } else {
+      max = getClassLevel(bundles, maxSpec.classId);
+      if (max === 0) {
+        logger.warn(
+          `resource-pool "${grant.poolId}" declares classId "${maxSpec.classId}" but no bundles for that class were found — max will be 0`
+        );
+      }
+    }
     pools.push({
       poolId: grant.poolId,
       max,

--- a/src/lib/resolver/resource-pools.ts
+++ b/src/lib/resolver/resource-pools.ts
@@ -1,15 +1,12 @@
 import type { GrantBundle } from '@/types/sources';
 import type { ResolvedResourcePool } from '@/types/resolved';
-import { collectGrantsByType } from '@/lib/resolver/helpers';
+import { collectGrantsByType, getClassLevel } from '@/lib/resolver/helpers';
 
 export function resolveResourcePools(bundles: readonly GrantBundle[]): readonly ResolvedResourcePool[] {
   const pools: ResolvedResourcePool[] = [];
   for (const { grant, source } of collectGrantsByType(bundles, 'resource-pool')) {
     const { max: maxSpec } = grant;
-    const max =
-      maxSpec.mode === 'fixed'
-        ? maxSpec.value
-        : bundles.filter((b) => b.source.origin === 'class' && b.source.id === maxSpec.classId).length;
+    const max = maxSpec.mode === 'fixed' ? maxSpec.value : getClassLevel(bundles, maxSpec.classId);
     pools.push({
       poolId: grant.poolId,
       max,

--- a/src/lib/resolver/resource-pools.ts
+++ b/src/lib/resolver/resource-pools.ts
@@ -1,0 +1,21 @@
+import type { GrantBundle } from '@/types/sources';
+import type { ResolvedResourcePool } from '@/types/resolved';
+import { collectGrantsByType } from '@/lib/resolver/helpers';
+
+export function resolveResourcePools(bundles: readonly GrantBundle[]): readonly ResolvedResourcePool[] {
+  const pools: ResolvedResourcePool[] = [];
+  for (const { grant, source } of collectGrantsByType(bundles, 'resource-pool')) {
+    const { max: maxSpec } = grant;
+    const max =
+      maxSpec.mode === 'fixed'
+        ? maxSpec.value
+        : bundles.filter((b) => b.source.origin === 'class' && b.source.id === maxSpec.classId).length;
+    pools.push({
+      poolId: grant.poolId,
+      max,
+      regen: grant.regen,
+      source,
+    });
+  }
+  return pools;
+}

--- a/src/lib/sources/classes.test.ts
+++ b/src/lib/sources/classes.test.ts
@@ -680,6 +680,19 @@ describe('Monk class grant structures', () => {
     expect(featureIds).toContain('monk-focus-points');
   });
 
+  it('level 2 has resource-pool grant for focus-points', () => {
+    const grant = source?.levels[1].grants.find((g) => g.type === 'resource-pool');
+    expect(grant).toBeDefined();
+    if (grant?.type === 'resource-pool') {
+      expect(grant.poolId).toBe('focus-points');
+      expect(grant.max.mode).toBe('class-level');
+      if (grant.max.mode === 'class-level') {
+        expect(grant.max.classId).toBe('monk');
+      }
+      expect(grant.regen).toBe('short-rest');
+    }
+  });
+
   it('level 3 has subclass grant and deflect-attacks feature', () => {
     const grants = source?.levels[2].grants ?? [];
     expect(grants.find((g) => g.type === 'subclass')).toBeDefined();

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -531,6 +531,12 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       {
         grants: [
           { type: 'feature', feature: { id: 'monk-focus-points' } },
+          {
+            type: 'resource-pool',
+            poolId: 'focus-points',
+            max: { mode: 'class-level', classId: 'monk' },
+            regen: 'short-rest',
+          },
           { type: 'feature', feature: { id: 'monk-unarmored-movement' } },
           { type: 'feature', feature: { id: 'monk-uncanny-metabolism' } },
         ],

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -963,7 +963,6 @@ describe('getSubclassSource — Warrior of Mercy', () => {
     const source = getSubclassSource('warriorofmercy');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
-    expect(level3?.grants).toHaveLength(6);
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -992,7 +991,7 @@ describe('getSubclassSource — Warrior of Mercy', () => {
     expect(level6?.grants).toHaveLength(1);
     expect(level6?.grants[0]).toMatchObject({
       type: 'feature',
-      feature: { id: 'warriorofmercy-physicians-touch' },
+      feature: { id: 'warriorofmercy-physicians-touch', saveDC: { dcAbility: 'wis' } },
     });
   });
 });
@@ -1068,7 +1067,7 @@ describe('getSubclassSource — Warrior of the Elements', () => {
     expect(level6?.grants).toHaveLength(1);
     expect(level6?.grants[0]).toMatchObject({
       type: 'feature',
-      feature: { id: 'warriorofelements-elemental-burst' },
+      feature: { id: 'warriorofelements-elemental-burst', saveDC: { dcAbility: 'wis' } },
     });
   });
 });
@@ -1091,7 +1090,7 @@ describe('getSubclassSource — Warrior of the Open Hand', () => {
     expect(level3?.grants).toHaveLength(1);
     expect(level3?.grants[0]).toMatchObject({
       type: 'feature',
-      feature: { id: 'warrioropenhand-open-hand-technique' },
+      feature: { id: 'warrioropenhand-open-hand-technique', saveDC: { dcAbility: 'wis' } },
     });
   });
 

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -959,13 +959,20 @@ describe('getSubclassSource — Warrior of Mercy', () => {
     expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
   });
 
-  it('warriorofmercy level 3 grants 2 features: hand-of-healing and hand-of-harm', () => {
+  it('warriorofmercy level 3 grants Implements of Mercy proficiencies plus hand-of-healing and hand-of-harm', () => {
     const source = getSubclassSource('warriorofmercy');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
-    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toHaveLength(6);
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'warriorofmercy-implements-of-mercy' }),
+        }),
+        { type: 'proficiency', category: 'skill', id: 'insight' },
+        { type: 'proficiency', category: 'skill', id: 'medicine' },
+        { type: 'proficiency', category: 'tool', id: 'herbalismkit' },
         expect.objectContaining({
           type: 'feature',
           feature: expect.objectContaining({ id: 'warriorofmercy-hand-of-healing' }),
@@ -1035,7 +1042,7 @@ describe('getSubclassSource — Warrior of the Elements', () => {
     expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
   });
 
-  it('warriorofelements level 3 grants 2 features: elemental-attunement and elemental-burst', () => {
+  it('warriorofelements level 3 grants 2 features: elemental-attunement and manipulate-elements', () => {
     const source = getSubclassSource('warriorofelements');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
@@ -1048,20 +1055,20 @@ describe('getSubclassSource — Warrior of the Elements', () => {
         }),
         expect.objectContaining({
           type: 'feature',
-          feature: expect.objectContaining({ id: 'warriorofelements-elemental-burst' }),
+          feature: expect.objectContaining({ id: 'warriorofelements-manipulate-elements' }),
         }),
       ])
     );
   });
 
-  it('warriorofelements level 6 grants elemental-epitome feature', () => {
+  it('warriorofelements level 6 grants elemental-burst feature', () => {
     const source = getSubclassSource('warriorofelements');
     const level6 = source?.features.find((f) => f.classLevel === 6);
     expect(level6).toBeDefined();
     expect(level6?.grants).toHaveLength(1);
     expect(level6?.grants[0]).toMatchObject({
       type: 'feature',
-      feature: { id: 'warriorofelements-elemental-epitome' },
+      feature: { id: 'warriorofelements-elemental-burst' },
     });
   });
 });

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -460,17 +460,26 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 3,
         grants: [
-          // Focus Point cost: as part of Flurry of Blows, replace a strike with healing equal to Martial Arts die + WIS mod
+          // Implements of Mercy: skill proficiencies in Insight, Medicine, plus Herbalism Kit tool proficiency
+          { type: 'feature', feature: { id: 'warriorofmercy-implements-of-mercy' } },
+          { type: 'proficiency', category: 'skill', id: 'insight' },
+          { type: 'proficiency', category: 'skill', id: 'medicine' },
+          { type: 'proficiency', category: 'tool', id: 'herbalismkit' },
+          // Hand of Healing: Magic action, 1 Focus Point — heal Martial Arts die + WIS mod;
+          // free during Flurry of Blows (replaces one Unarmed Strike)
           { type: 'feature', feature: { id: 'warriorofmercy-hand-of-healing' } },
-          // Focus Point cost: when you hit with an unarmed strike, deal extra necrotic damage equal to Martial Arts die
+          // Hand of Harm: 1 Focus Point on a hit with an unarmed strike — extra necrotic damage equal to Martial Arts die + WIS mod
           { type: 'feature', feature: { id: 'warriorofmercy-hand-of-harm' } },
         ],
       },
       {
         classLevel: 6,
         grants: [
-          // Enhances Hand of Healing (end a condition) and Hand of Harm (Poisoned on failed CON save)
-          { type: 'feature', feature: { id: 'warriorofmercy-physicians-touch' } },
+          // Enhances Hand of Healing (end a condition) and Hand of Harm (Poisoned on failed CON save vs Monk DC)
+          {
+            type: 'feature',
+            feature: { id: 'warriorofmercy-physicians-touch', saveDC: { dcAbility: 'wis' } },
+          },
         ],
       },
     ] satisfies readonly SubclassFeature[],
@@ -501,19 +510,21 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
         classLevel: 3,
         grants: [
           // Focus Point cost: Bonus Action — infuse unarmed strikes with chosen element (Acid/Cold/Fire/Lightning/Thunder)
-          // for 10 min; deal Martial Arts die extra damage on hit; push target 10 ft
+          // for 10 min; reach extends to 10 ft; deal Martial Arts die extra damage on hit
           { type: 'feature', feature: { id: 'warriorofelements-elemental-attunement' } },
-          // Focus Point cost: Action — choose a point within 60 ft; all creatures within 20 ft make DEX save or
-          // take 2d8 + Monk level damage of attunement element, half on success
-          { type: 'feature', feature: { id: 'warriorofelements-elemental-burst' } },
+          // Free Elementalism cantrip (WIS); modeled as inert feature grant pending #93 cantrip catalog
+          { type: 'feature', feature: { id: 'warriorofelements-manipulate-elements' } },
         ],
       },
       {
         classLevel: 6,
         grants: [
-          // Canonical 2024 PHB L6 feature name unconfirmed; modeled as elemental-epitome per implementation notes.
-          // When Elemental Attunement is active, enhances push/pull distance and adds elemental aura effects.
-          { type: 'feature', feature: { id: 'warriorofelements-elemental-epitome' } },
+          // Focus Point cost: Magic action — choose a point within 120 ft; all creatures in 20-ft sphere
+          // make DEX save vs Monk DC or take 3× Martial Arts die damage of attunement element, half on success
+          {
+            type: 'feature',
+            feature: { id: 'warriorofelements-elemental-burst', saveDC: { dcAbility: 'wis' } },
+          },
         ],
       },
     ] satisfies readonly SubclassFeature[],
@@ -523,9 +534,12 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 3,
         grants: [
-          // When you hit with Flurry of Blows, impose one of: knock Prone (STR save), push 15 ft (STR save),
-          // or prevent Reactions until end of your next turn (no save)
-          { type: 'feature', feature: { id: 'warrioropenhand-open-hand-technique' } },
+          // Per-hit choice on Flurry of Blows: Addle (no Opportunity Attacks, no save), Push (STR save vs Monk DC, 15 ft),
+          // or Topple (DEX save vs Monk DC, Prone). Sub-option choice is a runtime/gameplay decision (out of scope).
+          {
+            type: 'feature',
+            feature: { id: 'warrioropenhand-open-hand-technique', saveDC: { dcAbility: 'wis' } },
+          },
         ],
       },
       {

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -468,7 +468,7 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
           // Hand of Healing: Magic action, 1 Focus Point — heal Martial Arts die + WIS mod;
           // free during Flurry of Blows (replaces one Unarmed Strike)
           { type: 'feature', feature: { id: 'warriorofmercy-hand-of-healing' } },
-          // Hand of Harm: 1 Focus Point on a hit with an unarmed strike — extra necrotic damage equal to Martial Arts die + WIS mod
+          // Hand of Harm: 1 Focus Point on a hit with an unarmed strike — extra necrotic damage equal to Martial Arts die
           { type: 'feature', feature: { id: 'warriorofmercy-hand-of-harm' } },
         ],
       },
@@ -512,7 +512,7 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
           // Focus Point cost: Bonus Action — infuse unarmed strikes with chosen element (Acid/Cold/Fire/Lightning/Thunder)
           // for 10 min; reach extends to 10 ft; deal Martial Arts die extra damage on hit
           { type: 'feature', feature: { id: 'warriorofelements-elemental-attunement' } },
-          // Free Elementalism cantrip (WIS); modeled as inert feature grant pending #93 cantrip catalog
+          // Free Elementalism cantrip (WIS); modeled as inert feature grant pending spell-id catalog
           { type: 'feature', feature: { id: 'warriorofelements-manipulate-elements' } },
         ],
       },

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -327,6 +327,10 @@
       "name": "Guarded Mind",
       "description": "You have Resistance to Psychic damage. In addition, if you start your turn with the Charmed or Frightened condition, you can spend one Psionic Energy die (no action required) to end one of those conditions on yourself."
     },
+    "warriorofmercy-implements-of-mercy": {
+      "name": "Implements of Mercy",
+      "description": "You gain proficiency in the Insight and Medicine skills, and proficiency with the Herbalism Kit."
+    },
     "warriorofmercy-hand-of-healing": {
       "name": "Hand of Healing",
       "description": "Focus Point: when you use Flurry of Blows, you can replace one of the strikes with a healing touch — the target regains Hit Points equal to a roll of your Martial Arts die + your Wisdom modifier."
@@ -351,13 +355,13 @@
       "name": "Elemental Attunement",
       "description": "Focus Point: as a Bonus Action, infuse your Unarmed Strikes with elemental energy, choosing Acid, Cold, Fire, Lightning, or Thunder. This lasts 10 minutes. While active, your Unarmed Strikes deal extra damage of the chosen type equal to a roll of your Martial Arts die, and you can push the target up to 10 feet away from you on a hit."
     },
+    "warriorofelements-manipulate-elements": {
+      "name": "Manipulate Elements",
+      "description": "You know the Elementalism cantrip. Wisdom is your spellcasting ability for it."
+    },
     "warriorofelements-elemental-burst": {
       "name": "Elemental Burst",
       "description": "Focus Point: as an Action, choose a point within 60 feet of you. All creatures within 20 feet of that point must make a DEX saving throw (DC = 8 + your proficiency bonus + your WIS modifier). On a failed save, a creature takes 2d8 + your Monk level damage of your attunement element; it takes half as much on a successful save."
-    },
-    "warriorofelements-elemental-epitome": {
-      "name": "Elemental Epitome",
-      "description": "While your Elemental Attunement is active, your mastery of elemental power grows: the push distance from Elemental Attunement increases to 15 feet, and you can choose to pull targets toward you instead of pushing them. You also gain resistance to the damage type you chose for your Elemental Attunement."
     },
     "warrioropenhand-open-hand-technique": {
       "name": "Open Hand Technique",

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -46,6 +46,11 @@ export interface FeatureDef {
   readonly description?: string;
   readonly usesPerRest?: 'short' | 'long';
   readonly usesCount?: number;
+  /**
+   * When present, the resolver computes a save DC as 8 + proficiencyBonus + abilities[dcAbility].modifier
+   * and exposes it on `ResolvedFeature.saveDC`. Used for features that force targets to make saves.
+   */
+  readonly saveDC?: { readonly dcAbility: AbilityKey };
 }
 
 // Grant variants
@@ -261,6 +266,19 @@ export interface LineageChoiceGrant {
   readonly from: readonly string[];
 }
 
+export type ResourcePoolMax =
+  | { readonly mode: 'class-level'; readonly classId: ClassId }
+  | { readonly mode: 'fixed'; readonly value: number };
+
+export type ResourcePoolRegen = 'short-rest' | 'long-rest';
+
+export interface ResourcePoolGrant {
+  readonly type: 'resource-pool';
+  readonly poolId: string;
+  readonly max: ResourcePoolMax;
+  readonly regen: ResourcePoolRegen;
+}
+
 export type Grant =
   | AbilityBonusGrant
   | AbilityChoiceGrant
@@ -287,4 +305,5 @@ export type Grant =
   | BundleChoiceGrant
   | LineageChoiceGrant
   | FeatureChoiceGrant
-  | FeatGrant;
+  | FeatGrant
+  | ResourcePoolGrant;

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -8,7 +8,7 @@ import type {
   LanguageId,
   ClassId,
 } from '@/lib/dnd-helpers';
-import type { FeatureDef, DamageTypeId, HitDie, SpeedMode } from '@/types/grants';
+import type { FeatureDef, DamageTypeId, HitDie, SpeedMode, ResourcePoolRegen } from '@/types/grants';
 import type { SourceTag } from '@/types/sources';
 import type { ChoiceKey } from '@/types/choices';
 import type {
@@ -78,6 +78,14 @@ export interface ResolvedAttack {
 
 export interface ResolvedFeature {
   readonly feature: FeatureDef;
+  readonly source: SourceTag;
+  readonly saveDC?: number;
+}
+
+export interface ResolvedResourcePool {
+  readonly poolId: string;
+  readonly max: number;
+  readonly regen: ResourcePoolRegen;
   readonly source: SourceTag;
 }
 
@@ -246,4 +254,5 @@ export interface ResolvedCharacter {
   } | null;
   readonly pendingChoices: readonly PendingChoice[];
   readonly weaponMasteries: readonly { readonly weaponId: string; readonly masteryId: WeaponMasteryId }[];
+  readonly resourcePools: readonly ResolvedResourcePool[];
 }


### PR DESCRIPTION
## Summary

Builder-time fixes for issue #148 verifying 2024 PHB Monk warrior subclasses against PR #147's implementation, plus two reusable primitives that the four sibling follow-ups (#146/#155/#157/#159) will inherit.

- **New primitives** (commit ae1e913): `ResourcePoolGrant` declaring named resource pools (class-level or fixed max, short/long-rest regen) → surfaced as `ResolvedCharacter.resourcePools`; optional `FeatureDef.saveDC` → resolver computes `8 + PB + abilityMod` and exposes it on `ResolvedFeature`.
- **Monk verification fixes** (commit eb824f0): corrected feature level placements against the 2024 PHB, added missing grants, wired the new infrastructure into the Monk source data.

Issue #148 has [a comment](https://github.com/drovani/dnd-maintainer/issues/148#issuecomment-4559196041) listing the 9 i18n descriptions that need verbatim 2024 PHB text. Descriptions in this PR were intentionally left untouched.

### Structural deltas (PHB verification)

- Elemental Burst: L3 → L6 (its real PHB level).
- Elemental Epitome (L17, out of scope) removed from L6.
- Added `warriorofmercy-implements-of-mercy` with `proficiency` grants for Insight + Medicine + Herbalism Kit.
- Added `warriorofelements-manipulate-elements` (Elementalism cantrip, inert pending #93 catalog).
- Monk L2 `monk-focus-points` now also emits a `resource-pool` grant (max = Monk class level, regen short-rest).
- WIS save-DC wired on `warriorofmercy-physicians-touch`, `warriorofelements-elemental-burst`, `warrioropenhand-open-hand-technique`.

### Out of scope (deferred)

- Open Hand per-hit sub-option picker (gameplay layer).
- Shadow Arts as structured spell grants (blocked by #161 + spell catalog).
- L11/L17 features (#111 meta-issue scopes implementations through L10).
- Description rewrites (queued in #148 comment for PHB-verbatim entry).

## Test plan

- [x] `npm run typecheck` clean
- [x] `npm run lint` clean on touched files (one pre-existing error in `src/lib/class-icons.tsx` is on main)
- [x] `npm run test` — 1555 passing (8 new tests covering `resolveResourcePools` and `FeatureDef.saveDC` computation)
- [x] `npm run build` clean
- [ ] Manual: open the character builder, create a Monk to L6 with Warrior of the Elements / Warrior of Mercy / Warrior of the Open Hand; verify the resolved features show on the sheet and the L3/L6 placement matches the PHB
- [ ] Manual: confirm new Mercy proficiencies (Insight, Medicine, Herbalism Kit) appear on the proficiencies panel without double-counting if also picked via the Monk skill-choice list
- [ ] Verbatim PHB text pass for the 9 i18n keys listed in the issue comment

🤖 Generated with [Claude Code](https://claude.com/claude-code)