### PR TITLE
fix(i18n): resolve feat-feature translation keys + silence BDD console noise

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -15,6 +15,7 @@ export default defineConfig(
       globals: {
         URL: 'readonly',
         TextDecoder: 'readonly',
+        console: 'readonly',
       },
     },
   },
@@ -58,6 +59,13 @@ export default defineConfig(
   },
   {
     files: ['src/lib/logger.ts'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
+  {
+    // BDD entrypoint must filter Cucumber's startup banner on the real console.
+    files: ['features/support/register.mjs'],
     rules: {
       'no-console': 'off',
     },

--- a/features/steps/support/world.ts
+++ b/features/steps/support/world.ts
@@ -1,7 +1,7 @@
 import { setWorldConstructor, World, type IWorldOptions, After } from '@cucumber/cucumber';
 import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
 import { createElement } from 'react';
-import { JSDOM } from 'jsdom';
+import { JSDOM, VirtualConsole } from 'jsdom';
 import { fileURLToPath } from 'node:url';
 import path from 'node:path';
 import type { renderHook } from '@testing-library/react';
@@ -115,9 +115,14 @@ class DndWorldImpl extends World implements DndWorld {
       },
     });
 
-    // Bootstrap jsdom for React Testing Library
+    // Bootstrap jsdom for React Testing Library. Forward real page console.* calls
+    // but omit jsdom's own "Not implemented" notices (e.g. navigation) so a passing
+    // run stays nothing but green dots.
+    const virtualConsole = new VirtualConsole();
+    virtualConsole.forwardTo(console, { jsdomErrors: 'none' });
     this.dom = new JSDOM('<!DOCTYPE html><html><body><div id="root"></div></body></html>', {
       url: 'http://localhost',
+      virtualConsole,
     });
     globalThis.document = this.dom.window.document;
     // @ts-expect-error - globalThis assignment for jsdom

--- a/features/support/alias-loader.mjs
+++ b/features/support/alias-loader.mjs
@@ -37,6 +37,8 @@ export async function load(url, context, nextLoad) {
     // Provide placeholder values for Vite env vars so modules load without throwing
     .replace(/import\.meta\.env\.VITE_SUPABASE_URL/g, '"http://localhost:54321"')
     .replace(/import\.meta\.env\.VITE_SUPABASE_ANON_KEY/g, '"test-anon-key"')
+    // Mute loggers during BDD so a passing run is nothing but green dots.
+    .replace(/import\.meta\.env\.VITE_LOG_LEVEL/g, '"silent"')
     .replace(/import\.meta\.env\.VITE_\w+/g, 'undefined')
     .replace(/import\.meta\.env/g, '({DEV:false,PROD:true,MODE:"test",SSR:false})');
 

--- a/features/support/register.mjs
+++ b/features/support/register.mjs
@@ -15,6 +15,19 @@ if (typeof import.meta.env === 'undefined') {
   });
 }
 
+// Cucumber emits a Node-version compatibility banner via console.warn before any
+// test runs (it ANDs our Node 24 against its narrower enginesTested range). Filter
+// only that exact notice so a passing run stays nothing but green dots; every other
+// warning still passes through. The durable fix is aligning the Node/Cucumber
+// supported versions — this just mutes a known, benign startup line.
+const originalWarn = console.warn.bind(console);
+console.warn = (...args) => {
+  if (typeof args[0] === 'string' && args[0].includes('has not been tested with this version of Cucumber')) {
+    return;
+  }
+  originalWarn(...args);
+};
+
 const __dirname = fileURLToPath(new URL('.', import.meta.url));
 const repoRoot = path.resolve(__dirname, '../../');
 

--- a/src/lib/i18n.ts
+++ b/src/lib/i18n.ts
@@ -6,6 +6,21 @@ import { getLogger } from '@/lib/logger';
 
 const logger = getLogger('i18n');
 
+// Resolved features for origin/general feats reuse the feat's own name and
+// description. The Source → Grant pipeline emits features keyed `feat-<featId>`
+// (e.g. `feat-savage-attacker`), but the feat text lives under the `feats` map
+// keyed by bare id. Mirror each feat into the `features` map at init so the
+// resolved-feature render path (`features.<id>.name`) resolves from a single
+// source of truth instead of firing the missing-key handler.
+const featFeatures: Record<string, { name: string; description?: string }> = Object.fromEntries(
+  Object.entries(gamedataEn.feats).map(([featId, entry]) => [`feat-${featId}`, entry])
+);
+
+const gamedata = {
+  ...gamedataEn,
+  features: { ...gamedataEn.features, ...featFeatures },
+};
+
 i18n
   .use(initReactI18next)
   .init({
@@ -14,7 +29,7 @@ i18n
     defaultNS: 'common',
     ns: ['common', 'gamedata'],
     resources: {
-      en: { common: commonEn, gamedata: gamedataEn },
+      en: { common: commonEn, gamedata },
     },
     interpolation: { escapeValue: false },
     saveMissing: true,

--- a/src/lib/logger.ts
+++ b/src/lib/logger.ts
@@ -1,6 +1,10 @@
 import log, { type Logger, type LogLevelDesc } from 'loglevel';
 
-const DEFAULT_LEVEL: LogLevelDesc = import.meta.env.DEV ? 'DEBUG' : 'WARN';
+// VITE_LOG_LEVEL overrides the default when set (e.g. 'silent' to mute output);
+// otherwise dev builds are verbose and prod builds warn-and-above. The BDD
+// harness sets this to 'silent' so a passing run is nothing but green dots.
+const DEFAULT_LEVEL: LogLevelDesc =
+  (import.meta.env.VITE_LOG_LEVEL as LogLevelDesc | undefined) ?? (import.meta.env.DEV ? 'DEBUG' : 'WARN');
 
 // setDefaultLevel is a no-op when the user has a level saved in localStorage under 'loglevel' or 'loglevel:<name>'; clear that key to reset.
 log.setDefaultLevel(DEFAULT_LEVEL);


### PR DESCRIPTION
## Summary

A passing `npm run test:bdd` run was logging missing-translation-key warnings plus several other expected console messages. This makes a green run produce **nothing but green dots**, and fixes the one real bug behind the noise.

### 1. Real bug — missing feat-feature translation keys (`fix(i18n)`)
The Source→Grant pipeline emits resolved features keyed `feat-<featId>` (e.g. `feat-savage-attacker`), but the `gamedata` `features` namespace had **zero** `feat-*` entries. Every feat was a latent missing-key; `savage-attacker` (soldier background) was just the only one the BDD specs exercise. `defaultValue` doesn't suppress the warning because i18n uses `saveMissing` + a `missingKeyHandler`.

**Fix:** inject `feat-<id>` entries into the `features` map at i18n init, derived from the existing `feats` data — single source of truth, covers all 75 feats, no duplication.

### 2. Test-harness noise (`chore(bdd)`) — BDD-only, no effect on Vitest or the app
- **App loggers** (ASI over-allocation guard, longsword item-source stub): added a `VITE_LOG_LEVEL` override to `logger.ts`; the BDD loader injects `'silent'`. Covers lazily-created loggers since all read `DEFAULT_LEVEL` at init. Vitest leaves it unset, so warn-asserting unit tests still pass.
- **jsdom** `Not implemented: navigation to another Document`: world's `VirtualConsole` now uses `forwardTo(console, { jsdomErrors: 'none' })`.
- **Cucumber's Node-version banner**: surgically filter that exact `console.warn` line in the BDD entrypoint, with a narrow `no-console` eslint exception.

> Note: muting the Cucumber banner hides a benign signal (Node 24 is outside Cucumber 11's *tested* range). Durable fix is aligning Node/Cucumber versions; the filter is scoped tightly so any new warning still surfaces.

## Verification
- ✅ `npm run typecheck`
- ✅ `npm run lint` (`--max-warnings 0`)
- ✅ `npm run test` — 1612 unit tests pass
- ✅ `npm run test:bdd` — 82/82 scenarios, 268/268 steps, output is pure green dots

🤖 Generated with [Claude Code](https://claude.com/claude-code)