### PR TITLE
docs(dnd-2024): add Classes/Spellcasting/Items/FightingStyles + PHB divergences

### DIFF
--- a/docs/dnd-2024.md
+++ b/docs/dnd-2024.md
@@ -2,15 +2,31 @@
 
 This file describes the data shapes as implemented in this codebase for the D&D 2024 PHB baseline. It is a reference for contributors adding new content — not a complete rules summary. The primary source files are `src/lib/dnd-helpers.ts`, `src/lib/sources/`, and `src/types/`. When in doubt, the code is authoritative.
 
+> **Code vs. rules-as-written:** this codebase intentionally diverges from the 2024 PHB in a few places (extra/missing/regrouped entries). Those known gaps are catalogued in [Known divergences from the 2024 PHB](#known-divergences-from-the-2024-phb) at the end of this document. The per-section text below describes the data **as implemented**.
+
+## Classes
+
+Source-of-truth: `src/lib/dnd-helpers.ts` (`ClassId`, `DND_CLASSES`, `DndClass`), `src/lib/sources/classes.ts` (`CLASS_SOURCES`), `src/types/sources.ts` (`ClassSource`, `LevelUp`).
+
+- `ClassId` union (12): `'barbarian' | 'bard' | 'cleric' | 'druid' | 'fighter' | 'monk' | 'paladin' | 'ranger' | 'rogue' | 'sorcerer' | 'warlock' | 'wizard'`.
+- Two complementary representations exist:
+  - **`DndClass`** (reference data in `dnd-helpers.ts`) — static class facts: `hitDie`, `primaryAbility`, `savingThrowProficiencies`, optional `spellcastingAbility`, `skillChoices` + `skillPool`, `armorProficiencies` / `weaponProficiencies` / `toolProficiencies`, and an optional `toolChoices: { count, from }`.
+  - **`ClassSource`** (grant pipeline in `sources/classes.ts`) — `{ id, primaryAbility, levels, quickBuild? }`, where `levels` is a readonly array of exactly 20 `LevelUp` entries (`levels[0]` = class level 1 … `levels[19]` = level 20) and each `LevelUp` is `{ grants: Grant[] }`.
+- Per-level grants drive everything a level adds: `hit-die`, `proficiency`, `asi`, `feature`, `spellcasting`, `subclass`, `fighting-style-choice`, `weapon-mastery-choice`, etc. (full grant catalogue: `src/types/grants.ts`).
+- Subclass selection is a `{ type: 'subclass', classId, key }` grant at class level 3 (`levels[2]`) for all 12 classes — see [Subclass Selection](#subclass-selection).
+- Coverage is **partial, not rules-as-written complete**: Fighter and Rogue class tables are incomplete past ~level 10 (missing ASIs at 12/16/19). Run `npm run coverage:matrix` to regenerate `docs/coverage-matrix.md`.
+- i18n: `gamedata.classes.<classId>` (e.g., `t('classes.wizard')`).
+
 ## Species
 
 Source-of-truth: `src/lib/dnd-helpers.ts` (`SpeciesId`, `DND_SPECIES`), `src/lib/sources/species.ts` (`SPECIES_SOURCES`).
 
 - `SpeciesId` union: `'aasimar' | 'dragonborn' | 'dwarf' | 'elf' | 'gnome' | 'goliath' | 'halfling' | 'human' | 'orc' | 'tiefling'`
 - Each species is a `SpeciesSource` with `id`, `defaultSize` (a `SizeId`; all 10 current species are `small` or `medium`), `defaultSpeed` (number, feet), and `grants` (`Grant[]`).
-- Five species have a `lineage-choice` grant: Dragonborn (15 lineages with prefixed IDs — `chromatic-{black,blue,green,red,white}`, `metallic-{brass,bronze,copper,gold,silver}`, `gem-{amethyst,crystal,emerald,sapphire,topaz}`), Elf (`drow`, `high-elf`, `wood-elf`), Gnome (`forest`, `rock`, `deep`), Goliath (`cloud`, `fire`, `frost`, `hill`, `stone`, `storm`), Tiefling (`abyssal`, `chthonic`, `infernal`). Only Dragonborn uses a `<category>-<name>` prefix convention; all other species use unprefixed lineage IDs.
+- Five species have a `lineage-choice` grant: Dragonborn, Elf (`drow`, `high-elf`, `wood-elf`), Gnome (`forest`, `rock`, `deep`), Goliath (`cloud`, `fire`, `frost`, `hill`, `stone`, `storm`), Tiefling (`abyssal`, `chthonic`, `infernal`). Only Dragonborn uses a `<category>-<name>` prefix convention (`chromatic-*`, `metallic-*`, `gem-*`); all other species use unprefixed lineage IDs.
+  - ⚠️ The Dragonborn `gem-*` lineages and the Gnome `deep` lineage are **not** in the 2024 PHB — see [Known divergences](#known-divergences-from-the-2024-phb).
 - Species do not grant Ability Score Increases — ASIs come entirely from backgrounds in the 2024 ruleset (except class ASI grants at specific levels; see Backgrounds below).
-- i18n: display names live at `gamedata.species.<speciesId>` (e.g., `t('species.dwarf')`).
+- i18n: display names live at `gamedata.species.<speciesId>` (e.g., `t('species.dwarf')`); lineage names at `gamedata.lineages.<lineageId>`.
 
 ## Backgrounds
 
@@ -27,13 +43,40 @@ Source-of-truth: `src/lib/sources/backgrounds.ts` (`BACKGROUND_SOURCES`), `src/l
 Source-of-truth: `src/lib/sources/feats.ts` (`FEAT_SOURCES`), `src/lib/dnd-helpers.ts` (`FeatId`, `FEAT_IDS`), `src/types/sources.ts` (`FeatCategory`, `FeatSource`, `FeatPrerequisite`).
 
 - `FeatCategory`: `'origin' | 'general' | 'fightingStyle' | 'epicBoon'`
-- **Origin feats** (12 total, `prerequisites: []`, granted exclusively by backgrounds): `alert`, `crafter`, `healer`, `lucky`, `magic-initiate-cleric`, `magic-initiate-druid`, `magic-initiate-wizard`, `musician`, `savage-attacker`, `skilled`, `tavern-brawler`, `tough`.
-- **Fighting Style feats** (6 total, `prerequisites: []`, granted by class): `archery`, `defense`, `dueling`, `great-weapon-fighting`, `protection`, `two-weapon-fighting`. Note: `fightingStyle` category feat IDs mirror `FightingStyleId` values — the same string serves both roles intentionally.
-- **General feats** (`level-minimum: 4` prerequisite): approximately 50 entries.
-- **Epic Boon feats** (`level-minimum: 19` prerequisite): 13 entries (`boon-of-combat-prowess` through `boon-of-truesight`).
+- **Origin feats** (12 entries, `prerequisites: []`, granted exclusively by backgrounds): `alert`, `crafter`, `healer`, `lucky`, `magic-initiate-cleric`, `magic-initiate-druid`, `magic-initiate-wizard`, `musician`, `savage-attacker`, `skilled`, `tavern-brawler`, `tough`.
+- **Fighting Style feats** (6 entries, `prerequisites: []`, granted by class): `archery`, `defense`, `dueling`, `great-weapon-fighting`, `protection`, `two-weapon-fighting`. Note: `fightingStyle` category feat IDs mirror `FightingStyleId` values — the same string serves both roles intentionally. The PHB has 10 such feats; see [Known divergences](#known-divergences-from-the-2024-phb).
+- **General feats** (53 entries, `level-minimum: 4` prerequisite).
+- **Epic Boon feats** (13 entries, `level-minimum: 19` prerequisite): `boon-of-combat-prowess` through `boon-of-truesight`.
 - `FeatPrerequisite` union types: `level-minimum`, `ability-minimum`, `proficiency`, `spellcasting`, `class-feature`.
 - Each `FeatSource` grants one or more `Grant` entries — typically `{ type: 'feature', feature: { id: '...' } }`.
+- **Repeatable-feat split convention:** the PHB models three "pick-X" feats as a single repeatable entry; this codebase expands each into multiple concrete per-choice feats so the choice is explicit in the data:
+  - **Magic Initiate** → 6 feats: `magic-initiate-{cleric,druid,wizard}` (origin) + `magic-initiate-{bard,sorcerer,warlock}`. _In the PHB this is one repeatable Origin feat — see divergences for the category mismatch on the bard/sorcerer/warlock variants._
+  - **Elemental Adept** → 5 feats: `elemental-adept-{acid,cold,fire,lightning,thunder}`.
+  - **Resilient** → 5 feats: `resilient-{constitution,dexterity,intelligence,strength,wisdom}`.
 - i18n: `gamedata.feats.<featId>.name` and `.description`.
+
+## Fighting Styles
+
+Source-of-truth: `src/lib/sources/fighting-styles.ts` (`FIGHTING_STYLE_SOURCES`, `FightingStyleSource`), `src/lib/dnd-helpers.ts` (`FIGHTING_STYLE_IDS`, `FightingStyleId`).
+
+- `FightingStyleId` union (6): `'archery' | 'defense' | 'dueling' | 'great-weapon-fighting' | 'protection' | 'two-weapon-fighting'`.
+- `FightingStyleSource` shape: `{ id, grants }`. Most styles are **feature-only** (`{ type: 'feature', feature: { id: 'fighting-style-<id>' } }`); `defense` additionally grants `{ type: 'ac-bonus', bonus: 1 }`. Other mechanical effects are deferred until the weapons/damage system lands.
+- Selected via a class `{ type: 'fighting-style-choice', key, count, from: FIGHTING_STYLE_IDS }` grant, and separately available as the `fightingStyle`-category feats whose IDs mirror these values (see [Feat Catalog](#feat-catalog)).
+- ⚠️ The PHB defines **10** Fighting Styles; this codebase implements 6 (missing `blind-fighting`, `interception`, `thrown-weapon-fighting`, `unarmed-fighting`) — see [Known divergences](#known-divergences-from-the-2024-phb).
+- i18n: `gamedata.fightingStyles.<fightingStyleId>`.
+
+## Spellcasting
+
+Source-of-truth: `src/lib/resolver/spellcasting.ts` (`resolveSpellcasting()`), `src/lib/dnd-helpers.ts` (spell-slot tables, pact-magic progression), `src/types/grants.ts` (`SpellcastingGrant`), `src/types/resolved.ts` (`ResolvedSpellcasting`, `ResolvedPactMagic`).
+
+- A `SpellcastingGrant` is `{ type: 'spellcasting', ability: AbilityKey, source: 'class' | 'species' | 'feat' }`. `resolveSpellcasting(...)` returns a `ResolvedSpellcasting` or `null` when the build has no spellcasting grants.
+- `ResolvedSpellcasting`: `{ ability, spellSaveDC, spellAttackBonus, cantrips, knownSpells, alwaysPreparedSpells, slots, preparedCount, pactMagic }`. `slots` is an array indexed by spell level − 1 (`slots[0]` = level-1 slots). `pactMagic` is a `ResolvedPactMagic { count, slotLevel }` for Warlock, else `null`.
+- Caster classification (encoded in `dnd-helpers.ts` slot tables / helper sets):
+  - **Full casters** (`getSpellSlots`): `bard`, `cleric`, `druid`, `sorcerer`, `wizard`.
+  - **Half casters** (slots begin at class level 2): `paladin`, `ranger`.
+  - **Pact magic** (`getPactMagicSlots`, separate progression): `warlock`.
+  - **Prepared casters** (`preparedCount = max(1, classLevel + abilityMod)`): `cleric`, `druid`, `wizard`, `paladin`, `ranger`.
+- Coverage is **partial**: subclass casters (e.g., Eldritch Knight, Arcane Trickster) depend on their subclass grants, which are only fully implemented for some subclasses (see [Subclass Selection](#subclass-selection)).
 
 ## Weapon Mastery
 
@@ -46,16 +89,26 @@ Source-of-truth: `src/types/items.ts` (`WEAPON_MASTERIES`, `WeaponMasteryId`, `W
 - Stored on the `Character` row as `weapon_masteries: { weaponId: string; masteryId: WeaponMasteryId }[] | null`.
 - i18n: `gamedata.weaponMasteries.<masteryId>.name` and `.description`.
 
+## Items & Equipment
+
+Source-of-truth: `src/types/items.ts` (`WeaponDef`, `ArmorDef`, `GearDef`, `PackDef`), `src/lib/sources/items.ts` (catalogs).
+
+- **`WEAPON_CATALOG`** (37 entries): `WeaponDef { id, category: 'simple' | 'martial', range: 'melee' | 'ranged', damageDice, damageType, properties[], weight, costGp, normalRange?, longRange?, versatileDice?, weaponProficiencyId, mastery? }`.
+- **`ARMOR_CATALOG`** (13 entries): `ArmorDef { id, category: 'light' | 'medium' | 'heavy' | 'shield', baseAc, maxDexBonus, stealthDisadvantage, strengthRequirement, weight, costGp }`.
+- **`GEAR_CATALOG`** (25 entries): `GearDef { id, weight, costGp }`.
+- **`PACK_CATALOG`** (3 entries): `PackDef { id, contents: { itemId, quantity }[], costGp }`.
+- i18n: item display names live under `gamedata.items.<weapons|armor|gear|packs>.<id>`; proficiency-category labels under `gamedata.weapons.*`, `gamedata.armor.*`, `gamedata.weaponProperties.*`, and `gamedata.damageTypes.*`.
+
 ## Subclass Selection
 
 Source-of-truth: `src/lib/sources/subclasses.ts` (`SUBCLASS_SOURCES`, `SUBCLASS_IDS_BY_CLASS`), `src/types/sources.ts` (`SubclassSource`, `SubclassFeature`).
 
 - All 12 classes select a subclass at class level 3 (index 2 of `ClassSource.levels`), matching the uniform 2024 PHB rule.
-- `SUBCLASS_IDS_BY_CLASS` maps each `ClassId` to exactly 4 subclass IDs.
+- `SUBCLASS_IDS_BY_CLASS` maps each `ClassId` to exactly 4 subclass IDs (48 subclasses total).
 - `SubclassSource` shape: `{ features: SubclassFeature[] }` where `SubclassFeature = { classLevel: number, grants: Grant[] }`.
-- **Populated** subclasses (features implemented): Fighter — `champion`, `battlemaster`, `eldritchknight`; Rogue — `thief`, `assassin`, `arcanetrickster`.
-- **Stub** subclasses (registered but `features: []`): all 42 remaining entries.
+- **All 48 subclasses have populated (non-empty) `features` arrays — there are no `features: []` stubs.** Coverage is, however, **partial, not rules-as-written complete**: subclass feature levels follow each class's own 2024 PHB table (not a uniform progression), and most subclasses are missing their higher-level milestones (only the 3 Fighter subclasses — `champion`, `battlemaster`, `eldritchknight` — currently cover the full 3/7/10/15/18 set). Run `npm run coverage:matrix` to regenerate `docs/coverage-matrix.md` — the live per-entry status report (`src/lib/sources/coverage-matrix.ts`). Note: `complete` there means _structurally shaped correctly_, not _verified against the PHB_.
 - Subclass grants are injected into the resolver via the `{ type: 'subclass', classId, key }` grant, which produces a `pending-choice` in `ResolvedCharacter` until the player selects one.
+- i18n: `gamedata.subclasses.<subclassId>`.
 
 ## Conditions
 
@@ -65,3 +118,24 @@ Source-of-truth: `src/lib/sources/conditions.ts` (`CONDITION_IDS`, `ConditionId`
 - Conditions are stored on `Combatant.conditions: readonly ConditionId[]` in the `Encounter` JSONB column.
 - Exhaustion specifically uses `ExhaustionLevel` (type: `0 | 1 | 2 | 3 | 4 | 5 | 6`) on the `Character` row, defined in `src/lib/dnd-helpers.ts`. The `exhaustionPenalty(level)` function there computes `{ d20Penalty, speedPenalty, dead }`.
 - i18n: `gamedata.conditions.<conditionId>`.
+
+## Known divergences from the 2024 PHB
+
+The data above describes the codebase as implemented. The following entries are known to differ from rules-as-written; tracked in [issue #175](https://github.com/drovani/dnd-maintainer/issues/175).
+
+**Content present in code but not in the 2024 PHB:**
+
+- **Dragonborn gem ancestries** — `species.ts` defines 15 lineages including 5 gem variants (`gem-amethyst/crystal/emerald/sapphire/topaz`); the PHB lists only the 10 chromatic + metallic.
+- **Gnome `deep` lineage** — the PHB has only Forest and Rock Gnome.
+- **`boon-of-luck`** (Epic Boon) — the PHB lists exactly 12 boons; this one is extra.
+- **`dungeon-delver`** (General feat) — not in the PHB Feat List.
+
+**Content in the 2024 PHB but missing from code:**
+
+- **Fighting Styles** — missing `blind-fighting`, `interception`, `thrown-weapon-fighting`, `unarmed-fighting` (code has 6 of the PHB's 10).
+- **`martial-weapon-training`** (General feat).
+- **`resilient-charisma`** — the Resilient split omits the charisma variant.
+
+**Miscategorized:**
+
+- **Magic Initiate** — `magic-initiate-{bard,sorcerer,warlock}` are categorized as `general`, but Magic Initiate is an **Origin** feat in the PHB (a single repeatable feat; this codebase splits it per spell list — see the [repeatable-feat split convention](#feat-catalog)).


### PR DESCRIPTION
Track A of the `docs/dnd-2024.md` accuracy review (against the 2024 PHB).

## Changes
- Fix stale subclass claim — all 48 subclasses are populated (not 42 `features: []` stubs).
- Add four new sections: **Classes**, **Spellcasting**, **Items & Equipment**, **Fighting Styles**.
- Document the **repeatable-feat split convention** (Magic Initiate / Elemental Adept / Resilient).
- Add a **"Known divergences from the 2024 PHB"** section linking #175.
- Correct General feat count (53) and note Fighting Styles are 6 of the PHB's 10.

Docs-only; all type shapes, export names, catalog counts, and slot tables were verified against the code. Code-level fixes for the divergences are tracked in #175.

🤖 Generated with [Claude Code](https://claude.com/claude-code)