### PR TITLE
test(bdd): revise auth/admin/collaboration specs per design decisions

### DIFF
--- a/features/admin/initiate-password-reset.feature
+++ b/features/admin/initiate-password-reset.feature
@@ -1,0 +1,39 @@
+@draft
+Feature: Admin-initiated password reset
+  As an admin,
+  I want to start a password reset for any user,
+  So that I can help someone locked out of their account without ever learning their password.
+
+  # assumption: an admin-initiated reset uses the same token mechanism as the
+  # self-service flow (see features/auth/password-reset.feature) — the admin
+  # triggers the reset link to be sent to the user; the admin never sets or sees
+  # the new password themselves.
+
+  Background:
+    Given the user is signed in as "boss@example.com" with the "admin" role
+
+  Scenario: An admin sends a reset link to a user
+    Given an account exists for "lockedout@example.com"
+    When the admin initiates a password reset for "lockedout@example.com"
+    Then a password reset link is sent to "lockedout@example.com"
+
+  Scenario: The admin never sets the user's password directly
+    Given an account exists for "lockedout@example.com"
+    When the admin initiates a password reset for "lockedout@example.com"
+    Then the admin is not shown a field to type a new password
+    And the user must complete the reset using their own link
+
+  Scenario: An admin can reset a disabled user's password
+    # The reset can be queued, but the account stays disabled until re-enabled,
+    # so the user still cannot sign in until an admin re-enables them.
+    Given the account "lockedout@example.com" has been disabled
+    When the admin initiates a password reset for "lockedout@example.com"
+    Then a password reset link is sent to "lockedout@example.com"
+    And "lockedout@example.com" still cannot sign in while disabled
+
+  Scenario: A non-admin cannot initiate a reset for someone else
+    Given the user is signed in as "player@example.com" with the "user" role
+    And an account exists for "victim@example.com"
+    When the user tries to initiate a password reset for "victim@example.com"
+    Then no password reset link is sent
+    And the user sees that they are not authorized

--- a/features/admin/manage-accounts.feature
+++ b/features/admin/manage-accounts.feature
@@ -1,0 +1,73 @@
+@draft
+Feature: Disable and re-enable accounts
+  As an admin,
+  I want to disable and re-enable accounts,
+  So that I can revoke or restore access while never dropping below one active admin.
+
+  # decision (no hard delete): account removal is a SOFT delete — there is no
+  # permanent account deletion. "Deleting" an account simply disables it; the
+  # account row, the campaigns it owns, and all characters in them are RETAINED.
+  # A disabled account is locked out (cannot sign in) but loses no data, and can
+  # be re-enabled later. This replaces the earlier "delete is permanent + cascade
+  # the owned campaigns" assumption.
+  # consequence: because nothing is destroyed, there is no "campaigns are deleted"
+  # or "assignments are cleared" behaviour on disable — an owner's campaigns and a
+  # player's character assignments survive a disable untouched and return intact on
+  # re-enable.
+  # decision (admin floor): at least one ACTIVE admin must always remain — the only
+  # admin cannot be disabled.
+
+  Background:
+    Given the user is signed in as "boss@example.com" with the "admin" role
+
+  Scenario: An admin disables an account
+    Given an account exists for "noisy@example.com" with the "user" role
+    When the admin disables "noisy@example.com"
+    Then "noisy@example.com" is marked as disabled
+    And "noisy@example.com" can no longer sign in
+
+  Scenario: An admin re-enables a disabled account
+    Given the account "noisy@example.com" has been disabled
+    When the admin re-enables "noisy@example.com"
+    Then "noisy@example.com" is marked as active
+    And "noisy@example.com" can sign in again
+
+  Scenario: Disabling an owner retains their campaigns
+    Given an account exists for "departing@example.com" with the "user" role
+    And "departing@example.com" owns a campaign named "Their Game"
+    When the admin disables "departing@example.com"
+    Then the campaign "Their Game" still exists
+    And "Their Game" is still owned by "departing@example.com"
+
+  Scenario: Re-enabling an owner restores access to their retained campaigns
+    Given an account exists for "departing@example.com" with the "user" role
+    And "departing@example.com" owns a campaign named "Their Game"
+    And the account "departing@example.com" has been disabled
+    When the admin re-enables "departing@example.com"
+    Then "departing@example.com" can sign in again
+    And "departing@example.com" still owns the campaign "Their Game"
+
+  Scenario: Disabling a player keeps their character assignments intact
+    Given an account exists for "departing@example.com" with the "user" role
+    And "departing@example.com" is the assigned player of the character "Borrowed Hero" in someone else's campaign
+    When the admin disables "departing@example.com"
+    Then the character "Borrowed Hero" still exists
+    And the character "Borrowed Hero" is still assigned to "departing@example.com"
+
+  Scenario: The last active admin cannot be disabled
+    Given "boss@example.com" is the only active admin
+    When the admin tries to disable "boss@example.com"
+    Then the account is not disabled
+    And the admin sees that at least one active admin must remain
+
+  Scenario: Disabling the second-to-last admin is allowed
+    Given an account exists for "cofounder@example.com" with the "admin" role
+    When the admin disables "cofounder@example.com"
+    Then "cofounder@example.com" is marked as disabled
+
+  Scenario: A non-admin cannot disable accounts
+    Given the user is signed in as "player@example.com" with the "user" role
+    And an account exists for "victim@example.com" with the "user" role
+    When the user tries to disable "victim@example.com"
+    Then the account is not disabled
+    And the user sees that they are not authorized

--- a/features/admin/manage-roles.feature
+++ b/features/admin/manage-roles.feature
@@ -1,0 +1,54 @@
+@draft
+Feature: Promote and demote account roles
+  As an admin,
+  I want to grant and revoke admin rights,
+  So that the right people can manage the system while always keeping at least one admin.
+
+  # assumption: there are exactly two global roles — "admin" and "user".
+  # "Promote" grants admin; "demote" revokes it. Per-campaign standing (owner vs
+  # invited player) is separate and lives under features/campaigns/ and
+  # features/collaboration/. Note "viewer" is not a distinct role — it is simply an
+  # invited player who has no character assigned (see collaboration/).
+
+  Background:
+    Given the user is signed in as "boss@example.com" with the "admin" role
+
+  Scenario: An admin promotes a user to admin
+    Given an account exists for "trusted@example.com" with the "user" role
+    When the admin promotes "trusted@example.com" to admin
+    Then "trusted@example.com" has the "admin" role
+
+  Scenario: An admin demotes another admin to user
+    Given an account exists for "trusted@example.com" with the "admin" role
+    When the admin demotes "trusted@example.com" to user
+    Then "trusted@example.com" has the "user" role
+
+  Scenario: The last active admin cannot be demoted
+    # The floor counts ACTIVE admins, matching disable/re-enable in
+    # features/admin/manage-accounts.feature — a disabled admin does not satisfy it.
+    Given "boss@example.com" is the only active admin
+    When the admin tries to demote "boss@example.com" to user
+    Then the role is not changed
+    And the admin sees that at least one active admin must remain
+    And "boss@example.com" still has the "admin" role
+
+  Scenario: The last active admin cannot be demoted even if a disabled admin exists
+    # Lockout guard: a disabled admin cannot re-enable anyone, so demoting the only
+    # active admin while the other admin is disabled would leave zero usable admins.
+    Given an account exists for "cofounder@example.com" with the "admin" role
+    And the account "cofounder@example.com" has been disabled
+    When the admin tries to demote "boss@example.com" to user
+    Then the role is not changed
+    And the admin sees that at least one active admin must remain
+
+  Scenario: An admin can demote themselves while another active admin remains
+    Given an account exists for "cofounder@example.com" with the "admin" role
+    When the admin demotes "boss@example.com" to user
+    Then "boss@example.com" has the "user" role
+
+  Scenario: A non-admin cannot change roles
+    Given the user is signed in as "player@example.com" with the "user" role
+    And an account exists for "victim@example.com" with the "user" role
+    When the user tries to promote "victim@example.com" to admin
+    Then the role is not changed
+    And the user sees that they are not authorized

--- a/features/auth/authentication.feature
+++ b/features/auth/authentication.feature
@@ -1,0 +1,57 @@
+@draft
+Feature: Sign in and sign out
+  As a registered user,
+  I want to sign in with my credentials and sign out when finished,
+  So that only I can access my campaigns and characters.
+
+  # decision (account enumeration): the app hides account existence and account
+  # state everywhere. Every failed sign-in — wrong password, unknown email,
+  # disabled account, or unconfirmed email — returns the SAME generic
+  # "invalid credentials" message, so a failed attempt never reveals whether an
+  # email is registered, disabled, or merely unconfirmed.
+  # decision (email verification): an account must have confirmed its email
+  # (see features/auth/sign-up.feature) before it can sign in.
+
+  Scenario: A user signs in with valid credentials
+    Given a confirmed account exists for "player@example.com" with password "Correct-Horse-1"
+    When the user signs in with email "player@example.com" and password "Correct-Horse-1"
+    Then the user is signed in as "player@example.com"
+
+  Scenario: Signing in with a wrong password is rejected
+    Given a confirmed account exists for "player@example.com" with password "Correct-Horse-1"
+    When the user signs in with email "player@example.com" and password "wrong-password"
+    Then the user is not signed in
+    And the user sees that the credentials are invalid
+
+  Scenario: Signing in with an unknown email is rejected
+    Given no account exists for "ghost@example.com"
+    When the user signs in with email "ghost@example.com" and password "anything"
+    Then the user is not signed in
+    And the user sees that the credentials are invalid
+
+  Scenario: A disabled account cannot sign in and is not distinguishable from a bad login
+    # Enumeration guard: a disabled account returns the SAME generic message as a
+    # wrong password — the attempt must not reveal that the account is disabled.
+    Given a confirmed account exists for "banned@example.com" with password "Correct-Horse-1"
+    And the account "banned@example.com" has been disabled by an admin
+    When the user signs in with email "banned@example.com" and password "Correct-Horse-1"
+    Then the user is not signed in
+    And the user sees that the credentials are invalid
+
+  Scenario: An unconfirmed account cannot sign in and is not distinguishable from a bad login
+    # Enumeration guard: an unconfirmed account returns the SAME generic message.
+    Given an account for "pending@example.com" is pending email confirmation
+    When the user signs in with email "pending@example.com" and the correct password
+    Then the user is not signed in
+    And the user sees that the credentials are invalid
+
+  Scenario: A signed-in user signs out
+    Given the user is signed in as "player@example.com"
+    When the user signs out
+    Then the user is no longer signed in
+    And visiting a campaign page redirects to the sign-in screen
+
+  Scenario: Protected pages require a signed-in user
+    Given no user is signed in
+    When the visitor opens a campaign page directly
+    Then the visitor is redirected to the sign-in screen

--- a/features/auth/password-reset.feature
+++ b/features/auth/password-reset.feature
@@ -1,0 +1,55 @@
+@draft
+Feature: Reset a forgotten password
+  As a user who has forgotten their password,
+  I want to request a reset link and choose a new password,
+  So that I can regain access to my account.
+
+  # assumption: reset is token-based — requesting a reset emails a single-use,
+  # time-limited link; following it lets the user set a new password. The token
+  # is consumed on use and old passwords stop working immediately.
+  # decision (account enumeration): this generic-confirmation behaviour is the
+  # account-enumeration policy applied across the whole suite (sign-up and sign-in
+  # hide existence too).
+  # decision (password policy): the strength rule is the Supabase project's
+  # configured policy — these specs do not pin a length/complexity value.
+  # "too weak" below is illustrative, not a hardcoded threshold.
+
+  Scenario: A user requests a password reset
+    Given an account exists for "forgetful@example.com"
+    When the user requests a password reset for "forgetful@example.com"
+    Then a password reset link is sent to "forgetful@example.com"
+
+  Scenario: Requesting a reset for an unknown email reveals nothing
+    # Security: the confirmation message is identical whether or not the email
+    # is registered, so attackers cannot enumerate accounts.
+    Given no account exists for "stranger@example.com"
+    When the user requests a password reset for "stranger@example.com"
+    Then the user sees the same generic confirmation message
+    And no password reset link is sent
+
+  Scenario: A user sets a new password with a valid reset token
+    Given a valid password reset token was issued for "forgetful@example.com"
+    When the user sets a new password "Brand-New-Pw-2" using that token
+    Then the password for "forgetful@example.com" is updated
+    And the user can sign in with "Brand-New-Pw-2"
+    And the user cannot sign in with their old password
+
+  Scenario: An expired reset token is rejected
+    Given an expired password reset token was issued for "forgetful@example.com"
+    When the user tries to set a new password using that token
+    Then the password is not changed
+    And the user sees that the reset link has expired
+
+  Scenario: A reset token can only be used once
+    Given a valid password reset token was issued for "forgetful@example.com"
+    And the token has already been used to set a new password
+    When the user tries to set another password using the same token
+    Then the password is not changed
+    And the user sees that the reset link is no longer valid
+
+  Scenario: The new password must meet the requirements
+    # The exact rule is the Supabase project's configured policy, not a fixed value.
+    Given a valid password reset token was issued for "forgetful@example.com"
+    When the user tries to set a new password that is too weak using that token
+    Then the password is not changed
+    And the user sees that the password does not meet the requirements

--- a/features/auth/sign-up.feature
+++ b/features/auth/sign-up.feature
@@ -1,0 +1,59 @@
+@draft
+Feature: Sign up for an account
+  As a visitor,
+  I want to create my own account,
+  So that I can own campaigns and play characters in others'.
+
+  # assumption: accounts are self-service — a visitor registers themselves with
+  # email + password. Admins do NOT create accounts (their powers are reset/
+  # disable/promote/demote — see features/admin/).
+  # decision (registration): registration is open self-service.
+  # decision (first admin): the initial admin is seeded by migration/env config,
+  # NOT by "whoever registers first". Every self-service account is a plain "user";
+  # there is no bootstrap-admin scenario.
+  # decision (email verification): a new account must confirm its email before it
+  # can sign in (Supabase email confirmation). Registering does NOT immediately
+  # sign the visitor in.
+  # decision (password policy): password strength is whatever the Supabase project
+  # is configured for — these specs do not pin a specific length/complexity rule.
+  # "too weak" below is illustrative, not a hardcoded threshold.
+  # decision (account enumeration): the suite hides account existence everywhere
+  # (see features/auth/password-reset.feature). Signing up with an already-registered
+  # email therefore must NOT reveal that on screen — the visitor sees the same
+  # generic "check your email" confirmation, and an email is sent to the existing
+  # account instead of creating a duplicate.
+
+  Scenario: A visitor registers with email and password
+    Given no account exists for "dm@example.com"
+    When the visitor signs up with email "dm@example.com" and a valid password
+    Then an account for "dm@example.com" is created
+    And the new account has the "user" role
+    And the new account is pending email confirmation
+    And the visitor is not yet signed in
+    And the visitor sees a generic "check your email to confirm your account" message
+
+  Scenario: A confirmed account can sign in
+    Given an account for "dm@example.com" is pending email confirmation
+    When the visitor confirms their email using the confirmation link
+    Then the account for "dm@example.com" is confirmed
+    And the user can sign in as "dm@example.com"
+
+  Scenario: Signing up with an already-registered email does not reveal the account exists
+    # Account-enumeration guard: the on-screen result is identical to a fresh signup.
+    # No duplicate account is created; an email is sent to the existing address.
+    Given an account exists for "dm@example.com"
+    When a visitor tries to sign up with email "dm@example.com"
+    Then no second account is created for "dm@example.com"
+    And the visitor sees the same generic "check your email to confirm your account" message
+    And an account-already-exists notice is emailed to "dm@example.com"
+
+  Scenario: A weak password is rejected
+    # The exact rule is the Supabase project's configured policy, not a fixed value.
+    When the visitor tries to sign up with email "new@example.com" and a password that is too weak
+    Then the account is not created
+    And the visitor sees that the password does not meet the requirements
+
+  Scenario: Email format is validated
+    When the visitor tries to sign up with email "not-an-email"
+    Then the account is not created
+    And the visitor sees that the email is invalid

--- a/features/collaboration/accept-invite.feature
+++ b/features/collaboration/accept-invite.feature
@@ -1,0 +1,39 @@
+@draft
+Feature: Respond to a campaign invite
+  As a player,
+  I want to accept or decline an invite to a campaign,
+  So that I only join the games I actually want to be part of.
+
+  Background:
+    Given the user is signed in as "alice@example.com"
+    And "alice@example.com" has a pending invite to "Sunless Citadel"
+
+  Scenario: A player accepts an invite
+    When "alice@example.com" accepts the invite to "Sunless Citadel"
+    Then "alice@example.com" is a player in "Sunless Citadel"
+    And "alice@example.com" can view "Sunless Citadel"
+    And the invite is no longer pending
+
+  Scenario: A player declines an invite
+    When "alice@example.com" declines the invite to "Sunless Citadel"
+    Then "alice@example.com" is not a member of "Sunless Citadel"
+    And the invite is no longer pending
+    And "alice@example.com" cannot view "Sunless Citadel"
+
+  Scenario: A user can only respond to their own invite
+    Given the user is signed in as "mallory@example.com"
+    When "mallory@example.com" tries to accept the invite addressed to "alice@example.com"
+    Then "mallory@example.com" is not a member of "Sunless Citadel"
+    And "mallory@example.com" sees that they are not authorized
+
+  Scenario: An invite revoked by the owner can no longer be accepted
+    Given the owner has revoked the invite to "alice@example.com"
+    When "alice@example.com" tries to accept the invite to "Sunless Citadel"
+    Then "alice@example.com" is not a member of "Sunless Citadel"
+    And "alice@example.com" sees that the invite is no longer available
+
+  Scenario: A player can leave a campaign they joined
+    Given "alice@example.com" accepted the invite and is a player in "Sunless Citadel"
+    When "alice@example.com" leaves "Sunless Citadel"
+    Then "alice@example.com" is not a member of "Sunless Citadel"
+    And any characters assigned to "alice@example.com" in "Sunless Citadel" have no assigned player

--- a/features/collaboration/assign-characters.feature
+++ b/features/collaboration/assign-characters.feature
@@ -1,0 +1,60 @@
+@draft
+Feature: Assign characters to players
+  As the owner of a campaign,
+  I want to assign characters in my campaign to players who have joined it,
+  So that each player controls the right character.
+
+  # Character-change-approval workflow is INTENTIONALLY out of scope: an assigned
+  # player edits their own character directly with no owner approval step. Do not
+  # add an approval gate to satisfy any future agent reading this file.
+  #
+  # Two hard invariants this feature pins down:
+  #   1. A character belongs to EXACTLY ONE campaign (already enforced structurally
+  #      by characters.campaign_id NOT NULL single FK — there is no move-between-
+  #      campaigns operation; the scenario below documents that invariant).
+  #   2. A character has EXACTLY ZERO OR ONE assigned player — assigning replaces
+  #      any previous assignee rather than accumulating.
+  #
+  # assumption: only the campaign owner assigns/reassigns/unassigns characters.
+  # A player creating their own character within a joined campaign is auto-assigned
+  # to themselves (see features/collaboration/manage-own-characters.feature).
+
+  Background:
+    Given the user is signed in as "owner@example.com"
+    And "owner@example.com" owns a campaign named "Sunless Citadel"
+    And "alice@example.com" is a player in "Sunless Citadel"
+    And a character named "Thorin" exists in "Sunless Citadel" with no assigned player
+
+  Scenario: An owner assigns a character to a player in the campaign
+    When the owner assigns "Thorin" to "alice@example.com"
+    Then "Thorin" is assigned to "alice@example.com"
+
+  Scenario: A character cannot be assigned to a non-member
+    Given "bob@example.com" is not a member of "Sunless Citadel"
+    When the owner tries to assign "Thorin" to "bob@example.com"
+    Then "Thorin" has no assigned player
+    And the owner sees that the player must be a member of the campaign
+
+  Scenario: Assigning a character to a new player replaces the previous assignee
+    Given "Thorin" is assigned to "alice@example.com"
+    And "carol@example.com" is a player in "Sunless Citadel"
+    When the owner assigns "Thorin" to "carol@example.com"
+    Then "Thorin" is assigned to "carol@example.com"
+    And "Thorin" is not assigned to "alice@example.com"
+
+  Scenario: An owner unassigns a character
+    Given "Thorin" is assigned to "alice@example.com"
+    When the owner unassigns "Thorin"
+    Then "Thorin" has no assigned player
+
+  Scenario: A character belongs to exactly one campaign
+    Given "owner@example.com" also owns a campaign named "Dragon Heist"
+    When the owner views the character "Thorin"
+    Then "Thorin" belongs only to "Sunless Citadel"
+    And there is no way to also place "Thorin" in "Dragon Heist"
+
+  Scenario: A non-owner cannot assign characters
+    Given the user is signed in as "alice@example.com"
+    When the player tries to assign "Thorin" to "alice@example.com"
+    Then "Thorin" has no assigned player
+    And the player sees that they are not authorized

--- a/features/collaboration/data-ownership-isolation.feature
+++ b/features/collaboration/data-ownership-isolation.feature
@@ -1,0 +1,68 @@
+@draft
+Feature: Each user owns their own campaigns and characters
+  As a user,
+  I want my campaigns and characters to be private to me and the players I invite,
+  So that other users cannot see or change my data.
+
+  # assumption: "ownership" of a campaign belongs to its creator. A user's
+  # campaign list shows campaigns they own PLUS campaigns they were invited to and
+  # accepted. Players see a joined campaign but only in a view capacity (plus their
+  # own characters); they do not own it.
+  # decision (view scope): for this first pass a joined player's view covers their
+  # own characters only; player visibility of sessions/encounters/notes is out of
+  # scope (see invite-players.feature).
+  # decision (denied = 403): denying access to a non-member returns a 403 Forbidden
+  # (the resource exists but is not authorized) — NOT a 404. Campaign existence is
+  # not treated as a secret from a signed-in user, unlike the anonymous
+  # account-enumeration guard on the sign-in/sign-up surface.
+
+  Scenario: Pre-auth data is assigned to the seeded admin when auth is introduced
+    # decision (existing data): the app currently has NO owner columns — campaigns
+    # and characters predate auth. When auth ships, the ownership migration backfills
+    # every pre-existing campaign (and its characters) to the seeded admin account
+    # (see features/auth/sign-up.feature), so no data is left ownerless.
+    Given a campaign named "Legacy Game" existed before authentication was introduced
+    And "admin@example.com" is the seeded admin account
+    When the ownership migration runs
+    Then "Legacy Game" is owned by "admin@example.com"
+    And every character in "Legacy Game" belongs to "Legacy Game"
+
+  Scenario: A new user starts with no campaigns
+    Given the user is signed in as "newbie@example.com"
+    And "newbie@example.com" owns no campaigns and has joined none
+    When "newbie@example.com" views their campaign list
+    Then the campaign list is empty
+
+  Scenario: A user sees campaigns they own
+    Given the user is signed in as "owner@example.com"
+    And "owner@example.com" owns a campaign named "Sunless Citadel"
+    When "owner@example.com" views their campaign list
+    Then "Sunless Citadel" appears in their campaign list
+
+  Scenario: A user does not see another user's campaigns
+    Given an account exists for "stranger@example.com" who owns a campaign named "Private Game"
+    And the user is signed in as "owner@example.com"
+    When "owner@example.com" views their campaign list
+    Then "Private Game" does not appear in their campaign list
+
+  Scenario: A user cannot open another user's campaign by direct link
+    Given an account exists for "stranger@example.com" who owns a campaign named "Private Game"
+    And the user is signed in as "owner@example.com"
+    And "owner@example.com" is not a member of "Private Game"
+    When "owner@example.com" opens the "Private Game" campaign page directly
+    Then access is denied with a 403 Forbidden
+
+  Scenario: A joined player sees the campaign but not the owner's other campaigns
+    Given the user is signed in as "alice@example.com"
+    And "alice@example.com" is a player in "Sunless Citadel" owned by "owner@example.com"
+    And "owner@example.com" also owns a campaign named "Secret Game" that "alice@example.com" has not joined
+    When "alice@example.com" views their campaign list
+    Then "Sunless Citadel" appears in their campaign list
+    And "Secret Game" does not appear in their campaign list
+
+  Scenario: A user cannot see characters in a campaign they have not joined
+    Given an account exists for "stranger@example.com" who owns a campaign named "Private Game" with a character named "Hidden Hero"
+    And the user is signed in as "owner@example.com"
+    When "owner@example.com" tries to view the characters in "Private Game"
+    Then access is denied with a 403 Forbidden
+    And "Hidden Hero" is not shown

--- a/features/collaboration/invite-players.feature
+++ b/features/collaboration/invite-players.feature
@@ -1,0 +1,72 @@
+@draft
+Feature: Invite players to a campaign
+  As the owner of a campaign,
+  I want to invite other users to view my campaign,
+  So that my players can follow along and be assigned characters.
+
+  # assumption: the user who creates a campaign is its sole "owner" (the DM).
+  # decision (invite target): only ALREADY-REGISTERED users can be invited, by
+  # email. Inviting an address with no account is out of scope for this pass.
+  # decision (view scope): for this first pass, a player's "view" of the campaign
+  # covers CHARACTERS only — creating/editing characters assigned to them. Player
+  # visibility of sessions, encounters, and notes is intentionally OUT OF SCOPE
+  # here and will be specified later. A player still cannot edit campaign settings
+  # or other players' characters.
+  # decision (viewer): "viewer" is not a separate role — it is simply an invited
+  # player who currently has no character assigned to them.
+  # decision (invite delivery): a pending invite is surfaced both in-app and by
+  # email, and does NOT expire (the owner can revoke it — see accept-invite.feature).
+  # assumption: an invite is pending until the invitee accepts or declines
+  # (see features/collaboration/accept-invite.feature). A pending invite does
+  # not yet grant view access.
+
+  Background:
+    Given the user is signed in as "owner@example.com"
+    And "owner@example.com" owns a campaign named "Sunless Citadel"
+
+  Scenario: An owner invites a registered user as a player
+    Given an account exists for "alice@example.com"
+    When the owner invites "alice@example.com" to "Sunless Citadel"
+    Then "alice@example.com" has a pending invite to "Sunless Citadel"
+
+  Scenario: An unregistered email cannot be invited
+    # Registered-users-only: inviting an address with no account is rejected for
+    # this pass (invite-then-signup is out of scope). Note: surfacing this to the
+    # owner does reveal whether that email has an account — an accepted trade-off
+    # for an authenticated, authorized owner, distinct from the anonymous
+    # account-enumeration guard on the sign-in/sign-up surface.
+    Given no account exists for "nobody@example.com"
+    When the owner tries to invite "nobody@example.com" to "Sunless Citadel"
+    Then no invite is created
+    And the owner sees that only registered users can be invited
+
+  Scenario: A pending invite does not yet grant access
+    Given the owner has invited "alice@example.com" to "Sunless Citadel"
+    And the invite is still pending
+    When "alice@example.com" tries to view "Sunless Citadel"
+    Then "alice@example.com" cannot view the campaign
+
+  Scenario: The same user cannot be invited twice while a pending invite exists
+    Given the owner has invited "alice@example.com" to "Sunless Citadel"
+    When the owner tries to invite "alice@example.com" to "Sunless Citadel" again
+    Then no second invite is created
+    And the owner sees that an invite is already pending
+
+  Scenario: A current member cannot be re-invited
+    Given "alice@example.com" is already a player in "Sunless Citadel"
+    When the owner tries to invite "alice@example.com" to "Sunless Citadel"
+    Then no invite is created
+    And the owner sees that the user is already a member
+
+  Scenario: A non-owner cannot invite players
+    Given "alice@example.com" is already a player in "Sunless Citadel"
+    And the user is signed in as "alice@example.com"
+    When the player tries to invite "bob@example.com" to "Sunless Citadel"
+    Then no invite is created
+    And the player sees that they are not authorized
+
+  Scenario: An owner removes a player from the campaign
+    Given "alice@example.com" is already a player in "Sunless Citadel"
+    When the owner removes "alice@example.com" from "Sunless Citadel"
+    Then "alice@example.com" is no longer a member of "Sunless Citadel"
+    And "alice@example.com" can no longer view the campaign

--- a/features/collaboration/manage-own-characters.feature
+++ b/features/collaboration/manage-own-characters.feature
@@ -1,0 +1,42 @@
+@draft
+Feature: Players manage their own characters
+  As a player in a campaign,
+  I want to create and edit the characters assigned to me,
+  So that I control my own character without waiting on the DM.
+
+  # No change-approval workflow: edits by an assigned player take effect
+  # immediately. The campaign owner can also edit any character in their campaign.
+
+  Background:
+    Given the user is signed in as "alice@example.com"
+    And "alice@example.com" is a player in "Sunless Citadel"
+
+  Scenario: A player creates a character in a campaign they joined and is auto-assigned
+    When "alice@example.com" creates a character named "Lyra" in "Sunless Citadel"
+    Then "Lyra" exists in "Sunless Citadel"
+    And "Lyra" is assigned to "alice@example.com"
+
+  Scenario: A player edits a character assigned to them
+    Given a character named "Lyra" in "Sunless Citadel" is assigned to "alice@example.com"
+    When "alice@example.com" levels up "Lyra"
+    Then the change is saved without any approval step
+
+  Scenario: A player cannot edit another player's character
+    Given "bob@example.com" is a player in "Sunless Citadel"
+    And a character named "Grog" in "Sunless Citadel" is assigned to "bob@example.com"
+    When "alice@example.com" tries to edit "Grog"
+    Then the change is not saved
+    And "alice@example.com" sees that they are not authorized
+
+  Scenario: A player cannot create a character in a campaign they have not joined
+    Given "alice@example.com" is not a member of "Waterdeep"
+    When "alice@example.com" tries to create a character in "Waterdeep"
+    Then no character is created
+    And "alice@example.com" sees that they are not a member of the campaign
+
+  Scenario: The campaign owner can edit any character in their campaign
+    Given the user is signed in as "owner@example.com"
+    And "owner@example.com" owns "Sunless Citadel"
+    And a character named "Lyra" in "Sunless Citadel" is assigned to "alice@example.com"
+    When the owner edits "Lyra"
+    Then the change is saved


### PR DESCRIPTION
## Summary

The junior BA's spec-first BDD suite for authentication and collaboration lived on a worktree (`bdd-auth-collab-specs`) that was **deleted before merge** — its commit was still reachable, so nothing was lost. This PR re-applies all 11 feature files onto `main` and resolves the BA's open `# assumption:` forks into confirmed product decisions (gathered via a round of design questions).

All files remain `@draft` (excluded from the default green `npm run test:bdd` run) and parse cleanly — **66 scenarios across 11 files**.

## Decisions applied

| Area | Decision | Spec change |
|---|---|---|
| **Registration** | Open self-service | kept |
| **First admin** | Seeded via migration/env | ❌ removed "first signup = admin" bootstrap scenario |
| **Email verification** | Required before sign-in | ➕ confirm-email scenario + sign-in gate |
| **Password policy** | Defer to Supabase config | softened hardcoded `"123"` rule to "too weak" |
| **Account enumeration** | Strict — hide existence everywhere | sign-in returns generic "invalid credentials" for wrong-password/unknown/disabled/unconfirmed; signup no longer leaks "email already in use" |
| **Account removal** | Soft-delete only (disable + retain) | ❗ removed hard-delete + cascade-destroy scenarios; campaigns/assignments survive a disable and return on re-enable |
| **Campaign view scope** | Characters only (this pass) | sessions/encounters/notes explicitly out of scope |
| **Per-campaign roles** | "Viewer" = invited player w/ no character | clarified; no new role |
| **Invite target** | Registered users only | ➕ explicit reject scenario for unregistered emails |
| **Invite delivery** | In-app + email, no expiry | documented |
| **Direct-link denial** | 403 Forbidden (not 404) | scenarios updated |
| **Pre-auth data** | Backfill to seeded admin | ➕ ownership-migration scenario (verified: no owner columns exist today) |

## Notes / tensions flagged in-spec
- **Strict-enum vs registered-only invites:** an authenticated owner inviting players will see whether an email is registered — accepted as a lower-risk, owner-facing trade-off distinct from the anonymous sign-in/sign-up guard. Noted in `invite-players.feature`.
- **403 vs strict-enum:** a 403 confirms a campaign exists to a signed-in user; campaign existence is not treated as secret (unlike account existence). Noted in `data-ownership-isolation.feature`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)