### PR TITLE
test(bdd): cover all _BACKLOG.md MVP stories with feature specs

### DIFF
--- a/features/campaigns/search-campaigns.feature
+++ b/features/campaigns/search-campaigns.feature
@@ -1,0 +1,25 @@
+Feature: Search campaigns by name
+  As a Dungeon Master with many campaigns,
+  I want to filter campaigns by name,
+  So that I can quickly find the one I need.
+
+  # Render-app seam: CampaignList holds the search term in local state and filters
+  # the already-loaded campaigns client-side (on name or setting). These scenarios
+  # render the real page, type into the search box, and assert on the rendered list.
+
+  Scenario: Typing a query narrows the list to matching campaigns
+    Given a campaign named "Dragon's Lair" exists
+    And a campaign named "City of Shadows" exists
+    And a campaign named "Dragon's Peak" exists
+    When the Dungeon Master searches campaigns for "Dragon"
+    Then "Dragon's Lair" appears in the list
+    And "Dragon's Peak" appears in the list
+    And "City of Shadows" does not appear in the list
+
+  Scenario: Clearing the search restores the full list
+    Given a campaign named "Dragon's Lair" exists
+    And a campaign named "City of Shadows" exists
+    When the Dungeon Master searches campaigns for "Dragon"
+    And the Dungeon Master clears the campaign search
+    Then "Dragon's Lair" appears in the list
+    And "City of Shadows" appears in the list

--- a/features/campaigns/steps/search-campaigns.steps.ts
+++ b/features/campaigns/steps/search-campaigns.steps.ts
@@ -1,0 +1,61 @@
+import { When } from '@cucumber/cucumber';
+import { createElement } from 'react';
+import type { DndWorld } from '../../steps/support/world.js';
+
+// ---------------------------------------------------------------------------
+// Campaign search — render-app seam.
+//
+// Reuses the global "a campaign named {string} exists" Given (campaigns.steps.ts)
+// and the global "{string} appears in the list" / "does not appear in the list"
+// Then steps. Only the search-specific When steps live here. The render helper
+// mirrors campaigns.steps.ts's renderCampaignList (those helpers are module-local
+// there, so a small local copy keeps this file self-contained).
+// ---------------------------------------------------------------------------
+
+async function renderCampaignList(world: DndWorld) {
+  const hooks = await world.esmockWithSupabase('@/hooks/useCampaigns');
+  const mod = await world.esmockWithSupabase('@/pages/CampaignList', {
+    '@/hooks/useCampaigns': hooks,
+    '@/hooks/usePageTitle': { usePageTitle: () => undefined },
+  });
+  const CampaignList = (mod.default ?? (mod as { CampaignList: unknown }).CampaignList) as () => React.ReactElement;
+  const r = await world.renderRoute('/', createElement(CampaignList));
+  await r.rtl.waitFor(() => {
+    if ((document.body.textContent ?? '').includes('Loading')) throw new Error('still loading');
+  });
+  return r;
+}
+
+function searchInput(): HTMLInputElement {
+  const input = (Array.from(document.querySelectorAll('input')) as HTMLInputElement[]).find((i) =>
+    /search campaigns/i.test(i.placeholder)
+  );
+  if (!input) {
+    throw new Error('Could not find the campaign search input (placeholder "Search campaigns by name or setting...")');
+  }
+  return input;
+}
+
+// React 19 controlled inputs need user-event to fire onChange (see campaigns.steps.ts).
+async function typeInto(el: HTMLInputElement, value: string): Promise<void> {
+  const userEvent = (await import('@testing-library/user-event')).default;
+  const user = userEvent.setup({ document });
+  await user.clear(el);
+  if (value) await user.type(el, value);
+}
+
+When('the Dungeon Master searches campaigns for {string}', async function (this: DndWorld, query: string) {
+  await renderCampaignList(this);
+  await typeInto(searchInput(), query);
+});
+
+When('the Dungeon Master clears the campaign search', async function (this: DndWorld) {
+  const el = searchInput();
+  const userEvent = (await import('@testing-library/user-event')).default;
+  const user = userEvent.setup({ document });
+  // user.clear() sets the DOM value but does not reliably fire React's onChange in
+  // this jsdom harness (React 19 value-tracker). Select-all + Delete emits real
+  // keystroke input events, so the controlled searchTerm state actually resets.
+  await user.click(el);
+  await user.keyboard('{Control>}a{/Control}{Delete}');
+});

--- a/features/characters/archive-character.feature
+++ b/features/characters/archive-character.feature
@@ -1,0 +1,20 @@
+Feature: Archive a character
+  As a Dungeon Master,
+  I want to archive a retired or deceased character,
+  So that they no longer appear in the active character list but are preserved.
+
+  Scenario: Active characters appear in the campaign's character list
+    Given a campaign with an active character named "Valeros"
+    When the Dungeon Master views the character list
+    Then "Valeros" appears in the character list
+
+  @future
+  Scenario: An archived character is hidden from the character list
+    # GAP: the Archive action sets characters.is_active = false, but useCharacters()
+    # selects every row for the campaign (.eq('campaign_id', id).order('name')) with
+    # no is_active filter, so an archived character still shows. Hiding archived
+    # characters from the list is not implemented — this asserts the intended
+    # behavior and fails (the character still appears) until it is built.
+    Given a campaign with an archived character named "Old Hero"
+    When the Dungeon Master views the character list
+    Then "Old Hero" does not appear in the character list

--- a/features/characters/builder-autosave.feature
+++ b/features/characters/builder-autosave.feature
@@ -1,0 +1,17 @@
+Feature: Autosave character builder draft
+  As a player,
+  I want my in-progress character draft to be saved automatically,
+  So that I don't lose my work if I navigate away.
+
+  # Render-app seam: a draft is persisted as a characters row (status='draft') plus
+  # character_build_levels rows. Returning to the builder at the draft's URL loads
+  # it — useCharacter(slug) + useCharacterBuildLevels rehydrate the wizard, so step
+  # 1 (name, species) is pre-filled. This exercises the resume/reload path (AC2 and
+  # the reload half of AC1); it seeds the draft rows directly rather than driving
+  # the autosave WRITE through the wizard's inputs.
+
+  Scenario: A saved draft is reloaded when returning to the builder
+    Given a saved character draft named "Aldara"
+    When the player opens the character builder for that draft
+    Then the builder resumes with the name "Aldara"
+    And the builder shows the species "Human"

--- a/features/characters/edit-character-backstory.feature
+++ b/features/characters/edit-character-backstory.feature
@@ -1,0 +1,19 @@
+Feature: Edit character backstory and personality
+  As a player,
+  I want to edit my character's backstory and personality from the character sheet,
+  So that I can keep my character's narrative up to date.
+
+  # Render-app seam: the CharacterSheet renders inline edit dialogs (the section
+  # pencil opens a Textarea + Save). Saving calls useCharacterMutations().update,
+  # which persists to the characters row. The backstory and personality sections
+  # only render when already populated, so the sheet is seeded with existing text.
+
+  Scenario: Editing the backstory saves the new text
+    Given a Fighter character sheet with an existing backstory and personality
+    When the Dungeon Master edits the backstory to "Born in the ashlands, sworn to the flame."
+    Then the character's backstory reads "Born in the ashlands, sworn to the flame."
+
+  Scenario: Editing the personality traits saves them
+    Given a Fighter character sheet with an existing backstory and personality
+    When the Dungeon Master edits the personality traits to "Quick to laugh, slow to trust."
+    Then the character's personality traits read "Quick to laugh, slow to trust."

--- a/features/characters/level-down.feature
+++ b/features/characters/level-down.feature
@@ -1,0 +1,26 @@
+Feature: Level down a character
+  As a Dungeon Master,
+  I want to remove a character's most recent level,
+  So that I can correct a mistaken level-up or adjust for a campaign retcon.
+
+  Scenario: Reverting a Fighter from level 4 to level 3 removes the ASI choice
+    # Resolver seam: dropping the most recent BuildLevel and re-resolving mirrors
+    # what useCharacterContext.levelDown() does (it soft-deletes the highest-sequence
+    # level row, which the resolver then excludes).
+    Given a Fighter at level 4 with no background chosen
+    Then the character has a pending ability score increase
+    When the most recent level is removed
+    Then the character is level 3
+    And the character has no pending ability score increase
+    And their proficiency bonus is 2
+
+  Scenario: A first-level character cannot be leveled down
+    # The app expresses "no level to remove" by HIDING the Level Down control at
+    # level 1 (LevelControls renders it only when level > 1), so the assertion
+    # checks the action is unavailable rather than that a disabled button exists.
+    Given a level 1 Fighter is shown on the character sheet
+    Then the Level Down action is unavailable
+
+  Scenario: A higher-level character offers the Level Down control
+    Given a level 3 Fighter is shown on the character sheet
+    Then the Level Down action is available

--- a/features/characters/level-up-character.feature
+++ b/features/characters/level-up-character.feature
@@ -8,3 +8,7 @@ Feature: Level up a character
     When the Fighter advances to level 4
     Then they must choose an ability score increase
     And their proficiency bonus is 2
+
+  Scenario: Reaching level 3 prompts a subclass choice
+    Given a new character with the fighter class at level 3
+    Then the character must choose a subclass

--- a/features/characters/resolve-asi.feature
+++ b/features/characters/resolve-asi.feature
@@ -1,0 +1,30 @@
+Feature: Resolve a pending ability score increase
+  As a player,
+  I want to allocate my ability score increase when prompted,
+  So that my character's ability scores stay current and fully resolved.
+
+  # Resolver seam: a build is resolved via the real collectBundles() +
+  # resolveCharacter() pipeline. An ASI grant stays in pendingChoices until its
+  # allocation sums to exactly the granted points (2); over- or under-allocation
+  # leaves it pending. This mirrors the AsiAllocator UI, which disables Confirm
+  # until exactly the granted points are spent.
+
+  Scenario: A Fighter reaching level 4 is prompted for an ability score increase
+    Given a Fighter at level 4 with no background chosen
+    Then the character has a pending ability score increase
+
+  Scenario: Allocating the full increase resolves the choice and raises the ability
+    Given a Fighter at level 4 with no background chosen
+    When the player allocates 2 points of ability score increase to Strength
+    Then the ability score increase is no longer pending
+    And the character's Strength score is increased by 2
+
+  Scenario: Splitting the increase across two abilities also resolves it
+    Given a Fighter at level 4 with no background chosen
+    When the player allocates 1 point of ability score increase to Strength and 1 to Constitution
+    Then the ability score increase is no longer pending
+
+  Scenario: Over-allocating beyond the granted points leaves the choice unresolved
+    Given a Fighter at level 4 with no background chosen
+    When the player allocates 3 points of ability score increase to Strength
+    Then the ability score increase is still pending

--- a/features/characters/steps/archive-character.steps.ts
+++ b/features/characters/steps/archive-character.steps.ts
@@ -1,0 +1,105 @@
+import { Given, When, Then } from '@cucumber/cucumber';
+import { createElement } from 'react';
+import type { DndWorld } from '../../steps/support/world.js';
+import type { Campaign } from '../../../src/types/database.js';
+import type { Row } from '../../steps/support/stateful-supabase.js';
+
+// ---------------------------------------------------------------------------
+// Archive character — render-app seam against CharacterList.
+//
+// The character list is campaign-scoped via useCampaignContext (stubbed) and
+// queries useCharacters(campaignId). We seed a character row directly (active or
+// archived) and assert what the rendered list shows. The archived case is
+// @future: useCharacters has no is_active filter, so an archived character is
+// not actually hidden yet.
+// ---------------------------------------------------------------------------
+
+let _seq = 0;
+
+function seedCampaignWithCharacter(world: DndWorld, name: string, isActive: boolean): Campaign {
+  _seq += 1;
+  const campaign: Campaign = {
+    id: `arch-c${_seq}`,
+    slug: `campaign-${_seq}`,
+    previous_slugs: [],
+    name: `Campaign ${_seq}`,
+    description: null,
+    setting: null,
+    status: 'active',
+    theme: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    archived_at: null,
+  };
+  world.db.seed('campaigns', [campaign as unknown as Row]);
+  world.db.seed('characters', [
+    {
+      id: `arch-ch${_seq}`,
+      campaign_id: campaign.id,
+      slug: name.toLowerCase().replace(/[^a-z0-9]+/g, '-'),
+      name,
+      character_type: 'pc',
+      is_active: isActive,
+      level: 1,
+      updated_at: '2024-01-01T00:00:00Z',
+    } as Row,
+  ]);
+  world.createdCampaign = campaign;
+  return campaign;
+}
+
+async function renderCharacterList(world: DndWorld, campaign: Campaign) {
+  const useCharactersMod = await world.esmockWithSupabase('@/hooks/useCharacters');
+  const mod = await world.esmockWithSupabase('@/pages/CharacterList', {
+    '@/hooks/useCharacters': useCharactersMod,
+    '@/hooks/useCampaignContext': {
+      useCampaignContext: () => ({
+        campaignSlug: campaign.slug,
+        campaignId: campaign.id,
+        setPageTitle: () => undefined,
+      }),
+    },
+    '@/hooks/usePageTitle': { usePageTitle: () => undefined },
+  });
+  const CharacterList = (mod.default ?? (mod as { CharacterList: unknown }).CharacterList) as () => React.ReactElement;
+  const router = (await import('react-router-dom')) as typeof import('react-router-dom');
+  const tree = createElement(
+    router.Routes,
+    null,
+    createElement(router.Route, { path: '/campaign/:campaignSlug', element: createElement(CharacterList) })
+  );
+  const r = await world.renderRoute(`/campaign/${campaign.slug}`, tree);
+  await r.rtl.waitFor(() => {
+    if ((document.body.textContent ?? '').includes('Loading')) throw new Error('character list still loading');
+  });
+  return r;
+}
+
+Given('a campaign with an active character named {string}', function (this: DndWorld, name: string) {
+  seedCampaignWithCharacter(this, name, true);
+});
+
+Given('a campaign with an archived character named {string}', function (this: DndWorld, name: string) {
+  seedCampaignWithCharacter(this, name, false);
+});
+
+When('the Dungeon Master views the character list', async function (this: DndWorld) {
+  await renderCharacterList(this, this.createdCampaign!);
+});
+
+Then('{string} appears in the character list', function (this: DndWorld, name: string) {
+  const txt = document.body.textContent ?? '';
+  if (!txt.includes(name)) {
+    throw new Error(`Expected "${name}" in the character list. Body: ${txt.slice(0, 300)}`);
+  }
+});
+
+Then('{string} does not appear in the character list', function (this: DndWorld, name: string) {
+  const txt = document.body.textContent ?? '';
+  if (txt.includes(name)) {
+    throw new Error(
+      `Expected "${name}" to be hidden from the character list (archived), but it still appears — ` +
+        `useCharacters() has no is_active filter`
+    );
+  }
+});

--- a/features/characters/steps/asi.steps.ts
+++ b/features/characters/steps/asi.steps.ts
@@ -1,0 +1,122 @@
+import { Given, When, Then } from '@cucumber/cucumber';
+import type { DndWorld } from '../../steps/support/world.js';
+import { makeBuild, resolveBuild, makeChoices } from '../../steps/support/character-builder.js';
+import { createChoiceKey } from '@/types/choices';
+import type { AbilityKey, ClassId } from '@/lib/dnd-helpers';
+
+// ---------------------------------------------------------------------------
+// Ability Score Increase — resolver seam.
+//
+// Shared ASI vocabulary used by resolve-asi.feature and level-down.feature.
+// Steps operate on this.build / this.resolved set up by the shared
+// "a new character with the {word} class at level {int}" Given
+// (character-common.steps.ts). Allocating re-runs the real resolver so the
+// pending-choice and ability totals reflect the production pipeline.
+// ---------------------------------------------------------------------------
+
+const ABILITY_BY_NAME: Readonly<Record<string, AbilityKey>> = {
+  Strength: 'str',
+  Dexterity: 'dex',
+  Constitution: 'con',
+  Intelligence: 'int',
+  Wisdom: 'wis',
+  Charisma: 'cha',
+};
+
+function abilityKey(name: string): AbilityKey {
+  const key = ABILITY_BY_NAME[name];
+  if (!key) {
+    throw new Error(`Unknown ability name "${name}" — expected one of ${Object.keys(ABILITY_BY_NAME).join(', ')}`);
+  }
+  return key;
+}
+
+/** The ASI grant lives on the first class at grant index 0 (e.g. asi:class:fighter:0). */
+function asiChoiceKey(world: DndWorld): ReturnType<typeof createChoiceKey> {
+  const classId = world.build!.levels[0].classId as ClassId;
+  return createChoiceKey('asi', 'class', classId, 0);
+}
+
+function hasPendingAsi(world: DndWorld): boolean {
+  return world.resolved!.pendingChoices.some((c) => c.type === 'asi');
+}
+
+function allocate(world: DndWorld, allocation: Partial<Record<AbilityKey, number>>): void {
+  const key = asiChoiceKey(world);
+  world.build = { ...world.build!, choices: makeChoices([key, { type: 'asi', allocation }]) };
+  world.resolved = resolveBuild(world.build);
+}
+
+// A no-background build so the only ASI is the class one. (2024 PHB backgrounds
+// ALSO grant an ASI — e.g. soldier yields asi:background:soldier:0 — which would
+// otherwise leave a second, unrelated ASI pending and make "the ability score
+// increase" ambiguous.)
+Given('a Fighter at level {int} with no background chosen', function (this: DndWorld, level: number) {
+  this.build = makeBuild({ classId: 'fighter', level, backgroundId: null });
+  this.resolved = resolveBuild(this.build);
+});
+
+When(
+  'the player allocates {int} points of ability score increase to {word}',
+  function (this: DndWorld, points: number, abilityName: string) {
+    const allocation: Partial<Record<AbilityKey, number>> = {};
+    allocation[abilityKey(abilityName)] = points;
+    allocate(this, allocation);
+  }
+);
+
+When(
+  'the player allocates {int} point of ability score increase to {word} and {int} to {word}',
+  function (this: DndWorld, p1: number, a1: string, p2: number, a2: string) {
+    const allocation: Partial<Record<AbilityKey, number>> = {};
+    allocation[abilityKey(a1)] = p1;
+    allocation[abilityKey(a2)] = p2;
+    allocate(this, allocation);
+  }
+);
+
+Then('the character has a pending ability score increase', function (this: DndWorld) {
+  if (!hasPendingAsi(this)) {
+    const keys = this.resolved!.pendingChoices.map((c) => c.choiceKey);
+    throw new Error(`Expected a pending ASI choice; pending choice keys were: ${JSON.stringify(keys)}`);
+  }
+});
+
+Then('the ability score increase is still pending', function (this: DndWorld) {
+  if (!hasPendingAsi(this)) {
+    throw new Error(
+      'Expected the ASI to remain pending (allocation did not equal the granted points), but it resolved'
+    );
+  }
+});
+
+Then('the ability score increase is no longer pending', function (this: DndWorld) {
+  if (hasPendingAsi(this)) {
+    const pendingKeys = this.resolved!.pendingChoices.filter((c) => c.type === 'asi').map((c) => c.choiceKey);
+    throw new Error(
+      `Expected the ASI to be resolved and removed from pending choices, but these ASI choices are still pending: ${JSON.stringify(pendingKeys)}`
+    );
+  }
+});
+
+Then('the character has no pending ability score increase', function (this: DndWorld) {
+  if (hasPendingAsi(this)) {
+    throw new Error('Expected no pending ASI choice, but one is present');
+  }
+});
+
+Then(
+  "the character's {word} score is increased by {int}",
+  function (this: DndWorld, abilityName: string, delta: number) {
+    const key = abilityKey(abilityName);
+    const withAllocation = this.resolved!.abilities[key].total;
+    // Baseline = the same build with the ASI unallocated, so the assertion isolates the
+    // ASI delta from any species/background contributions to the score.
+    const baseline = resolveBuild({ ...this.build!, choices: {} }).abilities[key].total;
+    if (withAllocation - baseline !== delta) {
+      throw new Error(
+        `Expected ${abilityName} to increase by ${delta} (baseline ${baseline}), got total ${withAllocation}`
+      );
+    }
+  }
+);

--- a/features/characters/steps/builder-autosave.steps.ts
+++ b/features/characters/steps/builder-autosave.steps.ts
@@ -1,0 +1,145 @@
+import { Given, When, Then } from '@cucumber/cucumber';
+import { createElement } from 'react';
+import type { DndWorld } from '../../steps/support/world.js';
+import type { Campaign } from '../../../src/types/database.js';
+import type { Row } from '../../steps/support/stateful-supabase.js';
+
+// ---------------------------------------------------------------------------
+// Builder autosave / draft resume — render-app seam.
+//
+// Seeds a draft (characters status='draft' + character_build_levels) and renders
+// the real CharacterBuilder at the draft's resume URL. useCharacter +
+// useCharacterBuildLevels rehydrate the wizard via the pure CharacterProvider,
+// so BasicsStep shows the saved name and species. useCampaignContext is stubbed.
+// ---------------------------------------------------------------------------
+
+const BASE_ABILITIES = { str: 15, dex: 14, con: 13, int: 12, wis: 10, cha: 8 };
+
+function seedDraft(world: DndWorld, name: string): { campaign: Campaign; slug: string } {
+  const campaign: Campaign = {
+    id: 'draft-camp',
+    slug: 'draft-camp',
+    previous_slugs: [],
+    name: 'Draft Campaign',
+    description: null,
+    setting: null,
+    status: 'active',
+    theme: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    archived_at: null,
+  };
+  world.db.seed('campaigns', [campaign as unknown as Row]);
+
+  const id = 'draft-char';
+  const slug = name.toLowerCase().replace(/[^a-z0-9]+/g, '-');
+  world.db.seed('characters', [
+    {
+      id,
+      slug,
+      previous_slugs: [],
+      campaign_id: campaign.id,
+      name,
+      status: 'draft',
+      character_type: 'pc',
+      is_active: true,
+      level: 1,
+      species: 'human',
+      class: 'fighter',
+      background: 'soldier',
+      alignment: 'neutral-good',
+      gender: null,
+      player_name: null,
+      created_at: '2024-01-01T00:00:00Z',
+      updated_at: '2024-01-01T00:00:00Z',
+    } as Row,
+  ]);
+  world.db.seed('character_build_levels', [
+    {
+      character_id: id,
+      sequence: 0,
+      base_abilities: BASE_ABILITIES,
+      ability_method: 'standard-array',
+      class_id: null,
+      class_level: null,
+      subclass_id: null,
+      asi_allocation: null,
+      feat_id: null,
+      hp_roll: null,
+      choices: null,
+      deleted_at: null,
+    } as Row,
+    {
+      character_id: id,
+      sequence: 1,
+      base_abilities: null,
+      ability_method: null,
+      class_id: 'fighter',
+      class_level: 1,
+      subclass_id: null,
+      asi_allocation: null,
+      feat_id: null,
+      hp_roll: null,
+      choices: null,
+      deleted_at: null,
+    } as Row,
+  ]);
+  world.db.seed('character_items', []);
+  world.createdCampaign = campaign;
+  return { campaign, slug };
+}
+
+let draftSlug = '';
+
+Given('a saved character draft named {string}', function (this: DndWorld, name: string) {
+  const { slug } = seedDraft(this, name);
+  draftSlug = slug;
+});
+
+When('the player opens the character builder for that draft', async function (this: DndWorld) {
+  const campaign = this.createdCampaign!;
+  const useCharactersMod = await this.esmockWithSupabase('@/hooks/useCharacters');
+  const useCharacterBuildMod = await this.esmockWithSupabase('@/hooks/useCharacterBuild');
+  const useBuilderAutosaveMod = await this.esmockWithSupabase('@/hooks/useBuilderAutosave');
+  const mod = await this.esmockWithSupabase('@/pages/CharacterBuilder', {
+    '@/hooks/useCharacters': useCharactersMod,
+    '@/hooks/useCharacterBuild': useCharacterBuildMod,
+    '@/hooks/useBuilderAutosave': useBuilderAutosaveMod,
+    '@/hooks/useCampaignContext': {
+      useCampaignContext: () => ({
+        campaignSlug: campaign.slug,
+        campaignId: campaign.id,
+        setPageTitle: () => undefined,
+      }),
+    },
+    '@/hooks/usePageTitle': { usePageTitle: () => undefined },
+  });
+  const CharacterBuilder = (mod.default ??
+    (mod as { CharacterBuilder: unknown }).CharacterBuilder) as () => React.ReactElement;
+  const router = (await import('react-router-dom')) as typeof import('react-router-dom');
+  const tree = createElement(
+    router.Routes,
+    null,
+    createElement(router.Route, {
+      path: '/campaign/:campaignSlug/character/:characterSlug',
+      element: createElement(CharacterBuilder),
+    })
+  );
+  const r = await this.renderRoute(`/campaign/${campaign.slug}/character/${draftSlug}`, tree);
+  await r.rtl.waitFor(() => {
+    const input = document.querySelector('#character-name') as HTMLInputElement | null;
+    if (!input || !input.value) throw new Error('builder draft not loaded yet');
+  });
+});
+
+Then('the builder resumes with the name {string}', function (this: DndWorld, name: string) {
+  const input = document.querySelector('#character-name') as HTMLInputElement | null;
+  if (!input) throw new Error('Could not find the character name input');
+  if (input.value !== name) throw new Error(`Expected the name field to read "${name}", got "${input.value}"`);
+});
+
+Then('the builder shows the species {string}', function (this: DndWorld, speciesName: string) {
+  if (!document.body.textContent?.includes(speciesName)) {
+    throw new Error(`Expected the resumed builder to show the species "${speciesName}"`);
+  }
+});

--- a/features/characters/steps/character-sheet.steps.ts
+++ b/features/characters/steps/character-sheet.steps.ts
@@ -1,0 +1,298 @@
+import { Given, When, Then } from '@cucumber/cucumber';
+import { createElement } from 'react';
+import type { DndWorld } from '../../steps/support/world.js';
+import type { Campaign } from '../../../src/types/database.js';
+import type { Row } from '../../steps/support/stateful-supabase.js';
+
+// ---------------------------------------------------------------------------
+// View character sheet — render-app seam.
+//
+// Seeds a characters row + character_build_levels rows (shapes copied from
+// src/lib/build-reconstruction.test.ts) + optional character_items, then renders
+// the real CharacterSheet. CharacterProvider/useCharacterContext is pure (no
+// supabase); only useCharacters / useCharacterBuild / useBuilderAutosave are
+// re-esmocked with the stateful store.
+// ---------------------------------------------------------------------------
+
+const BASE_ABILITIES = { str: 15, dex: 14, con: 13, int: 12, wis: 10, cha: 8 };
+
+function creationRow(characterId: string): Row {
+  return {
+    character_id: characterId,
+    sequence: 0,
+    base_abilities: BASE_ABILITIES,
+    ability_method: 'standard-array',
+    class_id: null,
+    class_level: null,
+    subclass_id: null,
+    asi_allocation: null,
+    feat_id: null,
+    hp_roll: null,
+    choices: null,
+    deleted_at: null,
+  };
+}
+
+function levelRow(characterId: string, classLevel: number): Row {
+  return {
+    character_id: characterId,
+    sequence: classLevel,
+    base_abilities: null,
+    ability_method: null,
+    class_id: 'fighter',
+    class_level: classLevel,
+    subclass_id: null,
+    asi_allocation: null,
+    feat_id: null,
+    hp_roll: 6,
+    choices: null,
+    deleted_at: null,
+  };
+}
+
+function seedCampaign(world: DndWorld): Campaign {
+  const campaign: Campaign = {
+    id: 'cs-camp',
+    slug: 'sheet-camp',
+    previous_slugs: [],
+    name: 'Sheet Campaign',
+    description: null,
+    setting: null,
+    status: 'active',
+    theme: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+    archived_at: null,
+  };
+  world.db.seed('campaigns', [campaign as unknown as Row]);
+  world.createdCampaign = campaign;
+  return campaign;
+}
+
+interface SheetSeed {
+  readonly level: number;
+  readonly status: 'draft' | 'ready';
+  readonly items?: readonly { item_id: string; quantity: number; equipped: boolean }[];
+  readonly backstory?: string;
+  readonly personalityTraits?: string;
+}
+
+function seedCharacter(world: DndWorld, campaign: Campaign, seed: SheetSeed): Row {
+  const id = 'cs-char';
+  const character: Row = {
+    id,
+    slug: 'aldara',
+    previous_slugs: [],
+    campaign_id: campaign.id,
+    name: 'Aldara',
+    status: seed.status,
+    character_type: 'pc',
+    is_active: true,
+    level: seed.level,
+    species: 'human',
+    class: 'fighter',
+    background: 'soldier',
+    alignment: null,
+    gender: null,
+    player_name: null,
+    armor_class: 10,
+    hit_points_max: 10,
+    speed: 30,
+    proficiency_bonus: 2,
+    personality_traits: seed.personalityTraits ?? null,
+    ideals: null,
+    bonds: null,
+    flaws: null,
+    backstory: seed.backstory ?? null,
+    appearance: null,
+    created_at: '2024-01-01T00:00:00Z',
+    updated_at: '2024-01-01T00:00:00Z',
+  };
+  world.db.seed('characters', [character]);
+
+  const rows: Row[] = [creationRow(id)];
+  for (let lvl = 1; lvl <= seed.level; lvl += 1) rows.push(levelRow(id, lvl));
+  world.db.seed('character_build_levels', rows);
+
+  world.db.seed(
+    'character_items',
+    (seed.items ?? []).map((it, i) => ({
+      id: `cs-item-${i}`,
+      character_id: id,
+      item_id: it.item_id,
+      quantity: it.quantity,
+      equipped: it.equipped,
+      attuned: false,
+      source: null,
+    }))
+  );
+  return character;
+}
+
+async function renderCharacterSheet(world: DndWorld, campaign: Campaign, character: Row) {
+  const useCharactersMod = await world.esmockWithSupabase('@/hooks/useCharacters');
+  const useCharacterBuildMod = await world.esmockWithSupabase('@/hooks/useCharacterBuild');
+  const useBuilderAutosaveMod = await world.esmockWithSupabase('@/hooks/useBuilderAutosave');
+  const mod = await world.esmockWithSupabase('@/pages/CharacterSheet', {
+    '@/hooks/useCharacters': useCharactersMod,
+    '@/hooks/useCharacterBuild': useCharacterBuildMod,
+    '@/hooks/useBuilderAutosave': useBuilderAutosaveMod,
+    '@/hooks/usePageTitle': { usePageTitle: () => undefined },
+  });
+  const CharacterSheet = (mod.default ??
+    (mod as { CharacterSheet: unknown }).CharacterSheet) as () => React.ReactElement;
+  const router = (await import('react-router-dom')) as typeof import('react-router-dom');
+  const tree = createElement(
+    router.Routes,
+    null,
+    createElement(router.Route, {
+      path: '/campaign/:campaignSlug/character/:characterSlug',
+      element: createElement(CharacterSheet),
+    })
+  );
+  const r = await world.renderRoute(`/campaign/${campaign.slug}/character/${character.slug}`, tree);
+  await r.rtl.waitFor(() => {
+    if (!document.body.textContent?.includes(character.name as string)) throw new Error('character sheet not ready');
+  });
+  return r;
+}
+
+async function setupSheet(world: DndWorld, seed: SheetSeed) {
+  const campaign = seedCampaign(world);
+  const character = seedCharacter(world, campaign, seed);
+  await renderCharacterSheet(world, campaign, character);
+}
+
+// --- Givens -----------------------------------------------------------------
+
+Given('a level {int} Fighter character sheet', async function (this: DndWorld, level: number) {
+  await setupSheet(this, { level, status: 'draft' });
+});
+
+Given('a finalized Fighter character sheet holding a longsword', async function (this: DndWorld) {
+  await setupSheet(this, {
+    level: 1,
+    status: 'ready',
+    items: [{ item_id: 'longsword', quantity: 1, equipped: true }],
+  });
+});
+
+// --- Assertions -------------------------------------------------------------
+
+function statRowValue(label: string): string | null {
+  const labelSpan = (Array.from(document.querySelectorAll('span')) as HTMLSpanElement[]).find(
+    (s) => s.textContent?.trim() === label
+  );
+  const valueSpan = labelSpan?.parentElement?.querySelector('span.font-mono');
+  return valueSpan?.textContent?.trim() ?? null;
+}
+
+Then('the sheet shows a proficiency bonus of {int}', function (this: DndWorld, expected: number) {
+  const value = statRowValue('Proficiency Bonus');
+  if (value !== `+${expected}`) {
+    throw new Error(`Expected proficiency bonus "+${expected}", got "${value ?? '(not found)'}"`);
+  }
+});
+
+Then('the sheet shows the {word} {word} section', function (this: DndWorld, w1: string, w2: string) {
+  const heading = `${w1} ${w2}`;
+  if (!document.body.textContent?.includes(heading)) {
+    throw new Error(`Expected the "${heading}" section heading on the sheet`);
+  }
+});
+
+Then('the sheet shows the {word} section', function (this: DndWorld, heading: string) {
+  if (!document.body.textContent?.includes(heading)) {
+    throw new Error(`Expected the "${heading}" section heading on the sheet`);
+  }
+});
+
+Then('the sheet prompts the player to resolve pending choices', function (this: DndWorld) {
+  if (!document.body.textContent?.includes('Choices Required')) {
+    throw new Error('Expected a "Choices Required" pending-choices panel, but it was not shown');
+  }
+});
+
+Then('the equipment list shows the longsword', function (this: DndWorld) {
+  const txt = document.body.textContent ?? '';
+  if (!/longsword/i.test(txt)) {
+    throw new Error(`Expected the equipment list to show the longsword. Body: ${txt.slice(0, 400)}`);
+  }
+});
+
+// --- US-012: edit backstory / personality -----------------------------------
+
+function characterRow(world: DndWorld): Row {
+  const row = (world.db.rows('characters') as Row[]).find((c) => c.id === 'cs-char');
+  if (!row) throw new Error('Setup error: seeded character not found in the store');
+  return row;
+}
+
+// React 19 controlled inputs need user-event to fire onChange.
+async function typeInto(el: HTMLTextAreaElement, value: string): Promise<void> {
+  const userEvent = (await import('@testing-library/user-event')).default;
+  const user = userEvent.setup({ document });
+  await user.clear(el);
+  await user.type(el, value);
+}
+
+async function openSectionEditor(world: DndWorld, heading: string) {
+  const r = world.renderRouteResult!;
+  await r.rtl.act(async () => {
+    const h2 = (Array.from(document.querySelectorAll('h2')) as HTMLHeadingElement[]).find(
+      (h) => h.textContent?.trim() === heading
+    );
+    const btn = h2?.parentElement?.querySelector('button') as HTMLButtonElement | null;
+    if (!btn) throw new Error(`Could not find the edit control for the "${heading}" section`);
+    r.rtl.fireEvent.click(btn);
+  });
+  await r.rtl.waitFor(() => {
+    if (!document.querySelector('textarea')) throw new Error('edit dialog did not open');
+  });
+  return r;
+}
+
+async function saveDialog(world: DndWorld, predicate: () => boolean) {
+  const r = world.renderRouteResult!;
+  await r.rtl.act(async () => {
+    const save = (Array.from(document.querySelectorAll('button')) as HTMLButtonElement[]).find((b) =>
+      /^Save$/i.test((b.textContent ?? '').trim())
+    );
+    if (!save) throw new Error('Could not find the Save button in the edit dialog');
+    r.rtl.fireEvent.click(save);
+  });
+  await r.rtl.waitFor(() => {
+    if (!predicate()) throw new Error('edit not persisted yet');
+  });
+}
+
+Given('a Fighter character sheet with an existing backstory and personality', async function (this: DndWorld) {
+  await setupSheet(this, {
+    level: 1,
+    status: 'draft',
+    backstory: 'A wandering sellsword.',
+    personalityTraits: 'Stoic and watchful.',
+  });
+});
+
+When('the Dungeon Master edits the backstory to {string}', async function (this: DndWorld, text: string) {
+  await openSectionEditor(this, 'Backstory');
+  await typeInto(document.querySelector('textarea') as HTMLTextAreaElement, text);
+  await saveDialog(this, () => characterRow(this).backstory === text);
+});
+
+When('the Dungeon Master edits the personality traits to {string}', async function (this: DndWorld, text: string) {
+  await openSectionEditor(this, 'Personality');
+  await typeInto(document.querySelector('#personality-traits') as HTMLTextAreaElement, text);
+  await saveDialog(this, () => characterRow(this).personality_traits === text);
+});
+
+Then("the character's backstory reads {string}", function (this: DndWorld, text: string) {
+  const actual = characterRow(this).backstory;
+  if (actual !== text) throw new Error(`Expected backstory "${text}", got "${actual}"`);
+});
+
+Then("the character's personality traits read {string}", function (this: DndWorld, text: string) {
+  const actual = characterRow(this).personality_traits;
+  if (actual !== text) throw new Error(`Expected personality traits "${text}", got "${actual}"`);
+});

--- a/features/characters/steps/level-down.steps.ts
+++ b/features/characters/steps/level-down.steps.ts
@@ -1,0 +1,79 @@
+import { Given, When, Then } from '@cucumber/cucumber';
+import { createElement } from 'react';
+import type { DndWorld } from '../../steps/support/world.js';
+import { resolveBuild } from '../../steps/support/character-builder.js';
+
+// ---------------------------------------------------------------------------
+// Level down — resolver seam for the mechanical revert, plus a light
+// LevelControls render for the level-1 availability rule.
+// ---------------------------------------------------------------------------
+
+When('the most recent level is removed', function (this: DndWorld) {
+  const levels = this.build!.levels;
+  if (levels.length <= 1) {
+    throw new Error('Cannot remove a level below level 1');
+  }
+  this.build = { ...this.build!, levels: levels.slice(0, -1) };
+  this.resolved = resolveBuild(this.build);
+  // Mirror onto resolvedAtLevel so the shared "their proficiency bonus is {int}"
+  // step (level-up.steps.ts) reads the post-revert character.
+  this.resolvedAtLevel = this.resolved;
+});
+
+Then('the character is level {int}', function (this: DndWorld, expected: number) {
+  const actual = this.build!.levels.length;
+  if (actual !== expected) {
+    throw new Error(`Expected the character to be level ${expected}, got ${actual}`);
+  }
+});
+
+// --- Light LevelControls render: the level-1 availability rule ---------------
+
+async function renderLevelControls(world: DndWorld, level: number) {
+  const ctxStub = {
+    useCharacterContext: () => ({
+      level,
+      rows: [],
+      resolved: null,
+      hasDeletedRows: false,
+      nextRestoreLevel: null,
+      levelUp: () => undefined,
+      levelDown: () => undefined,
+      undoLevelDown: () => undefined,
+    }),
+  };
+  const mod = await world.esmockWithSupabase('@/components/character-sheet/LevelControls', {
+    '@/hooks/useCharacterContext': ctxStub,
+    // Stub the heavy level-up dialog — it is closed in these scenarios anyway.
+    '@/components/character-sheet/LevelUpDialog': { LevelUpDialog: () => null },
+  });
+  const LevelControls = (mod as { LevelControls: (p: { classId: string }) => React.ReactElement }).LevelControls;
+  return world.renderRoute('/', createElement(LevelControls, { classId: 'fighter' }));
+}
+
+function levelDownButton(): HTMLButtonElement | null {
+  return (
+    (Array.from(document.querySelectorAll('button')) as HTMLButtonElement[]).find((b) =>
+      /Level Down/i.test((b.textContent ?? '').trim())
+    ) ?? null
+  );
+}
+
+Given('a level {int} Fighter is shown on the character sheet', async function (this: DndWorld, level: number) {
+  await renderLevelControls(this, level);
+});
+
+Then('the Level Down action is unavailable', function (this: DndWorld) {
+  const btn = levelDownButton();
+  // Unavailable = either not rendered, or rendered disabled. The app hides it.
+  if (btn && !btn.disabled) {
+    throw new Error('Expected no actionable Level Down control at level 1, but an enabled button was rendered');
+  }
+});
+
+Then('the Level Down action is available', function (this: DndWorld) {
+  const btn = levelDownButton();
+  if (!btn || btn.disabled) {
+    throw new Error('Expected an actionable Level Down control above level 1, but none was rendered');
+  }
+});

--- a/features/characters/view-character-sheet.feature
+++ b/features/characters/view-character-sheet.feature
@@ -1,0 +1,23 @@
+Feature: View character sheet
+  As a player,
+  I want to view my character sheet,
+  So that I can reference my character's stats, features, and equipment during a session.
+
+  # Render-app seam: the real CharacterSheet page renders inside the real
+  # CharacterProvider, which reconstructs the build from seeded
+  # character_build_levels rows and resolves it via resolveCharacter(). Assertions
+  # read the rendered sheet (proficiency bonus, sections, pending panel, equipment).
+
+  Scenario: The sheet shows the resolved core statistics
+    Given a level 5 Fighter character sheet
+    Then the sheet shows a proficiency bonus of 3
+    And the sheet shows the Saving Throws section
+    And the sheet shows the Skills section
+
+  Scenario: Unresolved choices surface a Pending Choices panel
+    Given a level 5 Fighter character sheet
+    Then the sheet prompts the player to resolve pending choices
+
+  Scenario: The sheet lists the character's equipment
+    Given a finalized Fighter character sheet holding a longsword
+    Then the equipment list shows the longsword

--- a/features/export/export-campaigns.feature
+++ b/features/export/export-campaigns.feature
@@ -1,0 +1,23 @@
+Feature: Export selected campaigns as a SQL seed file
+  As a Dungeon Master,
+  I want to export one or more campaigns as a SQL seed file,
+  So that I can back up my data or migrate it to another environment.
+
+  # Render-app seam: the real ExportData page fetches the selected campaigns'
+  # rows through the stateful supabase, builds SQL via generateSeedSql(), and
+  # hands it to downloadFile() (URL.createObjectURL is stubbed so the Blob can be
+  # captured and inspected). Assertions read the generated SQL text.
+
+  Scenario: Exporting a campaign produces SQL with its related data
+    Given a campaign named "Dragon's Lair" exists with 2 characters and 2 sessions
+    And the Dungeon Master is on the export page
+    When the Dungeon Master selects "Dragon's Lair" for export
+    And the Dungeon Master exports the selected campaigns
+    Then the generated SQL contains INSERT statements for the campaigns table
+    And the generated SQL contains INSERT statements for the characters table
+    And the generated SQL contains INSERT statements for the sessions table
+
+  Scenario: The export button is disabled when nothing is selected
+    Given a campaign named "Dragon's Lair" exists
+    And the Dungeon Master is on the export page
+    Then the export button is disabled

--- a/features/export/export-error-handling.feature
+++ b/features/export/export-error-handling.feature
@@ -1,0 +1,28 @@
+Feature: Show an export error when the data fetch fails
+  As a Dungeon Master,
+  I want to see a clear error message if the export fails,
+  So that I know something went wrong and can try again.
+
+  # Render-app seam: ExportData's data fetch is routed through a supabase wrapper
+  # that can be toggled to fail. handleExport() catches the failure and sets
+  # errorMessage (rendered in an AlertCircle banner); a later successful export
+  # clears it (setErrorMessage(null) at the start of each attempt).
+
+  Scenario: A failed fetch shows an error instead of a download
+    Given a campaign named "Dragon's Lair" exists
+    And the export data fetch will fail
+    And the Dungeon Master is on the export page
+    When the Dungeon Master selects "Dragon's Lair" for export
+    And the Dungeon Master exports the selected campaigns
+    Then an export error is shown
+
+  Scenario: A successful retry clears a previous export error
+    Given a campaign named "Dragon's Lair" exists
+    And the export data fetch will fail
+    And the Dungeon Master is on the export page
+    When the Dungeon Master selects "Dragon's Lair" for export
+    And the Dungeon Master exports the selected campaigns
+    Then an export error is shown
+    When the export data fetch recovers
+    And the Dungeon Master exports the selected campaigns
+    Then no export error is shown

--- a/features/export/export-select-all.feature
+++ b/features/export/export-select-all.feature
@@ -1,0 +1,24 @@
+Feature: Select all or deselect all campaigns for export
+  As a Dungeon Master,
+  I want to quickly select or deselect all campaigns for export,
+  So that I can efficiently choose what to include without clicking each one.
+
+  # Pure UI state on the ExportData page — selectAll()/deselectAll() update the
+  # selectedIds Set, reflected in the "{selected} of {total} selected" counter.
+
+  Scenario: Select All checks every campaign
+    Given a campaign named "Dragon's Lair" exists
+    And a campaign named "City of Shadows" exists
+    And a campaign named "Dragon's Peak" exists
+    And the Dungeon Master is on the export page
+    When the Dungeon Master clicks Select All
+    Then 3 of 3 campaigns are selected for export
+
+  Scenario: Deselect All clears the selection
+    Given a campaign named "Dragon's Lair" exists
+    And a campaign named "City of Shadows" exists
+    And a campaign named "Dragon's Peak" exists
+    And the Dungeon Master is on the export page
+    When the Dungeon Master clicks Select All
+    And the Dungeon Master clicks Deselect All
+    Then 0 of 3 campaigns are selected for export

--- a/features/export/steps/export.steps.ts
+++ b/features/export/steps/export.steps.ts
@@ -1,0 +1,197 @@
+import { Before, Given, When, Then } from '@cucumber/cucumber';
+import { createElement } from 'react';
+import type { DndWorld } from '../../steps/support/world.js';
+
+// ---------------------------------------------------------------------------
+// Export — render-app seam.
+//
+// Renders the real ExportData page. useCampaigns is backed by the stateful
+// store; ExportData's direct supabase (the export fetch) is routed through a
+// togglable wrapper so US-020 can simulate a fetch failure. downloadFile() needs
+// URL.createObjectURL, which jsdom lacks — we stub it and capture the Blob so the
+// generated SQL can be inspected.
+// ---------------------------------------------------------------------------
+
+let failFetch = false;
+let capturedBlobs: Blob[] = [];
+
+Before(function () {
+  failFetch = false;
+  capturedBlobs = [];
+});
+
+// A thenable chain that resolves to a fetch error for the export's select().in() calls.
+function errorChain(): Record<string, unknown> {
+  const chain: Record<string, unknown> = {};
+  const self = (): Record<string, unknown> => chain;
+  chain.select = self;
+  chain.is = self;
+  chain.order = self;
+  chain.in = () => Promise.resolve({ data: null, error: { message: 'Simulated database failure' } });
+  return chain;
+}
+
+// Wrap the stateful client so from() fails while failFetch is set, else delegates.
+function failableSupabase(stateful: { from: (t: string) => unknown }) {
+  return {
+    from(table: string): unknown {
+      return failFetch ? errorChain() : stateful.from(table);
+    },
+  };
+}
+
+function stubObjectUrl(): void {
+  const url = globalThis.URL as unknown as {
+    createObjectURL?: (b: Blob) => string;
+    revokeObjectURL?: (u: string) => void;
+  };
+  url.createObjectURL = (blob: Blob): string => {
+    capturedBlobs.push(blob);
+    return 'blob:mock-url';
+  };
+  url.revokeObjectURL = (): void => undefined;
+}
+
+async function renderExport(world: DndWorld) {
+  stubObjectUrl();
+  const useCampaignsMod = await world.esmockWithSupabase('@/hooks/useCampaigns');
+  const mod = await world.esmockWithSupabase('@/pages/ExportData', {
+    // Override the default '@/lib/supabase' injection with the failable wrapper.
+    '@/lib/supabase': { supabase: failableSupabase(world.statefulSupabase as { from: (t: string) => unknown }) },
+    '@/hooks/useCampaigns': useCampaignsMod,
+    '@/hooks/usePageTitle': { usePageTitle: () => undefined },
+  });
+  const ExportData = (mod.default ?? (mod as { ExportData: unknown }).ExportData) as () => React.ReactElement;
+  const r = await world.renderRoute('/export', createElement(ExportData));
+  await r.rtl.waitFor(() => {
+    if ((document.body.textContent ?? '').includes('Loading')) throw new Error('still loading campaigns');
+  });
+  return r;
+}
+
+function campaignCard(name: string): HTMLButtonElement | null {
+  return (
+    (Array.from(document.querySelectorAll('button')) as HTMLButtonElement[]).find(
+      (b) => b.querySelector('p.font-medium')?.textContent === name
+    ) ?? null
+  );
+}
+
+function exportButton(): HTMLButtonElement | null {
+  return (
+    (Array.from(document.querySelectorAll('button')) as HTMLButtonElement[]).find((b) =>
+      /Export SQL Backup|Exporting/i.test((b.textContent ?? '').trim())
+    ) ?? null
+  );
+}
+
+function buttonByText(re: RegExp): HTMLButtonElement | null {
+  return (
+    (Array.from(document.querySelectorAll('button')) as HTMLButtonElement[]).find((b) =>
+      re.test((b.textContent ?? '').trim())
+    ) ?? null
+  );
+}
+
+// --- Givens -----------------------------------------------------------------
+
+Given('the Dungeon Master is on the export page', async function (this: DndWorld) {
+  await renderExport(this);
+});
+
+Given('the export data fetch will fail', function () {
+  failFetch = true;
+});
+
+When('the export data fetch recovers', function () {
+  failFetch = false;
+});
+
+// --- Selection --------------------------------------------------------------
+
+When('the Dungeon Master selects {string} for export', async function (this: DndWorld, name: string) {
+  const r = this.renderRouteResult!;
+  await r.rtl.act(async () => {
+    const card = campaignCard(name);
+    if (!card) throw new Error(`Could not find the "${name}" campaign card on the export page`);
+    r.rtl.fireEvent.click(card);
+  });
+});
+
+When('the Dungeon Master clicks Select All', async function (this: DndWorld) {
+  const r = this.renderRouteResult!;
+  await r.rtl.act(async () => {
+    const btn = buttonByText(/^Select All$/i);
+    if (!btn) throw new Error('Could not find the Select All button');
+    r.rtl.fireEvent.click(btn);
+  });
+});
+
+When('the Dungeon Master clicks Deselect All', async function (this: DndWorld) {
+  const r = this.renderRouteResult!;
+  await r.rtl.act(async () => {
+    const btn = buttonByText(/^Deselect All$/i);
+    if (!btn) throw new Error('Could not find the Deselect All button');
+    r.rtl.fireEvent.click(btn);
+  });
+});
+
+// --- Export action ----------------------------------------------------------
+
+When('the Dungeon Master exports the selected campaigns', async function (this: DndWorld) {
+  const r = this.renderRouteResult!;
+  const blobsBefore = capturedBlobs.length;
+  await r.rtl.act(async () => {
+    const btn = exportButton();
+    if (!btn) throw new Error('Could not find the Export button');
+    r.rtl.fireEvent.click(btn);
+  });
+  // Settle on a definite outcome: either a download Blob was produced or the error banner appeared.
+  await r.rtl.waitFor(() => {
+    const downloaded = capturedBlobs.length > blobsBefore;
+    const errored = (document.body.textContent ?? '').includes('Export failed');
+    if (!downloaded && !errored) throw new Error('export has not completed yet');
+  });
+});
+
+// --- Assertions -------------------------------------------------------------
+
+Then(
+  'the generated SQL contains INSERT statements for the {word} table',
+  async function (this: DndWorld, table: string) {
+    if (capturedBlobs.length === 0) {
+      throw new Error('No export Blob was captured — the download did not occur');
+    }
+    const sql = await capturedBlobs[capturedBlobs.length - 1].text();
+    if (!sql.includes(`INSERT INTO ${table}`)) {
+      throw new Error(`Expected SQL to contain "INSERT INTO ${table}", but it did not`);
+    }
+  }
+);
+
+Then('the export button is disabled', function (this: DndWorld) {
+  const btn = exportButton();
+  if (!btn) throw new Error('Could not find the Export button');
+  if (!btn.disabled) throw new Error('Expected the Export button to be disabled with no campaigns selected');
+});
+
+Then('{int} of {int} campaigns are selected for export', function (this: DndWorld, selected: number, total: number) {
+  const txt = document.body.textContent ?? '';
+  if (!txt.includes(`${selected} of ${total}`)) {
+    throw new Error(`Expected the selection counter to read "${selected} of ${total}". Body: ${txt.slice(0, 200)}`);
+  }
+});
+
+Then('an export error is shown', function (this: DndWorld) {
+  const txt = document.body.textContent ?? '';
+  if (!txt.includes('Export failed')) {
+    throw new Error(`Expected an "Export failed" error banner. Body: ${txt.slice(0, 200)}`);
+  }
+});
+
+Then('no export error is shown', function (this: DndWorld) {
+  const txt = document.body.textContent ?? '';
+  if (txt.includes('Export failed')) {
+    throw new Error('Expected no export error banner, but one is present');
+  }
+});

--- a/features/settings/color-mode.feature
+++ b/features/settings/color-mode.feature
@@ -1,0 +1,27 @@
+Feature: Switch light and dark mode
+  As a user,
+  I want to toggle between light and dark mode,
+  So that I can use the application comfortably in different lighting.
+
+  # Render-app seam: SettingsTheme inside the real ThemeProvider. Selecting a color
+  # mode persists to localStorage ('dnd-color-mode') and toggles the `.dark` class
+  # on <html>. "System" resolves against the prefers-color-scheme media query.
+
+  Scenario: Switching to Dark mode darkens the interface
+    Given the Dungeon Master is on the theme settings page
+    When the Dungeon Master selects the "Dark" color mode
+    Then the interface is in dark mode
+
+  Scenario: Switching back to Light mode lightens the interface
+    Given the Dungeon Master is on the theme settings page
+    When the Dungeon Master selects the "Dark" color mode
+    And the Dungeon Master selects the "Light" color mode
+    Then the interface is in light mode
+
+  Scenario: System mode follows the operating system preference
+    Given the operating system prefers dark mode
+    And the Dungeon Master is on the theme settings page
+    When the Dungeon Master selects the "Light" color mode
+    Then the interface is in light mode
+    When the Dungeon Master selects the "System" color mode
+    Then the interface is in dark mode

--- a/features/settings/global-theme.feature
+++ b/features/settings/global-theme.feature
@@ -1,0 +1,20 @@
+Feature: Switch the global color theme
+  As a user,
+  I want to choose a global color theme (Default, Sylvan, Arcane),
+  So that my preferred aesthetic is applied across all pages.
+
+  # Render-app seam: the real SettingsTheme page renders inside the real
+  # ThemeProvider. Selecting a theme calls setTheme, which persists to
+  # localStorage ('dnd-theme') and applies data-theme to <html> (the attribute is
+  # removed for the Default theme). Persistence across a reload is shown by the
+  # stored value, which a fresh ThemeProvider reads on mount.
+
+  Scenario: Selecting Sylvan applies it immediately
+    Given the Dungeon Master is on the theme settings page
+    When the Dungeon Master selects the "Sylvan" global theme
+    Then the interface uses the "Sylvan" theme
+
+  Scenario: The chosen global theme persists for the next visit
+    Given the Dungeon Master is on the theme settings page
+    When the Dungeon Master selects the "Arcane" global theme
+    Then the saved global theme is "Arcane"

--- a/features/settings/per-campaign-theme-override.feature
+++ b/features/settings/per-campaign-theme-override.feature
@@ -1,0 +1,21 @@
+Feature: Override per-campaign theme from Settings
+  As a Dungeon Master,
+  I want to set or clear the theme override for each campaign from the Settings page,
+  So that I can manage all campaign themes in one place.
+
+  # Render-app seam: SettingsTheme renders one CampaignThemeRow per campaign, each
+  # with its own ThemePicker (allowNone). Setting writes campaigns.theme; "Use
+  # global theme" writes null (inherit). Assertions read the persisted row, where
+  # the effective theme is `theme ?? default`.
+
+  Scenario: Setting an override for a campaign from Settings
+    Given a campaign named "Curse of Strahd" exists with no theme set
+    And the Dungeon Master is on the theme settings page
+    When the Dungeon Master sets the "Arcane" theme for "Curse of Strahd" in Settings
+    Then "Curse of Strahd" uses the "Arcane" theme
+
+  Scenario: Resetting a campaign override back to inherit the global theme
+    Given a campaign named "Curse of Strahd" exists with theme "Sylvan"
+    And the Dungeon Master is on the theme settings page
+    When the Dungeon Master resets "Curse of Strahd" to inherit in Settings
+    Then "Curse of Strahd" uses the "Default" theme

--- a/features/settings/steps/theme-settings.steps.ts
+++ b/features/settings/steps/theme-settings.steps.ts
@@ -1,0 +1,167 @@
+import { Given, When, Then } from '@cucumber/cucumber';
+import { createElement } from 'react';
+import type { DndWorld } from '../../steps/support/world.js';
+import type { Campaign } from '../../../src/types/database.js';
+
+// ---------------------------------------------------------------------------
+// Theme settings — render-app seam.
+//
+// Renders the real SettingsTheme page inside the real ThemeProvider, with the
+// stateful supabase injected (so useCampaigns and CampaignThemeRow's direct
+// supabase.update both hit the in-memory store). Reuses the global theme Then
+// steps from campaigns.steps.ts:
+//   - "the interface uses the {string} theme"  (asserts <html> data-theme)
+//   - "{string} uses the {string} theme"       (asserts the persisted campaign row)
+// and the campaign-seeding Givens ("a campaign named ... exists with theme ...").
+// ---------------------------------------------------------------------------
+
+async function renderSettings(world: DndWorld) {
+  const useCampaignsMod = await world.esmockWithSupabase('@/hooks/useCampaigns');
+  const mod = await world.esmockWithSupabase('@/pages/SettingsTheme', {
+    '@/hooks/useCampaigns': useCampaignsMod,
+    '@/hooks/usePageTitle': { usePageTitle: () => undefined },
+  });
+  const SettingsTheme = (mod.default ?? (mod as { SettingsTheme: unknown }).SettingsTheme) as () => React.ReactElement;
+  const themeMod = await import('@/components/ThemeProvider');
+  const ThemeProvider = themeMod.ThemeProvider;
+  const tree = createElement(ThemeProvider, null, createElement(SettingsTheme));
+  const r = await world.renderRoute('/settings/theme', tree);
+  await r.rtl.waitFor(() => {
+    if (!document.body.textContent?.includes('Global Theme')) throw new Error('settings page not ready');
+  });
+  return r;
+}
+
+function buttonByExactText(re: RegExp): HTMLButtonElement | null {
+  return (
+    (Array.from(document.querySelectorAll('button')) as HTMLButtonElement[]).find((b) =>
+      re.test((b.textContent ?? '').trim())
+    ) ?? null
+  );
+}
+
+/** The CampaignThemeRow wrapper (rounded border card) for a given campaign name. */
+function campaignThemeRow(name: string): HTMLElement {
+  const row = (Array.from(document.querySelectorAll('div.rounded-lg.border')) as HTMLElement[]).find(
+    (d) => d.querySelector('span.font-medium')?.textContent === name
+  );
+  if (!row) throw new Error(`Could not find the Settings theme row for campaign "${name}"`);
+  return row;
+}
+
+function rowButtonByText(row: HTMLElement, re: RegExp): HTMLButtonElement | null {
+  return (
+    (Array.from(row.querySelectorAll('button')) as HTMLButtonElement[]).find((b) =>
+      re.test((b.textContent ?? '').trim())
+    ) ?? null
+  );
+}
+
+function findCampaign(world: DndWorld, name: string): Campaign {
+  const row = (world.db.rows('campaigns') as unknown as Campaign[]).find((c) => c.name === name);
+  if (!row) throw new Error(`Setup error: no campaign named "${name}" in the store`);
+  return row;
+}
+
+// --- Givens -----------------------------------------------------------------
+
+Given('the Dungeon Master is on the theme settings page', async function (this: DndWorld) {
+  await renderSettings(this);
+});
+
+Given('the operating system prefers dark mode', function (this: DndWorld) {
+  // ThemeProvider resolves "system" via window.matchMedia('(prefers-color-scheme: dark)').
+  const win = globalThis.window as unknown as { matchMedia: (q: string) => unknown };
+  win.matchMedia = (query: string) => ({
+    matches: /dark/.test(query),
+    media: query,
+    onchange: null,
+    addListener: () => undefined,
+    removeListener: () => undefined,
+    addEventListener: () => undefined,
+    removeEventListener: () => undefined,
+    dispatchEvent: () => false,
+  });
+});
+
+// --- Global theme -----------------------------------------------------------
+
+When('the Dungeon Master selects the {string} global theme', async function (this: DndWorld, themeName: string) {
+  const r = this.renderRouteResult!;
+  await r.rtl.act(async () => {
+    const btn = buttonByExactText(new RegExp(`^${themeName}$`, 'i'));
+    if (!btn) throw new Error(`Could not find the "${themeName}" global theme button`);
+    r.rtl.fireEvent.click(btn);
+  });
+});
+
+Then('the saved global theme is {string}', async function (this: DndWorld, themeName: string) {
+  const themeId = themeName.toLowerCase();
+  const r = this.renderRouteResult!;
+  await r.rtl.waitFor(() => {
+    const stored = globalThis.localStorage.getItem('dnd-theme');
+    if (stored !== themeId) throw new Error(`Expected stored theme "${themeId}", got "${stored}"`);
+  });
+});
+
+// --- Color mode -------------------------------------------------------------
+
+When('the Dungeon Master selects the {string} color mode', async function (this: DndWorld, modeName: string) {
+  const r = this.renderRouteResult!;
+  await r.rtl.act(async () => {
+    const btn = buttonByExactText(new RegExp(`^${modeName}$`, 'i'));
+    if (!btn) throw new Error(`Could not find the "${modeName}" color mode button`);
+    r.rtl.fireEvent.click(btn);
+  });
+});
+
+Then('the interface is in dark mode', async function (this: DndWorld) {
+  const r = this.renderRouteResult!;
+  await r.rtl.waitFor(() => {
+    if (!document.documentElement.classList.contains('dark')) {
+      throw new Error('Expected <html> to have the "dark" class, but it did not');
+    }
+  });
+});
+
+Then('the interface is in light mode', async function (this: DndWorld) {
+  const r = this.renderRouteResult!;
+  await r.rtl.waitFor(() => {
+    if (document.documentElement.classList.contains('dark')) {
+      throw new Error('Expected <html> NOT to have the "dark" class, but it did');
+    }
+  });
+});
+
+// --- Per-campaign override from Settings ------------------------------------
+
+When(
+  'the Dungeon Master sets the {string} theme for {string} in Settings',
+  async function (this: DndWorld, themeName: string, campaignName: string) {
+    const themeId = themeName.toLowerCase();
+    const r = this.renderRouteResult!;
+    await r.rtl.act(async () => {
+      const btn = rowButtonByText(campaignThemeRow(campaignName), new RegExp(`^${themeName}$`, 'i'));
+      if (!btn) throw new Error(`Could not find the "${themeName}" theme button in "${campaignName}"'s row`);
+      r.rtl.fireEvent.click(btn);
+    });
+    await r.rtl.waitFor(() => {
+      if (findCampaign(this, campaignName).theme !== themeId) throw new Error('campaign theme not persisted yet');
+    });
+  }
+);
+
+When(
+  'the Dungeon Master resets {string} to inherit in Settings',
+  async function (this: DndWorld, campaignName: string) {
+    const r = this.renderRouteResult!;
+    await r.rtl.act(async () => {
+      const btn = rowButtonByText(campaignThemeRow(campaignName), /Use global theme/i);
+      if (!btn) throw new Error(`Could not find the "Use global theme" button in "${campaignName}"'s row`);
+      r.rtl.fireEvent.click(btn);
+    });
+    await r.rtl.waitFor(() => {
+      if (findCampaign(this, campaignName).theme != null) throw new Error('campaign theme not cleared yet');
+    });
+  }
+);

--- a/features/steps/support/stateful-supabase.ts
+++ b/features/steps/support/stateful-supabase.ts
@@ -15,7 +15,7 @@
  *   .update(patch).eq('id', x).select().single()
  *   .update(patch).eq('id', x)                 // awaited without select (archive)
  *   .delete().eq('id', x)
- *   .is(col, null) / .eq(col, val) / .order(col, {ascending})
+ *   .is(col, null) / .eq(col, val) / .in(col, [...]) / .order(col, {ascending})
  *   .not('sequence', 'in', '(0,1)') / .not('archived_at', 'is', null)
  *   .or('slug.eq.<v>,previous_slugs.cs.{"<v>"}') // slug-or-previous-slug lookup
  *   .single() / .maybeSingle()
@@ -161,6 +161,12 @@ export function createStatefulSupabase(): { supabase: unknown; db: StatefulDb } 
         this.s.predicates.push((r) => r[col] != null);
       }
       // UNSUPPORTED not() operator — ignored.
+      return this;
+    }
+    in(col: string, vals: readonly unknown[]): this {
+      // .in('id', [...]) → keep rows whose col matches any of the listed values.
+      const set = new Set(vals);
+      this.s.predicates.push((r) => set.has(r[col]));
       return this;
     }
     order(col: string, opts?: { ascending?: boolean }): this {

--- a/features/steps/support/world.ts
+++ b/features/steps/support/world.ts
@@ -274,23 +274,15 @@ After(function (this: DndWorld) {
   } catch {
     /* ignore */
   }
+  // NB: do NOT delete globalThis.window/document/navigator here. React's scheduler
+  // flushes deferred work on a setImmediate AFTER this hook returns; if the globals
+  // were deleted it throws "window is not defined" (an unhandled rejection that
+  // flips the process exit code even though every scenario passed). Each scenario's
+  // World constructor reassigns these globals to a fresh jsdom, so leaving the
+  // previous window in place until then preserves isolation. We still close the old
+  // window to release its resources.
   try {
     (globalThis.window as { close?: () => void } | undefined)?.close?.();
-  } catch {
-    /* ignore */
-  }
-  try {
-    delete (globalThis as { document?: Document }).document;
-  } catch {
-    /* ignore */
-  }
-  try {
-    delete (globalThis as { window?: Window }).window;
-  } catch {
-    /* ignore */
-  }
-  try {
-    delete (globalThis as { navigator?: Navigator }).navigator;
   } catch {
     /* ignore */
   }


### PR DESCRIPTION
## Summary

Adds Gherkin feature files + step bindings for **every story** in `features/_BACKLOG.md` (US-003, US-008–US-020). Implemented behaviors get full passing steps; the one genuine app gap is tagged `@future` with a real failing assertion (spec-first: the red scenario *is* the work order).

## Coverage

**Implemented → full passing steps** (default profile: 82 scenarios, 268 steps, 0 undefined):
- **Campaigns** — US-003 search (render `CampaignList`, type/clear the search box)
- **Characters** — US-008 builder draft resume, US-009 view sheet (proficiency bonus / saves / skills / pending-choices panel / equipment), US-010 subclass-at-L3 (added to existing `level-up-character.feature`), US-011 level-down (resolver mechanics + `LevelControls` availability), US-012 edit backstory & personality, US-014 resolve ASI (resolver seam)
- **Settings** — US-015 global theme, US-016 light/dark/system, US-017 per-campaign override
- **Export** — US-018 SQL generation, US-019 select/deselect all, US-020 error handling + retry-clears

**Genuine app gap → `@future`:**
- **US-013 archive** — the archive action sets `is_active:false`, but `useCharacters()` has no `is_active` filter, so archived characters still appear in the list. Tagged `@future`; fails because the character *appears* (a real assertion, not an undefined/throwing step). Hiding archived characters from the list is the to-do.

## Seam choices
- **Resolver seam** (no UI) for character mechanics — ASI, level-down revert, subclass prompt — mirroring the existing `level-up-character.feature`.
- **Render-app + stateful-supabase seam** where the rendered surface *is* the behavior — search, theme settings, export, character sheet, builder.

## Harness changes (test infra under `features/` only — no `src/` or migration changes)
- `stateful-supabase.ts` gains `.in(col, values)` (the export page issues `.select('*').in('id', ids)`).
- `world.ts` teardown no longer deletes `window`/`document`/`navigator`: React's scheduler flushes a deferred `setImmediate` *after* the `After` hook, which threw `window is not defined` and flaked the process exit code (~1 in 5 runs). Each scenario's World constructor reassigns these globals, so isolation is preserved. Verified 0/10 non-zero exits after the fix.

## Verification
- `npm run test:bdd` → 82 scenarios green, **0 undefined steps**
- `npm run test:bdd:future` → 8 scenarios red with real assertions (7 pre-existing + the new US-013 gap)
- 0 `@draft` remaining
- `npm run typecheck` + `eslint features` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)