### PR TITLE
feat(feats): resolve feat-origin feature-choices through the real pipeline + restore Magic Initiate badge

### DIFF
--- a/src/components/character-builder/OriginStep.test.tsx
+++ b/src/components/character-builder/OriginStep.test.tsx
@@ -1,9 +1,9 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { OriginStep } from '@/components/character-builder/OriginStep';
 import type { Character } from '@/types/database';
 import type { GrantBundle } from '@/types/sources';
-import type { ChoiceKey } from '@/types/choices';
+import { createChoiceKey, type ChoiceKey } from '@/types/choices';
 import type { ResolvedCharacter } from '@/types/resolved';
 
 // ---------------------------------------------------------------------------
@@ -342,6 +342,39 @@ describe('OriginStep', () => {
     const radios = screen.getAllByRole('radio') as HTMLInputElement[];
     const featureRadios = radios.filter((r) => r.name?.startsWith('choice-feature-'));
     expect(featureRadios.length).toBe(3);
+  });
+
+  it('fires makeChoice with the correct choiceKey and decision when a feature radio is changed', () => {
+    const magicInitiateChoiceKey = createChoiceKey('feature-choice', 'feat', 'magic-initiate', 0);
+    mockResolved = {
+      ...makeDefaultResolved(),
+      pendingChoices: [
+        {
+          type: 'feature-choice' as const,
+          choiceKey: magicInitiateChoiceKey,
+          source: { origin: 'feat', id: 'magic-initiate' } as const,
+          options: [
+            { optionId: 'cleric', featureId: 'feat-magic-initiate-cleric' },
+            { optionId: 'druid', featureId: 'feat-magic-initiate-druid' },
+            { optionId: 'wizard', featureId: 'feat-magic-initiate-wizard' },
+          ],
+        },
+      ],
+    };
+
+    render(<OriginStep />);
+
+    // Click the cleric radio — identified by its label text (mock returns the last key segment)
+    // t('features.feat-magic-initiate-cleric.name', { defaultValue: 'feat-magic-initiate-cleric' }) → 'feat-magic-initiate-cleric'
+    const clericRadio = screen.getByRole('radio', {
+      name: /feat-magic-initiate-cleric/i,
+    }) as HTMLInputElement;
+    fireEvent.click(clericRadio);
+
+    expect(mockMakeChoice).toHaveBeenCalledWith(magicInitiateChoiceKey, {
+      type: 'feature-choice',
+      optionId: 'cleric',
+    });
   });
 
   it('does not render a feat-origin feature-choice picker when no such pending choice exists', () => {

--- a/src/components/character-builder/OriginStep.test.tsx
+++ b/src/components/character-builder/OriginStep.test.tsx
@@ -311,4 +311,91 @@ describe('OriginStep', () => {
 
     expect(screen.queryByText('loadingLineage')).toBeNull();
   });
+
+  // ---------------------------------------------------------------------------
+  // Part 2: feat-origin feature-choice picker
+  // ---------------------------------------------------------------------------
+
+  it('renders a ChoicePicker with radios when a feat-origin feature-choice is pending', () => {
+    // Simulate magic-initiate in build.feats and no decision yet → pending choice arrives via resolved.
+    // The OriginStep renders regardless of background state — we omit background here to show
+    // the picker section is driven by resolved.pendingChoices, not by background presence.
+    mockResolved = {
+      ...makeDefaultResolved(),
+      pendingChoices: [
+        {
+          type: 'feature-choice' as const,
+          choiceKey: 'feature-choice:feat:magic-initiate:0' as ChoiceKey,
+          source: { origin: 'feat', id: 'magic-initiate' } as const,
+          options: [
+            { optionId: 'cleric', featureId: 'feat-magic-initiate-cleric' },
+            { optionId: 'druid', featureId: 'feat-magic-initiate-druid' },
+            { optionId: 'wizard', featureId: 'feat-magic-initiate-wizard' },
+          ],
+        },
+      ],
+    };
+
+    render(<OriginStep />);
+
+    // ChoicePicker renders radio inputs for each option (name = choice-feature-<key>)
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    const featureRadios = radios.filter((r) => r.name?.startsWith('choice-feature-'));
+    expect(featureRadios.length).toBe(3);
+  });
+
+  it('does not render a feat-origin feature-choice picker when no such pending choice exists', () => {
+    mockResolved = {
+      ...makeDefaultResolved(),
+      pendingChoices: [],
+    };
+
+    render(<OriginStep />);
+
+    const radios = screen.queryAllByRole('radio') as HTMLInputElement[];
+    const featureRadios = radios.filter((r) => r.name?.startsWith('choice-feature-'));
+    expect(featureRadios).toHaveLength(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Part 4: badge shows for a direct feat-magic-initiate-* feature grant (acolyte)
+  // ---------------------------------------------------------------------------
+
+  it('shows the Origin Feat badge for a direct feat-magic-initiate-cleric feature grant (acolyte style)', () => {
+    mockCharacter = buildSeedCharacter({ background: 'acolyte' });
+    // Acolyte grants feat-magic-initiate-cleric as a direct feature, not a feat grant (post-#177)
+    mockBundles = [
+      {
+        source: { origin: 'background', id: 'acolyte' as const },
+        grants: [
+          {
+            type: 'feature' as const,
+            feature: { id: 'feat-magic-initiate-cleric' },
+          },
+        ],
+      },
+    ] as readonly GrantBundle[];
+
+    render(<OriginStep />);
+
+    // originFeatTitle label renders
+    expect(screen.getByText('originFeatTitle')).toBeTruthy();
+    // t('features.feat-magic-initiate-cleric.name', { defaultValue: 'feat-magic-initiate-cleric' })
+    // Mock: defaultValue wins → 'feat-magic-initiate-cleric'
+    expect(screen.getByText('feat-magic-initiate-cleric')).toBeTruthy();
+  });
+
+  it('does not show Origin Feat section when background has neither feat nor direct feature grant', () => {
+    mockCharacter = buildSeedCharacter({ background: 'acolyte' });
+    mockBundles = [
+      {
+        source: { origin: 'background', id: 'acolyte' as const },
+        grants: [],
+      },
+    ] as readonly GrantBundle[];
+
+    render(<OriginStep />);
+
+    expect(screen.queryByText('originFeatTitle')).toBeNull();
+  });
 });

--- a/src/components/character-builder/OriginStep.tsx
+++ b/src/components/character-builder/OriginStep.tsx
@@ -4,6 +4,7 @@ import { useCharacterContext } from '@/hooks/useCharacterContext';
 import { type SpeciesId, type ToolProficiencyId } from '@/lib/dnd-helpers';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
 import { getChoiceSourceName } from '@/lib/character-builder/choice-source-name';
+import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
 import type { ChoiceDecision } from '@/types/choices';
 import type { PendingChoice } from '@/types/resolved';
 import { useMemo } from 'react';
@@ -26,23 +27,9 @@ export function OriginStep() {
   const backgroundGrants = bundles.filter((b) => b.source.origin === 'background').flatMap((b) => b.grants);
 
   // Extract background origin grant info for the badge.
-  // PR #177 made acolyte/guide/sage grant Magic Initiate as a direct `feature` grant (not a `feat`
-  // grant), so we must check both shapes:
-  //   1. `{ type: 'feat', featId }` — the common case (e.g. Alert, Savage Attacker)
-  //   2. `{ type: 'feature', feature.id }` where id starts with 'feat-magic-initiate-' — the
-  //      direct-feature path used by acolyte/guide/sage after #177
-  // The returned object carries a `isDirectFeature` flag so the render picks the right i18n namespace
-  // (features.* vs feats.*.name).
-  const originFeatInfo: { id: string; isDirectFeature: boolean } | null = (() => {
-    const featGrant = backgroundGrants.find((g): g is Extract<typeof g, { type: 'feat' }> => g.type === 'feat');
-    if (featGrant) return { id: featGrant.featId, isDirectFeature: false };
-    const directFeatureGrant = backgroundGrants.find(
-      (g): g is Extract<typeof g, { type: 'feature' }> =>
-        g.type === 'feature' && g.feature.id.startsWith('feat-magic-initiate-')
-    );
-    if (directFeatureGrant) return { id: directFeatureGrant.feature.id, isDirectFeature: true };
-    return null;
-  })();
+  // deriveOriginFeatInfo handles both shapes (feat grant and direct feat-magic-initiate-* feature),
+  // returning { id, namespace } where namespace drives the i18n key prefix.
+  const originFeatInfo = deriveOriginFeatInfo(backgroundGrants);
 
   // Pending feat-origin feature-choices (e.g. magic-initiate class picker, elemental-adept, resilient).
   // NOTE: the general-feat ENTRY POINT (a UI to select feats at ASI level) is OUT OF SCOPE for #178.
@@ -100,7 +87,7 @@ export function OriginStep() {
           <div className="space-y-2 p-3 rounded-md border border-border bg-muted/30">
             <div className="flex items-center gap-3">
               <Badge variant="secondary" className="text-sm">
-                {originFeatInfo.isDirectFeature
+                {originFeatInfo.namespace === 'features'
                   ? t(`features.${originFeatInfo.id}.name` as `features.${string}.name`, {
                       defaultValue: originFeatInfo.id,
                     })
@@ -115,7 +102,7 @@ export function OriginStep() {
               )}
             </div>
             <p className="text-sm text-foreground">
-              {originFeatInfo.isDirectFeature
+              {originFeatInfo.namespace === 'features'
                 ? t(`features.${originFeatInfo.id}.description` as `features.${string}.description`, {
                     defaultValue: '',
                   })

--- a/src/components/character-builder/OriginStep.tsx
+++ b/src/components/character-builder/OriginStep.tsx
@@ -3,8 +3,10 @@ import { Label } from '@/components/ui/label';
 import { useCharacterContext } from '@/hooks/useCharacterContext';
 import { type SpeciesId, type ToolProficiencyId } from '@/lib/dnd-helpers';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
+import { getChoiceSourceName } from '@/lib/character-builder/choice-source-name';
 import type { ChoiceDecision } from '@/types/choices';
 import type { PendingChoice } from '@/types/resolved';
+import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { ChoicePicker } from './ChoicePicker';
 import { LineagePicker } from './LineagePicker';
@@ -14,7 +16,7 @@ export function OriginStep() {
   const { t } = useTranslation('gamedata');
   const { t: tc } = useTranslation('common');
   const context = useCharacterContext();
-  const { character, bundles, build } = context;
+  const { character, bundles, build, resolved } = context;
 
   const background = character.background ?? '';
   const species = character.species as SpeciesId | undefined;
@@ -23,8 +25,35 @@ export function OriginStep() {
   // Extract background grants (shared filter — avoids repeating the chain)
   const backgroundGrants = bundles.filter((b) => b.source.origin === 'background').flatMap((b) => b.grants);
 
-  // Extract background feat grant
-  const backgroundFeatGrant = backgroundGrants.find((g): g is Extract<typeof g, { type: 'feat' }> => g.type === 'feat');
+  // Extract background origin grant info for the badge.
+  // PR #177 made acolyte/guide/sage grant Magic Initiate as a direct `feature` grant (not a `feat`
+  // grant), so we must check both shapes:
+  //   1. `{ type: 'feat', featId }` — the common case (e.g. Alert, Savage Attacker)
+  //   2. `{ type: 'feature', feature.id }` where id starts with 'feat-magic-initiate-' — the
+  //      direct-feature path used by acolyte/guide/sage after #177
+  // The returned object carries a `isDirectFeature` flag so the render picks the right i18n namespace
+  // (features.* vs feats.*.name).
+  const originFeatInfo: { id: string; isDirectFeature: boolean } | null = (() => {
+    const featGrant = backgroundGrants.find((g): g is Extract<typeof g, { type: 'feat' }> => g.type === 'feat');
+    if (featGrant) return { id: featGrant.featId, isDirectFeature: false };
+    const directFeatureGrant = backgroundGrants.find(
+      (g): g is Extract<typeof g, { type: 'feature' }> =>
+        g.type === 'feature' && g.feature.id.startsWith('feat-magic-initiate-')
+    );
+    if (directFeatureGrant) return { id: directFeatureGrant.feature.id, isDirectFeature: true };
+    return null;
+  })();
+
+  // Pending feat-origin feature-choices (e.g. magic-initiate class picker, elemental-adept, resilient).
+  // NOTE: the general-feat ENTRY POINT (a UI to select feats at ASI level) is OUT OF SCOPE for #178.
+  // This only renders a picker when such a choice is already pending in the resolved state — e.g.
+  // when magic-initiate is in build.feats and the user must still pick a spellcasting class.
+  const featFeatureChoices = useMemo<readonly Extract<PendingChoice, { type: 'feature-choice' }>[]>(() => {
+    return (resolved?.pendingChoices ?? []).filter(
+      (c): c is Extract<PendingChoice, { type: 'feature-choice' }> =>
+        c.type === 'feature-choice' && c.source.origin === 'feat'
+    );
+  }, [resolved]);
 
   // Synthesize tool-choice and language-choice PendingChoices from background grants
   const backgroundToolChoiceGrants = collectGrantsByType(bundles, 'proficiency-choice').filter(
@@ -65,15 +94,19 @@ export function OriginStep() {
       )}
 
       {/* Origin Feat */}
-      {background && backgroundFeatGrant && (
+      {background && originFeatInfo && (
         <div className="space-y-2">
           <Label className="text-base font-semibold">{tc('characterBuilder.backgroundStep.originFeatTitle')}</Label>
           <div className="space-y-2 p-3 rounded-md border border-border bg-muted/30">
             <div className="flex items-center gap-3">
               <Badge variant="secondary" className="text-sm">
-                {t(`feats.${backgroundFeatGrant.featId}.name` as `feats.${string}.name`, {
-                  defaultValue: backgroundFeatGrant.featId,
-                })}
+                {originFeatInfo.isDirectFeature
+                  ? t(`features.${originFeatInfo.id}.name` as `features.${string}.name`, {
+                      defaultValue: originFeatInfo.id,
+                    })
+                  : t(`feats.${originFeatInfo.id}.name` as `feats.${string}.name`, {
+                      defaultValue: originFeatInfo.id,
+                    })}
               </Badge>
               {backgroundName && (
                 <span className="text-xs text-muted-foreground">
@@ -82,9 +115,13 @@ export function OriginStep() {
               )}
             </div>
             <p className="text-sm text-foreground">
-              {t(`feats.${backgroundFeatGrant.featId}.description` as `feats.${string}.description`, {
-                defaultValue: '',
-              })}
+              {originFeatInfo.isDirectFeature
+                ? t(`features.${originFeatInfo.id}.description` as `features.${string}.description`, {
+                    defaultValue: '',
+                  })
+                : t(`feats.${originFeatInfo.id}.description` as `feats.${string}.description`, {
+                    defaultValue: '',
+                  })}
             </p>
           </div>
         </div>
@@ -110,6 +147,30 @@ export function OriginStep() {
               );
             })}
           </div>
+        </div>
+      )}
+
+      {/* Feat-origin feature-choices (e.g. magic-initiate spellcasting class, elemental-adept element).
+          Renders only when such a choice is pending — i.e. the feat is in build.feats but the user
+          has not yet picked an option. The general-feat ENTRY POINT (selecting feats at ASI level)
+          is OUT OF SCOPE for #178 and is not rendered here. */}
+      {featFeatureChoices.length > 0 && (
+        <div className="space-y-4">
+          {featFeatureChoices.map((choice) => (
+            <div key={choice.choiceKey}>
+              <p className="text-xs text-muted-foreground mb-1">
+                {tc('characterBuilder.pendingChoices.fromSource', {
+                  source: getChoiceSourceName(choice.choiceKey, t),
+                })}
+              </p>
+              <ChoicePicker
+                choice={choice}
+                currentDecision={build?.choices[choice.choiceKey]}
+                onDecide={(choiceKey, decision) => context.makeChoice(choiceKey, decision)}
+                onClear={(choiceKey) => context.clearChoice(choiceKey)}
+              />
+            </div>
+          ))}
         </div>
       )}
     </div>

--- a/src/lib/character-builder/origin-feat-info.test.ts
+++ b/src/lib/character-builder/origin-feat-info.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from 'vitest';
+import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
+import type { Grant } from '@/types/grants';
+
+describe('deriveOriginFeatInfo', () => {
+  it('returns { namespace: feats } when a feat grant is present', () => {
+    const grants: readonly Grant[] = [{ type: 'feat', featId: 'alert' }];
+    const result = deriveOriginFeatInfo(grants);
+    expect(result).toEqual({ id: 'alert', namespace: 'feats' });
+  });
+
+  it('returns { namespace: features } for a direct feat-magic-initiate-cleric feature grant', () => {
+    const grants: readonly Grant[] = [{ type: 'feature', feature: { id: 'feat-magic-initiate-cleric' } }];
+    const result = deriveOriginFeatInfo(grants);
+    expect(result).toEqual({ id: 'feat-magic-initiate-cleric', namespace: 'features' });
+  });
+
+  it('returns { namespace: features } for a direct feat-magic-initiate-druid feature grant', () => {
+    const grants: readonly Grant[] = [{ type: 'feature', feature: { id: 'feat-magic-initiate-druid' } }];
+    const result = deriveOriginFeatInfo(grants);
+    expect(result).toEqual({ id: 'feat-magic-initiate-druid', namespace: 'features' });
+  });
+
+  it('returns { namespace: features } for a direct feat-magic-initiate-wizard feature grant', () => {
+    const grants: readonly Grant[] = [{ type: 'feature', feature: { id: 'feat-magic-initiate-wizard' } }];
+    const result = deriveOriginFeatInfo(grants);
+    expect(result).toEqual({ id: 'feat-magic-initiate-wizard', namespace: 'features' });
+  });
+
+  it('returns null when no feat or magic-initiate feature grant exists', () => {
+    const grants: readonly Grant[] = [{ type: 'proficiency', category: 'skill', id: 'insight' }];
+    const result = deriveOriginFeatInfo(grants);
+    expect(result).toBeNull();
+  });
+
+  it('returns null for empty grants array', () => {
+    const result = deriveOriginFeatInfo([]);
+    expect(result).toBeNull();
+  });
+
+  it('feat grant wins over direct feature grant when both are present (feat-first precedence)', () => {
+    const grants: readonly Grant[] = [
+      { type: 'feature', feature: { id: 'feat-magic-initiate-cleric' } },
+      { type: 'feat', featId: 'alert' },
+    ];
+    const result = deriveOriginFeatInfo(grants);
+    expect(result).toEqual({ id: 'alert', namespace: 'feats' });
+  });
+
+  it('ignores feature grants whose id does not start with feat-magic-initiate-', () => {
+    const grants: readonly Grant[] = [{ type: 'feature', feature: { id: 'fighter-second-wind' } }];
+    const result = deriveOriginFeatInfo(grants);
+    expect(result).toBeNull();
+  });
+});

--- a/src/lib/character-builder/origin-feat-info.ts
+++ b/src/lib/character-builder/origin-feat-info.ts
@@ -1,0 +1,32 @@
+import type { Grant } from '@/types/grants';
+
+export interface OriginFeatInfo {
+  readonly id: string;
+  readonly namespace: 'features' | 'feats';
+}
+
+/**
+ * Derives the origin feat badge info from a background's grants array.
+ *
+ * Two shapes exist in the data (see PR #177):
+ *   1. `{ type: 'feat', featId }` — common case (e.g. Alert, Savage Attacker).
+ *      Maps to namespace 'feats' so callers use `t('feats.<id>.name')`.
+ *   2. `{ type: 'feature', feature.id }` where the id starts with
+ *      'feat-magic-initiate-' — direct-feature path used by acolyte/guide/sage.
+ *      Maps to namespace 'features' so callers use `t('features.<id>.name')`.
+ *
+ * Feat-grant wins when both are present (preserves pre-extract behaviour).
+ * Returns null when neither is found.
+ */
+export function deriveOriginFeatInfo(grants: readonly Grant[]): OriginFeatInfo | null {
+  const featGrant = grants.find((g): g is Extract<Grant, { type: 'feat' }> => g.type === 'feat');
+  if (featGrant) return { id: featGrant.featId, namespace: 'feats' };
+
+  const directFeatureGrant = grants.find(
+    (g): g is Extract<Grant, { type: 'feature' }> =>
+      g.type === 'feature' && g.feature.id.startsWith('feat-magic-initiate-')
+  );
+  if (directFeatureGrant) return { id: directFeatureGrant.feature.id, namespace: 'features' };
+
+  return null;
+}

--- a/src/lib/sources/feats.ts
+++ b/src/lib/sources/feats.ts
@@ -31,7 +31,7 @@ export const FEAT_SOURCES: readonly FeatSource[] = [
     id: 'magic-initiate',
     category: 'origin',
     prerequisites: [],
-    repeatable: true,
+    repeatable: true, // TODO(#178): repeatable not yet enforced — per-instance ChoiceKey indexing needed
     grants: [
       {
         type: 'feature-choice',

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -582,3 +582,69 @@ describe('Magic Initiate pipeline integration (acolyte → cleric spells)', () =
     expect(warnings.some((w) => w.includes('magic-initiate'))).toBe(false);
   });
 });
+
+describe('feat-origin feature-choice pipeline (build.feats: magic-initiate)', () => {
+  // Use soldier background (grants savage-attacker feat) — no magic-initiate collision.
+  // Acolyte/guide/sage grant feat-magic-initiate-cleric/druid/wizard as a *direct feature* (PR #177),
+  // so using them here would create a second feat-magic-initiate-cleric from two sources.
+  const magicInitiateKey = createChoiceKey('feature-choice', 'feat', 'magic-initiate', 0);
+
+  const buildWithDecision: CharacterBuild = {
+    speciesId: 'human' as SpeciesId,
+    backgroundId: 'soldier' as BackgroundId,
+    baseAbilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 },
+    abilityMethod: 'standard-array',
+    levels: [{ classId: 'fighter' as ClassId, classLevel: 1, hpRoll: null }],
+    choices: {
+      [magicInitiateKey]: { type: 'feature-choice' as const, optionId: 'cleric' },
+    },
+    feats: ['magic-initiate' as FeatId],
+    activeItems: [],
+  };
+
+  const buildWithoutDecision: CharacterBuild = {
+    ...buildWithDecision,
+    choices: {},
+  };
+
+  it('with decision: feat-magic-initiate-cleric appears exactly once in resolved features', () => {
+    const { bundles, expandedFeats } = collectBundles(buildWithDecision);
+    const result = resolveCharacter({
+      baseAbilities: buildWithDecision.baseAbilities,
+      level: buildWithDecision.levels.length,
+      bundles,
+      choices: buildWithDecision.choices,
+      levels: buildWithDecision.levels,
+      expandedFeats,
+    });
+    const clericFeatures = result.features.filter((f) => f.feature.id === 'feat-magic-initiate-cleric');
+    expect(clericFeatures, 'feat-magic-initiate-cleric should appear exactly once').toHaveLength(1);
+    const pendingMagicInitiate = result.pendingChoices.find(
+      (c) => 'choiceKey' in c && String(c.choiceKey).includes('magic-initiate')
+    );
+    expect(pendingMagicInitiate, 'no pending magic-initiate choice after resolution').toBeUndefined();
+  });
+
+  it('without decision: a pending feature-choice for magic-initiate is emitted', () => {
+    const { bundles, expandedFeats } = collectBundles(buildWithoutDecision);
+    const result = resolveCharacter({
+      baseAbilities: buildWithoutDecision.baseAbilities,
+      level: buildWithoutDecision.levels.length,
+      bundles,
+      choices: buildWithoutDecision.choices,
+      levels: buildWithoutDecision.levels,
+      expandedFeats,
+    });
+    const pendingMagicInitiate = result.pendingChoices.find(
+      (c) => c.type === 'feature-choice' && String(c.choiceKey).includes('magic-initiate')
+    );
+    expect(pendingMagicInitiate, 'pending feature-choice for magic-initiate should be emitted').toBeDefined();
+    expect(pendingMagicInitiate?.type).toBe('feature-choice');
+  });
+
+  it('with decision: no origin-mismatch warning fires for a resolved feat-origin choice', () => {
+    const { warnings } = collectBundles(buildWithDecision);
+    const originMismatch = warnings.find((w) => w.includes('non-class origin') && w.includes('feat'));
+    expect(originMismatch, 'no origin-mismatch warning for resolved feat-origin feature-choice').toBeUndefined();
+  });
+});

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -20,6 +20,11 @@ import {
   getFeatSource,
   getItemSource,
   collectBundles,
+  SPECIES_SOURCES,
+  CLASS_SOURCES,
+  SUBCLASS_SOURCES,
+  BACKGROUND_SOURCES,
+  FEAT_SOURCES,
 } from '@/lib/sources';
 import { resolveCharacter } from '@/lib/resolver';
 import type { CharacterBuild } from '@/types/choices';
@@ -646,5 +651,76 @@ describe('feat-origin feature-choice pipeline (build.feats: magic-initiate)', ()
     const { warnings } = collectBundles(buildWithDecision);
     const originMismatch = warnings.find((w) => w.includes('non-class origin') && w.includes('feat'));
     expect(originMismatch, 'no origin-mismatch warning for resolved feat-origin feature-choice').toBeUndefined();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Single-pass safety invariant
+// ---------------------------------------------------------------------------
+// collectBundles expands feature-choice options in a single pass (not a fixpoint).
+// This means any option grant of type 'feat', 'lineage-choice', or 'feature-choice'
+// would be silently dropped. The invariant test below iterates every feature-choice
+// grant across ALL sources and asserts no option contains such a grant.
+// If this test goes red, promote the expansion to a fixpoint loop before merging.
+
+describe('feature-choice single-pass safety invariant', () => {
+  it('no feature-choice option grant has type feat, lineage-choice, or feature-choice across all sources', () => {
+    const FORBIDDEN_GRANT_TYPES = new Set(['feat', 'lineage-choice', 'feature-choice']);
+
+    // Collect all feature-choice grants from every source collection.
+    // Classes: levels[].grants; Subclasses: features[].grants; others: .grants
+    const violations: string[] = [];
+
+    function checkGrants(sourceLabel: string, grants: readonly { type: string }[]) {
+      for (const grant of grants) {
+        if (grant.type === 'feature-choice') {
+          const fcGrant = grant as {
+            type: 'feature-choice';
+            options: readonly { optionId: string; grants: readonly { type: string }[] }[];
+            key: string;
+          };
+          for (const option of fcGrant.options) {
+            for (const optionGrant of option.grants) {
+              if (FORBIDDEN_GRANT_TYPES.has(optionGrant.type)) {
+                violations.push(
+                  `${sourceLabel} feature-choice key="${String(fcGrant.key)}" option="${option.optionId}" has forbidden grant type "${optionGrant.type}"`
+                );
+              }
+            }
+          }
+        }
+      }
+    }
+
+    for (const source of SPECIES_SOURCES) {
+      checkGrants(`species:${source.id}`, source.grants);
+    }
+
+    for (const source of CLASS_SOURCES) {
+      for (const [i, level] of source.levels.entries()) {
+        checkGrants(`class:${source.id}:level${i + 1}`, level.grants);
+      }
+    }
+
+    for (const [subclassId, source] of Object.entries(SUBCLASS_SOURCES)) {
+      for (const feature of source.features) {
+        checkGrants(`subclass:${subclassId}:classLevel${feature.classLevel}`, feature.grants);
+      }
+    }
+
+    for (const source of BACKGROUND_SOURCES) {
+      checkGrants(`background:${source.id}`, source.grants);
+    }
+
+    for (const source of FEAT_SOURCES) {
+      checkGrants(`feat:${source.id}`, source.grants);
+    }
+
+    expect(
+      violations,
+      'feature-choice option grants must not contain feat, lineage-choice, or feature-choice — ' +
+        'collectBundles expands options in a single pass and would silently drop these. ' +
+        'Promote to a fixpoint loop before adding such an option.'
+    ).toHaveLength(0);
   });
 });

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -301,9 +301,15 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
 
   // Feature-choice expansion — runs AFTER all sources (species, class, subclass, background, feat, item)
   // are pushed into bundles so feat-origin feature-choices (e.g. magic-initiate, elemental-adept,
-  // resilient) are visible here. Expansion runs once (not to a fixpoint) — this is safe because
-  // feat-origin feature-choice options expand only to terminal grants (no option nests another
-  // feature-choice); revisit with a fixpoint if that ever changes.
+  // resilient) are visible here.
+  //
+  // SINGLE-PASS SAFETY ASSUMPTION: expansion runs exactly once (not to a fixpoint) AND runs after
+  // the feat and lineage expansion passes, so a chosen option whose own grants contain a grant of
+  // type 'feat', 'lineage-choice', or 'feature-choice' would be silently dropped. This is safe ONLY
+  // because all current feature-choice options expand to terminal grants (proficiency, feature, etc.)
+  // — none nests another feat, lineage-choice, or feature-choice. The invariant is enforced by a
+  // companion test in index.test.ts; if that test goes red, promote this to a fixpoint loop before
+  // adding the new option.
   const allFeatureChoiceGrants: { grant: FeatureChoiceGrant; source: SourceTag }[] = [];
   for (const bundle of bundles) {
     for (const grant of bundle.grants) {

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -216,42 +216,6 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
     }
   }
 
-  // Feature-choice grants
-  const allFeatureChoiceGrants: { grant: FeatureChoiceGrant; source: SourceTag }[] = [];
-  for (const bundle of bundles) {
-    for (const grant of bundle.grants) {
-      if (grant.type === 'feature-choice') {
-        allFeatureChoiceGrants.push({ grant: grant as FeatureChoiceGrant, source: bundle.source });
-      }
-    }
-  }
-
-  for (const { grant, source } of allFeatureChoiceGrants) {
-    // Today only ClassStep dispatches feature-choice pending choices through the builder UI.
-    // A non-class origin would silently strand the user on an undisplayable pending choice;
-    // surface as a warning so the CharacterBuilder amber banner shows it instead of failing silently.
-    if (source.origin !== 'class') {
-      const msg = `feature-choice "${grant.key}" has non-class origin "${source.origin}" — no builder UI exists for this origin, choice will be invisible`;
-      warnings.push(msg);
-      logger.warn(msg);
-    }
-
-    const decision = build.choices[grant.key];
-    if (decision?.type === 'feature-choice') {
-      const option = grant.options.find((o) => o.optionId === decision.optionId);
-      if (option) {
-        bundles.push({
-          source,
-          grants: [{ type: 'feature', feature: { id: option.featureId } }, ...option.grants],
-        });
-      } else {
-        const msg = `feature-choice "${grant.key}" decision references unknown option "${decision.optionId}"`;
-        warnings.push(msg);
-        logger.warn(msg);
-      }
-    }
-  }
-
   // Lineage choices — expand chosen lineage into grant bundles
   const allLineageChoiceGrants: { grant: LineageChoiceGrant; source: SourceTag }[] = [];
   for (const bundle of bundles) {
@@ -332,6 +296,46 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
       const msg = `No source data found for item "${itemId}" — item grants will be empty`;
       warnings.push(msg);
       logger.warn(msg);
+    }
+  }
+
+  // Feature-choice expansion — runs AFTER all sources (species, class, subclass, background, feat, item)
+  // are pushed into bundles so feat-origin feature-choices (e.g. magic-initiate, elemental-adept,
+  // resilient) are visible here. Expansion runs once (not to a fixpoint) — this is safe because
+  // feat-origin feature-choice options expand only to terminal grants (no option nests another
+  // feature-choice); revisit with a fixpoint if that ever changes.
+  const allFeatureChoiceGrants: { grant: FeatureChoiceGrant; source: SourceTag }[] = [];
+  for (const bundle of bundles) {
+    for (const grant of bundle.grants) {
+      if (grant.type === 'feature-choice') {
+        allFeatureChoiceGrants.push({ grant: grant as FeatureChoiceGrant, source: bundle.source });
+      }
+    }
+  }
+
+  for (const { grant, source } of allFeatureChoiceGrants) {
+    // ClassStep and OriginStep handle their respective origins in the builder UI.
+    // Any other origin (e.g. 'item', 'subclass') would produce an invisible pending choice;
+    // surface as a warning so the CharacterBuilder amber banner shows it instead of failing silently.
+    if (source.origin !== 'class' && source.origin !== 'feat') {
+      const msg = `feature-choice "${grant.key}" has non-class origin "${source.origin}" — no builder UI exists for this origin, choice will be invisible`;
+      warnings.push(msg);
+      logger.warn(msg);
+    }
+
+    const decision = build.choices[grant.key];
+    if (decision?.type === 'feature-choice') {
+      const option = grant.options.find((o) => o.optionId === decision.optionId);
+      if (option) {
+        bundles.push({
+          source,
+          grants: [{ type: 'feature', feature: { id: option.featureId } }, ...option.grants],
+        });
+      } else {
+        const msg = `feature-choice "${grant.key}" decision references unknown option "${decision.optionId}"`;
+        warnings.push(msg);
+        logger.warn(msg);
+      }
     }
   }
 

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -15,6 +15,7 @@ import { ProficienciesPanel } from '@/components/character-sheet/ProficienciesPa
 import { ResourcePoolsPanel } from '@/components/character-sheet/ResourcePoolsPanel';
 import { SkillsPanel } from '@/components/character-sheet/SkillsPanel';
 import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
+import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
 import { getGrantIcon, getSourceDisplayName } from '@/lib/class-icons';
 import { getItemDef, getItemNameKey } from '@/lib/sources/items';
 import { useCharacter, useCharacterMutations } from '@/hooks/useCharacters';
@@ -222,22 +223,13 @@ function CharacterSheetInner({
     return decision.type === 'lineage-choice' ? decision.lineageId : null;
   })();
 
-  // Origin feat: find the feat or direct feature granted by the character's background source.
-  // PR #177 made acolyte/guide/sage grant Magic Initiate as a direct `feature` grant whose id
-  // starts with 'feat-magic-initiate-', so we check both shapes. The `isDirectFeature` flag
-  // selects the right i18n namespace at the render site.
-  const originFeatInfo: { id: string; isDirectFeature: boolean } | null = (() => {
+  // Origin feat: derive badge info from the background source's grants.
+  // deriveOriginFeatInfo handles both shapes (feat grant and direct feat-magic-initiate-* feature).
+  const originFeatInfo = (() => {
     if (!character.background || !isBackgroundId(character.background)) return null;
     const bg = BACKGROUND_SOURCES.find((s) => s.id === character.background);
     if (!bg) return null;
-    const featGrant = bg.grants.find((g) => g.type === 'feat');
-    if (featGrant && 'featId' in featGrant) return { id: featGrant.featId, isDirectFeature: false };
-    const directFeatureGrant = bg.grants.find(
-      (g) => g.type === 'feature' && 'feature' in g && g.feature.id.startsWith('feat-magic-initiate-')
-    );
-    if (directFeatureGrant && 'feature' in directFeatureGrant)
-      return { id: directFeatureGrant.feature.id, isDirectFeature: true };
-    return null;
+    return deriveOriginFeatInfo(bg.grants);
   })();
 
   return (
@@ -326,7 +318,7 @@ function CharacterSheetInner({
               </p>
               {originFeatInfo && (
                 <p className="text-xs text-muted-foreground mt-0.5">
-                  {originFeatInfo.isDirectFeature
+                  {originFeatInfo.namespace === 'features'
                     ? t(`features.${originFeatInfo.id}.name` as `features.${string}.name`, {
                         defaultValue: originFeatInfo.id,
                       })

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -222,12 +222,22 @@ function CharacterSheetInner({
     return decision.type === 'lineage-choice' ? decision.lineageId : null;
   })();
 
-  // Origin feat: find the feat granted by the character's background source
-  const originFeatId: string | null = (() => {
+  // Origin feat: find the feat or direct feature granted by the character's background source.
+  // PR #177 made acolyte/guide/sage grant Magic Initiate as a direct `feature` grant whose id
+  // starts with 'feat-magic-initiate-', so we check both shapes. The `isDirectFeature` flag
+  // selects the right i18n namespace at the render site.
+  const originFeatInfo: { id: string; isDirectFeature: boolean } | null = (() => {
     if (!character.background || !isBackgroundId(character.background)) return null;
     const bg = BACKGROUND_SOURCES.find((s) => s.id === character.background);
-    const featGrant = bg?.grants.find((g) => g.type === 'feat');
-    return featGrant && 'featId' in featGrant ? featGrant.featId : null;
+    if (!bg) return null;
+    const featGrant = bg.grants.find((g) => g.type === 'feat');
+    if (featGrant && 'featId' in featGrant) return { id: featGrant.featId, isDirectFeature: false };
+    const directFeatureGrant = bg.grants.find(
+      (g) => g.type === 'feature' && 'feature' in g && g.feature.id.startsWith('feat-magic-initiate-')
+    );
+    if (directFeatureGrant && 'feature' in directFeatureGrant)
+      return { id: directFeatureGrant.feature.id, isDirectFeature: true };
+    return null;
   })();
 
   return (
@@ -314,9 +324,15 @@ function CharacterSheetInner({
                     : character.background
                   : ''}
               </p>
-              {originFeatId && (
+              {originFeatInfo && (
                 <p className="text-xs text-muted-foreground mt-0.5">
-                  {t(`feats.${originFeatId}.name`, { defaultValue: originFeatId })}
+                  {originFeatInfo.isDirectFeature
+                    ? t(`features.${originFeatInfo.id}.name` as `features.${string}.name`, {
+                        defaultValue: originFeatInfo.id,
+                      })
+                    : t(`feats.${originFeatInfo.id}.name` as `feats.${string}.name`, {
+                        defaultValue: originFeatInfo.id,
+                      })}
                 </p>
               )}
             </div>

--- a/src/types/sources.ts
+++ b/src/types/sources.ts
@@ -101,6 +101,12 @@ export interface FeatSource {
   readonly category: FeatCategory;
   readonly prerequisites: readonly FeatPrerequisite[];
   readonly grants: readonly Grant[];
+  /**
+   * When true, this feat may be taken more than once (e.g. magic-initiate, elemental-adept).
+   * NOT YET ENFORCED: CharacterBuild.feats is a set-like FeatId[]; the feature-choice ChoiceKey
+   * hardcodes index 0, so a second instance would collide with the first. Full support requires
+   * per-instance indexing. Tracked in #178.
+   */
   readonly repeatable?: boolean;
 }
 


### PR DESCRIPTION
Closes #178

## Summary
Makes feat-origin `feature-choice` grants resolve end-to-end through the real `collectBundles` + `resolveCharacter` pipeline (previously they were silently dropped due to expansion ordering), renders a `ChoicePicker` for them in the Origin step, restores the Magic Initiate origin-feat badge that regressed in PR #177, and documents `repeatable` as not-yet-enforced.

## What Changed
- **Part 1 (pipeline ordering)** — `src/lib/sources/index.ts`: moved the `feature-choice` expansion block to run AFTER feats/items are pushed into `bundles`, so feat-origin choices get their chosen option's grants applied. Narrowed the non-class warning guard to also exempt `feat` origin. Added a comment documenting the single-pass (non-fixpoint) safety assumption.
- **Part 2 (feat-picker UI)** — `src/components/character-builder/OriginStep.tsx`: renders a `ChoicePicker` for any pending `feature-choice` with `source.origin === 'feat'` (mirrors the class path in ClassStep).
- **Part 3 (repeatable)** — documented `FeatSource.repeatable` as not-yet-enforced (`src/types/sources.ts`) + `TODO(#178)` at magic-initiate (`src/lib/sources/feats.ts`).
- **Part 4 (badge)** — `src/pages/CharacterSheet.tsx` + `OriginStep.tsx`: origin-feat badge now also recognizes `feat-magic-initiate-*` direct feature grants (restores acolyte/guide/sage badge), routing to `features.*` vs `feats.*` translation namespaces appropriately.

## Scope decision (deferred)
The **general-feat entry point** — a UI to pick elemental-adept/resilient/magic-initiate as a general feat at ASI level-up — is **out of scope**. No background emits a magic-initiate `feat` grant (they use the direct-feature path post-#177) and `build.feats` has no wizard entry point yet. This PR makes the pipeline *resolve* feat-origin choices and *render* the picker when one is pending (proven via a mocked-pending component test). The entry point is a follow-up.

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 1651 pass (8 new; existing class/subclass/species feature-choice regression tests green, confirming the reorder is safe)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)