### PR TITLE
fix(security): harden DB functions, scrub UI errors, ban XSS sinks

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -72,7 +72,7 @@ jobs:
           # Prefix the list here with "+" to use these queries and those in the config file.
 
           # For more details on CodeQL's query packs, refer to: https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
-          # queries: security-extended,security-and-quality
+          queries: security-extended,security-and-quality
 
       # If the analyze step fails for one of the languages you are analyzing with
       # "We were unable to automatically build your code", modify the matrix above

--- a/docs/security-review-2026-06-01.md
+++ b/docs/security-review-2026-06-01.md
@@ -1,0 +1,148 @@
+# Security Review — dnd-maintainer
+
+**Date:** 2026-06-01
+**Scope:** Entire codebase (288 tracked files), reviewed as a prerequisite for implementing authentication & authorization.
+**Reviewer:** Claude Code security review.
+
+## Threat model (read this first)
+
+This is a **client-only React SPA talking directly to Supabase/PostgREST with a public anon key**. The anon key ships inside the JavaScript bundle — it is _meant_ to be public. The **only** server-side authorization boundary is Postgres Row Level Security (RLS). Today that boundary is wide open.
+
+**Consequence:** Any hook-layer "scoping" (`.eq('campaign_id', …)`, slug filters, the export page selecting specific IDs) is **convention, not security**. Anyone who opens devtools, reads the anon key, and hits the PostgREST REST endpoint directly can read, modify, and delete **every row in every table** — campaigns, characters, sessions, notes — regardless of what the React code does. There is no auth and no per-row ownership, so there is currently nothing to enforce.
+
+This is **known and intentional for local dev** (the migration says so), but it is the entire problem the upcoming auth work must close. The findings below are framed around that goal.
+
+---
+
+## Findings by severity
+
+### CRITICAL
+
+#### C1 — No authorization model exists; RLS is fully permissive
+
+- **Where:** `supabase/migrations/00001_initial_schema.sql:378-405`
+- **What:** Every table has RLS _enabled_ but with `CREATE POLICY … FOR ALL USING (true) WITH CHECK (true)`, plus `GRANT SELECT, INSERT, UPDATE, DELETE … TO anon, authenticated` on all seven tables. There is **no `owner_id` / `user_id` / membership column** on any table. The DB has no concept of who owns a campaign or character.
+- **Impact:** Unrestricted public DML on all data via the anon key. This is the headline issue.
+- **Fix (part of the auth work):**
+  1. Add `owner_id uuid NOT NULL REFERENCES auth.users(id)` to `campaigns` (the tenancy root).
+  2. Replace the `USING (true)` policies with policies keyed on `auth.uid()` and campaign membership (see C2 for the collaboration shape).
+  3. **Revoke the blanket `anon` grants** — decide deliberately whether unauthenticated access is allowed at all (`config.toml` already has `enable_anonymous_sign_ins = false`, but the Postgres `anon` _role_ still holds table grants, which is what actually matters).
+  4. Child tables (characters, sessions, encounters, notes, character_build_levels, character_items) should enforce ownership transitively via their `campaign_id` / `character_id` FK in the RLS policy (e.g. `EXISTS (SELECT 1 FROM campaigns c WHERE c.id = campaign_id AND c.owner_id = auth.uid())`).
+
+#### C2 — Schema does not support the collaboration/role model the specs already describe
+
+- **Where:** BDD specs in `features/admin/*` (manage-accounts, manage-roles, initiate-password-reset), `features/auth/*`, `features/collaboration/*` (invite-players, assign-characters, manage-own-characters, accept-invite, **data-ownership-isolation**).
+- **What:** These specs describe accounts, roles (admin/DM/player), invitations, per-player character ownership, and cross-tenant data isolation. The schema supports **none** of it: no users, no roles, no campaign membership, and `characters.player_name` is **free text**, not a FK to a user.
+- **Impact:** "Manage own characters", "assign characters", and "data ownership isolation" cannot be enforced with the current schema. If auth is bolted on without modeling this, RLS will only express "DM owns everything" and the player-facing features will have no enforcement layer.
+- **Fix:** Design the membership model up front:
+  - `profiles` (1:1 with `auth.users`) for app-level role/display data.
+  - `campaign_members(campaign_id, user_id, role)` where role ∈ {dm, player} for multi-user campaigns.
+  - Add `owning_user_id uuid REFERENCES auth.users` to `characters` (distinct from the campaign owner) so "players manage their own characters" is expressible in RLS.
+  - Write RLS policies per table that read from `campaign_members` so DM-vs-player visibility is enforced server-side, not in React.
+
+---
+
+### HIGH
+
+#### H1 — Global slug lookups are IDOR today; must be covered by RLS
+
+- **Where:** `src/hooks/useCampaigns.ts:32`, `src/hooks/useCharacters.ts:34`, `src/hooks/useSessions.ts:32` — each does `.or(\`slug.eq.${safe},previous_slugs.cs.{"${safe}"}\`)` with **no campaign/owner scoping**.
+- **What:** A slug resolves a row across the _entire_ table. Slugs are short and name-derived (`name-slice` + 8 hex chars, max 24), so they are guessable/enumerable. With RLS open, knowing or guessing a slug returns another tenant's data.
+- **Impact:** Cross-tenant read today; will be a real IDOR after auth **if** the RLS policies from C1 don't cover SELECT on these tables.
+- **Fix:** No code change needed in the hooks — but the C1 RLS policies **must** apply to SELECT (not just writes), so these global lookups silently return only rows the caller may see. Verify with a test that an authenticated non-owner gets zero rows for another user's slug.
+- **Note (positive):** The PostgREST `.or()` injection vector here **is** properly defended — `validateSlug()` (`src/lib/slug-utils.ts`) enforces `^[a-z0-9](?:[a-z0-9-]*[a-z0-9])?$` (max 128) and throws on anything that could inject PostgREST operators, before interpolation. This is correct and should be kept.
+
+#### H2 — plpgsql functions have a mutable `search_path` (latent privilege-escalation vector)
+
+- **Where:** `supabase/migrations/00001_initial_schema.sql` — `update_updated_at_column()` (l.14), `generate_slug()` (l.27), `trigger_manage_slug()` (l.99). None set `search_path`; all are default `SECURITY INVOKER`.
+- **What:** Today the risk is **latent** (invoker functions run with the caller's privileges). But the auth work will almost certainly introduce a `SECURITY DEFINER` helper — e.g. a membership check, or an `owner_id = auth.uid()` enforcement trigger. A `SECURITY DEFINER` function with a mutable `search_path` is the classic Postgres privilege-escalation hole (an attacker shadows a referenced table/function in a schema they control).
+- **Impact:** Invisible in a frontend sweep; directly on-point for "prerequisite to auth."
+- **Fix:** Add `SET search_path = ''` (and schema-qualify all object references, e.g. `public.campaigns`) to the existing functions now, and make it a hard rule for every auth helper/trigger you add. Supabase's own linter flags this as `function_search_path_mutable`.
+
+---
+
+### MEDIUM
+
+#### M1 — Auth config defaults need hardening before launch
+
+- **Where:** `supabase/config.toml`
+- **Findings:**
+  - `[auth] enabled = false` (l.151) — currently off; flip on when ready.
+  - `minimum_password_length = 6` (l.175) and `password_requirements = ""` — raise to ≥ 8 and set complexity requirements.
+  - `[auth.email] enable_confirmations = false` (l.209) — **enable email confirmation** before launch, otherwise users can sign up with email addresses they don't own (account squatting / spam).
+  - `secure_password_change = false` (l.211) — consider enabling so password changes require recent re-auth.
+  - Good already: `jwt_expiry = 3600`, `enable_refresh_token_rotation = true`, `enable_anonymous_sign_ins = false`, OTP expiry/length sane, email send rate-limited.
+
+#### M2 — Session tokens live in `localStorage` (XSS → token theft)
+
+- **What:** `supabase-js` stores the session/refresh token in `localStorage` by default. Any XSS becomes full account takeover (token exfiltration), and refresh-token rotation doesn't save you if the attacker grabs the live token.
+- **Current state (positive):** No XSS sinks exist today — **no** `dangerouslySetInnerHTML`, `innerHTML`, `eval`, `new Function`, `document.write`, or dynamic `javascript:` URLs anywhere in `src/`. React's default escaping is intact.
+- **Fix / discipline for the auth build:**
+  - Keep the no-`dangerouslySetInnerHTML` invariant (consider an ESLint rule to enforce it).
+  - Add a **Content-Security-Policy** at the host (see M4) — for a localStorage-token SPA this is the single most effective XSS-to-takeover mitigation.
+  - When `portrait_url` / `image_url` (currently stored but **not rendered** anywhere) start being displayed, restrict to `http(s)` schemes and reject `javascript:`/`data:` — render via `<img src>` only, never as a link `href` without scheme validation.
+
+#### M3 — Dependency: `ws` moderate advisory (bundled but unused)
+
+- **Where:** `ws@8.19.0` pulled transitively by `@supabase/supabase-js` → `realtime-js` and by `@tanstack/devtools-vite`. Advisory GHSA-58qx-3vcg-4xpx (uninitialized memory disclosure, affects 8.0.0–8.20.0).
+- **Impact:** Low in practice — confirmed **no Realtime usage** in the app (`grep` for `.channel(`/`.subscribe(`/`realtime` is empty), so this code path isn't exercised client-side, and devtools is stripped from prod builds (`removeDevtoolsOnBuild: true`).
+- **Fix:** `npm audit fix` (non-breaking bump to ≥ 8.20.1). Full `npm audit` also shows a `fast-uri` high advisory, but it's a **dev-only** transitive dep (tooling); not shipped.
+
+#### M4 — No security headers / CSP (no hosting config in repo)
+
+- **What:** There's no `netlify.toml` / `vercel.json` / `_headers` defining response headers. For an SPA that holds auth tokens in `localStorage`, a CSP is a meaningful defense-in-depth layer.
+- **Fix:** When you pick a host, add a CSP (`default-src 'self'`, allow the Supabase URL for `connect-src`, `frame-ancestors 'none'`), plus `X-Content-Type-Options: nosniff` and `Referrer-Policy`. Don't over-invest beyond this — the RLS/anon-key story (C1) is the real exposure, not header hygiene.
+
+---
+
+### LOW / INFORMATIONAL
+
+#### L1 — Error messages leak raw DB/PostgREST strings to the UI
+
+- **Where:** `src/pages/ExportData.tsx:104-107` (and the banner at l.187 renders the raw message), `src/pages/CharacterList.tsx`, `src/pages/SessionDetail.tsx`.
+- **What:** Raw Supabase error `.message` values are surfaced to the user. Fine pre-auth; post-auth these can leak schema/RLS-policy details on permission-denied errors.
+- **Fix:** Catch, log internally via the existing `logger`, and show a generic translated message for permission/DB errors.
+
+#### L2 — SQL export: escaping is sound; relies on RLS for tenant scoping
+
+- **Where:** `src/lib/export-sql.ts`, `src/pages/ExportData.tsx:56-62`.
+- **Assessment (positive):** Injection-safe — `standard_conforming_strings = ON`, single quotes doubled, null bytes stripped, integers `Math.trunc`'d, booleans coerced, identifiers come from a **hardcoded allowlist** (`TABLE_COLUMNS`), never user input. The output is a `.sql` file the user runs against their own DB.
+- **Note for auth:** The export fetches by `.in('id', ids)` / `.in('campaign_id', ids)` with **no ownership check** — it relies entirely on RLS (C1) to ensure a user can only export campaigns they own. Once C1's SELECT policies exist, this is automatically correct; verify it.
+
+#### L3 — CodeQL `security-extended` queries are commented out
+
+- **Where:** `.github/workflows/codeql.yml` (the `queries:` line is commented).
+- **Fix:** Uncomment `queries: security-extended,security-and-quality` for deeper static analysis coverage.
+
+#### L4 — Secrets / storage hygiene: clean
+
+- `.env.local` is **gitignored** (not tracked) and contains only the local demo anon key + `127.0.0.1` URL — no real secrets. No hardcoded credentials/tokens anywhere in `src/`. `localStorage` is used only for theme/color-mode (`src/lib/theme.ts`) — non-sensitive. Character-builder drafts persist in the **DB** (`status='draft'`), not client storage, so they'll be covered by RLS automatically.
+
+---
+
+## Confirmed-clean surfaces (verified, not assumed)
+
+- **XSS sinks:** none (no `dangerouslySetInnerHTML`/`innerHTML`/`eval`/`new Function`/`document.write`).
+- **Open redirects:** none (no `window.location`/`location.href` assignment from user input; navigation via React Router with validated slugs).
+- **PostgREST injection:** all `.or()` filters guarded by `validateSlug()` allowlist.
+- **Supabase Storage:** not used (no `.storage`/`.upload(`).
+- **Supabase Realtime:** not used (no `.channel(`/`.subscribe(`).
+- **RPC:** no `.rpc(` calls.
+- **Regex injection:** only static patterns; no user-built regex.
+
+---
+
+## Recommended sequence for the auth implementation
+
+1. **Model tenancy first (C1 + C2):** add `auth.users`-backed `owner_id` on campaigns, a `campaign_members(campaign_id, user_id, role)` table, and `owning_user_id` on characters. Write a migration for this _before_ writing any RLS.
+2. **Replace permissive policies with `auth.uid()`-based RLS** on all seven tables (SELECT included — H1), and **revoke the blanket `anon` grants**.
+3. **Harden the DB functions (H2):** `SET search_path = ''` + schema-qualified refs on existing functions; same rule for every new auth trigger/helper, especially `SECURITY DEFINER` ones.
+4. **Harden auth config (M1):** enable email confirmation, raise password length/requirements, flip `[auth] enabled = true`.
+5. **Keep the XSS invariant + add a CSP (M2/M4)** since tokens live in `localStorage`.
+6. **Run the platform linter as a gate (post-RLS):** Supabase's `get_advisors` (security) / `supabase db lint` natively flags `rls_policy_allows_public_access` and `function_search_path_mutable` — run it after the RLS migration lands and treat findings as blocking. (Couldn't run it here — this is a local-only stack with no linked cloud project_id.)
+7. **`npm audit fix` (M3)** to clear the `ws` advisory.
+8. **Scrub UI error messages (L1)** once permission-denied paths exist.
+
+## Bottom line
+
+The application code is **clean on the usual SPA vulnerability classes** — no XSS, no injection, no leaked secrets, sound SQL-export escaping, and a genuinely good PostgREST-injection guard. The risk is **entirely** in the authorization layer: there is no auth and no per-row ownership, RLS is `USING(true)`, and the public anon key grants full DML to anyone. That, plus the collaboration/role model the specs assume but the schema lacks (C2) and the latent `search_path` issue (H2), is exactly the work the auth project needs to do. Build the tenancy model and RLS first; everything else is secondary.

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -49,7 +49,19 @@ export default defineConfig(
           selector: 'TSAsExpression > TSNeverKeyword',
           message: "Do not use 'as never'. Narrow the type instead — see CLAUDE.md i18n guidance.",
         },
+        {
+          selector: 'JSXAttribute[name.name="dangerouslySetInnerHTML"]',
+          message:
+            'Do not use dangerouslySetInnerHTML — it is an XSS sink. Render text via JSX (auto-escaped). See docs/security-review-2026-06-01.md (M2).',
+        },
+        {
+          selector: 'AssignmentExpression[left.property.name="innerHTML"]',
+          message:
+            'Do not assign to innerHTML — it is an XSS sink. Use textContent or JSX. See docs/security-review-2026-06-01.md (M2).',
+        },
       ],
+      'no-eval': 'error',
+      'no-implied-eval': 'error',
     },
   },
   {

--- a/package-lock.json
+++ b/package-lock.json
@@ -4315,9 +4315,9 @@
       }
     },
     "node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -5795,13 +5795,13 @@
       }
     },
     "node_modules/express-rate-limit": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.3.1.tgz",
-      "integrity": "sha512-D1dKN+cmyPWuvB+G2SREQDzPY1agpBIcTa9sJxOPMCNeH3gwzhqJRDWCXW3gg0y//+LQ/8j52JbMROWyrKdMdw==",
+      "version": "8.5.2",
+      "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.5.2.tgz",
+      "integrity": "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "ip-address": "10.1.0"
+        "ip-address": "^10.2.0"
       },
       "engines": {
         "node": ">= 16"
@@ -5862,9 +5862,9 @@
       "license": "MIT"
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "dev": true,
       "funding": [
         {
@@ -6455,9 +6455,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.12",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.12.tgz",
-      "integrity": "sha512-p1JfQMKaceuCbpJKAPKVqyqviZdS0eUxH9v82oWo1kb9xjQ5wA6iP3FNVAPDFlz5/p7d45lO+BpSk1tuSZMF4Q==",
+      "version": "4.12.23",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
+      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -6693,9 +6693,9 @@
       }
     },
     "node_modules/ip-address": {
-      "version": "10.1.0",
-      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.1.0.tgz",
-      "integrity": "sha512-XXADHxXmvT9+CRxhXg56LJovE+bmWnEWB78LB83VZTprKTmaC5QfruXocxzTZ2Kl0DNwKuBdlIhjL8LeY8Sf8Q==",
+      "version": "10.2.0",
+      "resolved": "https://registry.npmjs.org/ip-address/-/ip-address-10.2.0.tgz",
+      "integrity": "sha512-/+S6j4E9AHvW9SWMSEY9Xfy66O5PWvVEJ08O0y5JGyEKQpojb0K0GKpz/v5HJ/G0vi3D2sjGK78119oXZeE0qA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -7989,9 +7989,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -8509,9 +8509,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "dev": true,
       "funding": [
         {
@@ -8529,7 +8529,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -8713,9 +8713,9 @@
       }
     },
     "node_modules/qs": {
-      "version": "6.15.0",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.0.tgz",
-      "integrity": "sha512-mAZTtNCeetKMH+pSjrb76NAM8V9a05I9aBZOHztWy/UqcJdQYNsf59vrRKWnojAT9Y+GbIvoTBC++CPHqpDBhQ==",
+      "version": "6.15.2",
+      "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.2.tgz",
+      "integrity": "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw==",
       "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
@@ -10796,9 +10796,9 @@
       "license": "ISC"
     },
     "node_modules/ws": {
-      "version": "8.19.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
-      "integrity": "sha512-blAT2mjOEIi0ZzruJfIhb3nps74PRWTCz1IjglWEEpQl5XS/UNama6u2/rjFkDDouqr4L67ry+1aGIALViWjDg==",
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
       "license": "MIT",
       "engines": {
         "node": ">=10.0.0"

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -559,7 +559,7 @@
     "level": "Level",
     "hp": "HP",
     "ac": "AC",
-    "errorLoading": "Error loading characters: {{error}}"
+    "errorLoading": "Error loading characters. Please try again."
   },
   "sessions": {
     "title": "Sessions",
@@ -725,6 +725,7 @@
     "loadingCampaigns": "Loading campaigns...",
     "failedToLoadCampaigns": "Failed to load campaigns",
     "exportFailed": "Export failed",
+    "fetchFailed": "Failed to fetch campaign data. Please try again — see the browser console for details.",
     "noCampaigns": "No Campaigns",
     "noCampaignsDescription": "Create a campaign first before exporting data.",
     "selectCampaigns": "Select campaigns to export ({{selected}} of {{total}} selected)",

--- a/src/pages/CharacterList.tsx
+++ b/src/pages/CharacterList.tsx
@@ -2,10 +2,13 @@ import { useCharacters } from '@/hooks/useCharacters';
 import { useCampaignContext } from '@/hooks/useCampaignContext';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { isBackgroundId } from '@/lib/dnd-helpers';
+import { getLogger } from '@/lib/logger';
 import { Plus, Search, User, Users } from 'lucide-react';
-import { useMemo, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
+
+const logger = getLogger('CharacterList');
 
 type FilterType = 'all' | 'pc' | 'npc';
 type SortType = 'name' | 'level' | 'class' | 'updated';
@@ -69,11 +72,17 @@ export default function CharacterList() {
   const pcCount = characters.filter((c) => c.character_type === 'pc').length;
   const npcCount = characters.filter((c) => c.character_type === 'npc').length;
 
+  useEffect(() => {
+    if (error) {
+      logger.error('Failed to load characters:', error);
+    }
+  }, [error]);
+
   if (error) {
     return (
       <div className="p-8">
         <div className="rounded-lg bg-destructive/10 border border-destructive/30 p-4 text-destructive">
-          {t('characterList.errorLoading', { error: String(error) })}
+          {t('characterList.errorLoading')}
         </div>
       </div>
     );

--- a/src/pages/ExportData.tsx
+++ b/src/pages/ExportData.tsx
@@ -2,10 +2,13 @@ import { useCampaigns } from '@/hooks/useCampaigns';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import type { ExportData as ExportDataType } from '@/lib/export-sql';
 import { downloadFile, generateSeedSql } from '@/lib/export-sql';
+import { getLogger } from '@/lib/logger';
 import { supabase } from '@/lib/supabase';
 import { AlertCircle, CheckSquare, Download, Loader2, Square } from 'lucide-react';
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+
+const logger = getLogger('ExportData');
 
 export default function ExportData() {
   const { t } = useTranslation('common');
@@ -20,6 +23,12 @@ export default function ExportData() {
   const [errorMessage, setErrorMessage] = useState<string | null>(null);
 
   usePageTitle(t('export.title'));
+
+  useEffect(() => {
+    if (isCampaignsError) {
+      logger.error('Failed to load campaigns:', campaignsError);
+    }
+  }, [isCampaignsError, campaignsError]);
 
   const toggleCampaign = (id: string): void => {
     setSelectedIds((prev) => {
@@ -74,7 +83,8 @@ export default function ExportData() {
         .map((r) => `${r.table}: ${r.error?.message ?? 'unknown error'}`);
 
       if (failures.length > 0) {
-        throw new Error(`Failed to fetch data:\n${failures.join('\n')}`);
+        logger.error('Export fetch failed:', failures);
+        throw new Error(t('export.fetchFailed'));
       }
 
       if (!campaignsRes.data || campaignsRes.data.length === 0) {
@@ -101,10 +111,12 @@ export default function ExportData() {
         ]);
 
         if (buildLevelsRes.error) {
-          throw new Error(`Failed to fetch data:\ncharacter_build_levels: ${buildLevelsRes.error.message}`);
+          logger.error('Export fetch failed (character_build_levels):', buildLevelsRes.error);
+          throw new Error(t('export.fetchFailed'));
         }
         if (itemsRes.error) {
-          throw new Error(`Failed to fetch data:\ncharacter_items: ${itemsRes.error.message}`);
+          logger.error('Export fetch failed (character_items):', itemsRes.error);
+          throw new Error(t('export.fetchFailed'));
         }
 
         buildLevelsData = (buildLevelsRes.data ?? []) as Record<string, unknown>[];
@@ -155,9 +167,7 @@ export default function ExportData() {
         <div className="max-w-3xl mx-auto text-center py-12">
           <AlertCircle className="size-8 text-destructive mx-auto" />
           <p className="text-destructive font-semibold mt-4">{t('export.failedToLoadCampaigns')}</p>
-          <p className="text-destructive text-sm mt-2">
-            {campaignsError instanceof Error ? campaignsError.message : t('errors.unexpectedError')}
-          </p>
+          <p className="text-destructive text-sm mt-2">{t('errors.unexpectedError')}</p>
         </div>
       </div>
     );

--- a/src/pages/SessionDetail.tsx
+++ b/src/pages/SessionDetail.tsx
@@ -1,4 +1,5 @@
 import { parseIntOrDefault } from '@/lib/utils';
+import { getLogger } from '@/lib/logger';
 import { supabase } from '@/lib/supabase';
 import { Session } from '@/types/database';
 import type { Json, TablesUpdate } from '@/types/supabase';
@@ -21,6 +22,8 @@ import {
   DialogTitle,
 } from '@/components/ui/dialog';
 import { ValidationError } from '@/components/ui/validation-error';
+
+const logger = getLogger('SessionDetail');
 
 interface LootEntry {
   id: string;
@@ -81,6 +84,12 @@ export default function SessionDetail() {
   const { data: encounters = [] } = useSessionEncounters(session?.id);
 
   usePageTitle(session?.name ?? t('nav.sessions'));
+
+  useEffect(() => {
+    if (error) {
+      logger.error('Failed to load session:', error);
+    }
+  }, [error]);
 
   // Update session mutation
   const updateSessionMutation = useMutation({
@@ -257,7 +266,7 @@ export default function SessionDetail() {
             <AlertCircle className="size-5 shrink-0 mt-0.5" />
             <div>
               <p className="font-semibold">{t('sessionDetail.errorLoadingSession')}</p>
-              <p className="text-sm">{String(error)}</p>
+              <p className="text-sm">{t('errors.unexpectedError')}</p>
             </div>
           </div>
         </div>

--- a/supabase/migrations/20260602000000_harden_function_search_path.sql
+++ b/supabase/migrations/20260602000000_harden_function_search_path.sql
@@ -1,0 +1,130 @@
+-- Migration: harden function search_path (security review H2)
+-- Recreates the existing trigger/helper functions with `SET search_path = ''` so they
+-- cannot be hijacked by a mutable search_path. Object references are schema-qualified.
+--
+-- These functions are SECURITY INVOKER today, so the risk is latent — but any future
+-- SECURITY DEFINER auth helper (membership checks, owner_id enforcement triggers) MUST
+-- follow this same pattern, or a mutable search_path becomes a privilege-escalation vector.
+-- See docs/security-review-2026-06-01.md (H2).
+
+-- ============================================================================
+-- update_updated_at_column() — only references pg_catalog built-ins (now()),
+-- which are always resolvable even with an empty search_path.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION update_updated_at_column()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+    NEW.updated_at = now() at time zone 'utc';
+    RETURN NEW;
+END;
+$$;
+
+-- ============================================================================
+-- generate_slug() — string helpers used here all live in pg_catalog, so an empty
+-- search_path is sufficient; no application schema objects are referenced.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION generate_slug(entity_name text, entity_id uuid)
+RETURNS text
+LANGUAGE plpgsql
+STABLE
+SET search_path = ''
+AS $$
+DECLARE
+  hex8        text;
+  cleaned     text;
+  all_words   text[];
+  stop_words  text[] := ARRAY['a','an','the','of','in','on','at','to','for','and','or','but','with','by','from'];
+  usable      text[];
+  word        text;
+  base        text;
+  result      text;
+BEGIN
+  -- 8-hex disambiguator derived from the start of the UUID
+  hex8 := substring(replace(entity_id::text, '-', '') FROM 1 FOR 8);
+
+  -- Fallback for NULL or blank names
+  IF entity_name IS NULL OR trim(entity_name) = '' THEN
+    RETURN 'draft-' || hex8;
+  END IF;
+
+  -- Lowercase and replace non-alphanumeric (except spaces/hyphens) with space
+  cleaned := lower(regexp_replace(entity_name, '[^a-z0-9 \-]', ' ', 'gi'));
+
+  -- Split into words on whitespace or hyphens
+  all_words := regexp_split_to_array(trim(cleaned), '[\s\-]+');
+
+  -- Collect non-stop words
+  usable := ARRAY[]::text[];
+  FOREACH word IN ARRAY all_words LOOP
+    IF word <> '' AND NOT (word = ANY(stop_words)) THEN
+      usable := usable || word;
+    END IF;
+  END LOOP;
+
+  -- If all words were stop words, fall back to first 2 original words
+  IF array_length(usable, 1) IS NULL OR array_length(usable, 1) = 0 THEN
+    usable := ARRAY[]::text[];
+    FOREACH word IN ARRAY all_words LOOP
+      IF word <> '' THEN
+        usable := usable || word;
+        IF array_length(usable, 1) >= 2 THEN
+          EXIT;
+        END IF;
+      END IF;
+    END LOOP;
+  END IF;
+
+  -- Take first 2 usable words
+  IF array_length(usable, 1) >= 2 THEN
+    base := usable[1] || '-' || usable[2];
+  ELSIF array_length(usable, 1) = 1 THEN
+    base := usable[1];
+  ELSE
+    RETURN 'draft-' || hex8;
+  END IF;
+
+  -- Truncate base to 15 chars, append suffix
+  base   := substring(base FROM 1 FOR 15);
+  result := base || '-' || hex8;
+
+  -- Total max 24 chars (15 base + 1 dash + 8 hex = 24)
+  RETURN substring(result FROM 1 FOR 24);
+END;
+$$;
+
+-- ============================================================================
+-- trigger_manage_slug() — calls generate_slug(), which is now schema-qualified
+-- (public.generate_slug) because the empty search_path no longer resolves
+-- unqualified names in the public schema.
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION trigger_manage_slug()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SET search_path = ''
+AS $$
+BEGIN
+  IF TG_OP = 'INSERT' THEN
+    IF NEW.slug IS NULL OR NEW.slug = '' THEN
+      NEW.slug := public.generate_slug(NEW.name, NEW.id);
+    END IF;
+
+  ELSIF TG_OP = 'UPDATE' THEN
+    IF OLD.name IS DISTINCT FROM NEW.name THEN
+      -- Preserve old slugs so previous URLs continue to resolve; lookup is performed
+      -- in the application layer using the GIN index on previous_slugs.
+      IF OLD.slug <> '' AND NOT (OLD.slug = ANY(NEW.previous_slugs)) THEN
+        NEW.previous_slugs := NEW.previous_slugs || OLD.slug;
+      END IF;
+      NEW.slug := public.generate_slug(NEW.name, NEW.id);
+    END IF;
+  END IF;
+
+  RETURN NEW;
+END;
+$$;


### PR DESCRIPTION
## Summary

Implements the **auth-independent** findings from the pre-auth security review (`docs/security-review-2026-06-01.md`). Auth-coupled and host-dependent findings are deferred to the AuthN/AuthZ work.

| Finding | Change |
|---|---|
| **H2** — mutable `search_path` | New migration locks `search_path = ''` on `update_updated_at_column`, `generate_slug`, `trigger_manage_slug` (schema-qualified cross-call) — closes the latent privilege-escalation vector before any `SECURITY DEFINER` auth helper is added |
| **L1** — raw DB errors in UI | `CharacterList`, `SessionDetail`, `ExportData` log raw Supabase/query errors via `logger` and render generic translated messages instead of `error.message` / `String(error)` |
| **M2** — XSS invariant | ESLint bans `dangerouslySetInnerHTML` + `innerHTML` assignment (plus `no-eval`/`no-implied-eval`) |
| **M3** — `ws` advisory | `npm audit fix` → `ws` 8.21.0 (GHSA-58qx-3vcg-4xpx) |
| **L3** — CodeQL coverage | Enable `security-extended` + `security-and-quality` query packs |

## Deferred (require auth or a chosen host)
C1/C2 (ownership model + RLS), H1 (slug-query scoping), M1 (auth config), M4 (CSP), L2 (export tenant scoping).

## Verification
- `npm run typecheck` ✓, `npm run lint` ✓, `npm run test` → **1612/1612** ✓
- Migration applied locally; all three functions report `search_path=""`; slug generation verified via direct call and the campaign-insert trigger
- ESLint rule confirmed to fire on a `dangerouslySetInnerHTML` probe
- Export BDD spec only asserts the unchanged "Export failed" heading

🤖 Generated with [Claude Code](https://claude.com/claude-code)