### PR TITLE
[5.5e] Human Versatile: feat-choice grant + origin-feat library (Tough/Skilled/Crafter/Musician)

### DIFF
--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -235,6 +235,88 @@ describe('ChoicePicker bundle-choice', () => {
 });
 
 // ---------------------------------------------------------------------------
+// ChoicePicker — feat-choice branch
+// ---------------------------------------------------------------------------
+
+const HUMAN_SPECIES_SOURCE = { origin: 'species' as const, id: 'human' as const };
+
+const FEAT_CHOICE: PendingChoice & { type: 'feat-choice' } = {
+  type: 'feat-choice',
+  choiceKey: 'feat-choice:species:human:0' as ChoiceKey,
+  source: HUMAN_SPECIES_SOURCE,
+  from: ['alert', 'lucky', 'skilled'] as unknown as readonly import('@/lib/dnd-helpers').FeatId[],
+  category: 'origin',
+};
+
+describe('ChoicePicker feat-choice', () => {
+  it('renders one radio per feat option', () => {
+    render(<ChoicePicker choice={FEAT_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />);
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios).toHaveLength(3);
+  });
+
+  it('no radio is checked when currentDecision is undefined', () => {
+    render(<ChoicePicker choice={FEAT_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />);
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios.every((r) => !r.checked)).toBe(true);
+  });
+
+  it('clicking a feat radio calls onDecide with {type: feat-choice, featId}', () => {
+    const onDecide = vi.fn();
+    render(<ChoicePicker choice={FEAT_CHOICE} currentDecision={undefined} onDecide={onDecide} onClear={vi.fn()} />);
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    fireEvent.click(radios[0]);
+    expect(onDecide).toHaveBeenCalledWith(FEAT_CHOICE.choiceKey, {
+      type: 'feat-choice',
+      featId: 'alert',
+    });
+  });
+
+  it('selected radio reflects currentDecision.featId', () => {
+    const currentDecision: ChoiceDecision = {
+      type: 'feat-choice',
+      featId: 'lucky' as import('@/lib/dnd-helpers').FeatId,
+    };
+    render(
+      <ChoicePicker choice={FEAT_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios[0].checked).toBe(false); // alert
+    expect(radios[1].checked).toBe(true); // lucky
+    expect(radios[2].checked).toBe(false); // skilled
+  });
+
+  it('Clear button does NOT appear when no feat is selected', () => {
+    render(<ChoicePicker choice={FEAT_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />);
+    expect(screen.queryByRole('button', { name: /clear/i })).toBeNull();
+  });
+
+  it('Clear button appears when a feat is selected', () => {
+    const currentDecision: ChoiceDecision = {
+      type: 'feat-choice',
+      featId: 'alert' as import('@/lib/dnd-helpers').FeatId,
+    };
+    render(
+      <ChoicePicker choice={FEAT_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    expect(screen.getByRole('button', { name: /clear/i })).toBeTruthy();
+  });
+
+  it('clicking Clear calls onClear with the correct choiceKey', () => {
+    const onClear = vi.fn();
+    const currentDecision: ChoiceDecision = {
+      type: 'feat-choice',
+      featId: 'alert' as import('@/lib/dnd-helpers').FeatId,
+    };
+    render(
+      <ChoicePicker choice={FEAT_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={onClear} />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+    expect(onClear).toHaveBeenCalledWith(FEAT_CHOICE.choiceKey);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // ChoicePicker — feature-choice branch
 // ---------------------------------------------------------------------------
 

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -6,8 +6,10 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { DND_LANGUAGES, DND_SKILLS, type LanguageId, type SkillId, type ToolProficiencyId } from '@/lib/dnd-helpers';
+import type { FeatId } from '@/lib/dnd-helpers';
 import { getItemDef, getItemNameKey, WEAPON_CATALOG } from '@/lib/sources/items';
 import { getBundleDef, getBundleNameKey, getItemsForSlot, resolveBundleRef } from '@/lib/sources/bundles';
+import { FEAT_SOURCES } from '@/lib/sources';
 import type { ChoiceDecision, ChoiceKey } from '@/types/choices';
 import type { BundleSlot, ItemDef, SlotFilter } from '@/types/items';
 import type { PendingChoice } from '@/types/resolved';
@@ -223,6 +225,53 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear }: Cho
           })}
         </div>
         {currentLineageId !== undefined && (
+          <Button variant="ghost" size="sm" onClick={() => onClear(choice.choiceKey)}>
+            {tc('characterBuilder.equipment.clearSelection')}
+          </Button>
+        )}
+      </div>
+    );
+  }
+
+  if (choice.type === 'feat-choice') {
+    const { from, category } = choice;
+    const pool: readonly FeatId[] = from ?? FEAT_SOURCES.filter((f) => f.category === category).map((f) => f.id);
+    const currentFeatId = currentDecision?.type === 'feat-choice' ? currentDecision.featId : undefined;
+
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-muted-foreground">{tc('characterBuilder.pendingChoices.featChoice')}</p>
+        <div className="space-y-1">
+          {pool.map((featId) => {
+            const radioId = `choice-feat-${choice.choiceKey}-${featId}`;
+            const nameKey = `feats.${featId}.name` as `feats.${string}.name`;
+            const descKey = `feats.${featId}.description` as `feats.${string}.description`;
+            const label = t(nameKey, { defaultValue: featId });
+            const description = t(descKey, { defaultValue: '' });
+            return (
+              <div
+                key={featId}
+                className="flex items-start gap-3 px-2 py-1.5 rounded-md transition-colors hover:bg-muted/50"
+              >
+                <input
+                  type="radio"
+                  id={radioId}
+                  name={`choice-feat-${choice.choiceKey}`}
+                  checked={currentFeatId === featId}
+                  onChange={() => onDecide(choice.choiceKey, { type: 'feat-choice', featId })}
+                  className="mt-1 size-4 text-primary"
+                />
+                <Label htmlFor={radioId} className="flex-1 cursor-pointer">
+                  <span className="font-medium">{label}</span>
+                  {description ? (
+                    <span className="block text-xs text-muted-foreground mt-0.5">{description}</span>
+                  ) : null}
+                </Label>
+              </div>
+            );
+          })}
+        </div>
+        {currentFeatId !== undefined && (
           <Button variant="ghost" size="sm" onClick={() => onClear(choice.choiceKey)}>
             {tc('characterBuilder.equipment.clearSelection')}
           </Button>

--- a/src/components/character-builder/OriginStep.test.tsx
+++ b/src/components/character-builder/OriginStep.test.tsx
@@ -431,4 +431,85 @@ describe('OriginStep', () => {
 
     expect(screen.queryByText('originFeatTitle')).toBeNull();
   });
+
+  // ---------------------------------------------------------------------------
+  // Part 5: species-origin feat-choice picker (Human Versatile)
+  // ---------------------------------------------------------------------------
+
+  it('renders a feat-choice picker (radios) when a species-origin feat-choice is pending', () => {
+    mockResolved = {
+      ...makeDefaultResolved(),
+      pendingChoices: [
+        {
+          type: 'feat-choice' as const,
+          choiceKey: 'feat-choice:species:human:0' as ChoiceKey,
+          source: { origin: 'species', id: 'human' } as const,
+          from: null,
+          category: 'origin' as const,
+        },
+      ],
+    };
+    // Provide species bundles so FEAT_SOURCES are visible for rendering
+    mockBundles = [
+      {
+        source: { origin: 'species', id: 'human' as const },
+        grants: [
+          {
+            type: 'feat-choice' as const,
+            key: 'feat-choice:species:human:0' as ChoiceKey,
+            from: ['alert', 'lucky', 'skilled'] as unknown as readonly import('@/lib/dnd-helpers').FeatId[],
+            category: 'origin' as const,
+          },
+        ],
+      },
+    ] as readonly GrantBundle[];
+
+    render(<OriginStep />);
+
+    // ChoicePicker renders radio inputs for each feat (name = choice-feat-<key>)
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    const featRadios = radios.filter((r) => r.name?.startsWith('choice-feat-'));
+    expect(featRadios.length).toBeGreaterThan(0);
+  });
+
+  it('does not render a species-origin feat-choice picker when no such pending choice exists', () => {
+    mockResolved = {
+      ...makeDefaultResolved(),
+      pendingChoices: [],
+    };
+
+    render(<OriginStep />);
+
+    const radios = screen.queryAllByRole('radio') as HTMLInputElement[];
+    const featRadios = radios.filter((r) => r.name?.startsWith('choice-feat-'));
+    expect(featRadios).toHaveLength(0);
+  });
+
+  it('fires makeChoice with the correct choiceKey and feat-choice decision when a feat radio is changed', () => {
+    const featChoiceKey = createChoiceKey('feat-choice', 'species', 'human', 0);
+    mockResolved = {
+      ...makeDefaultResolved(),
+      pendingChoices: [
+        {
+          type: 'feat-choice' as const,
+          choiceKey: featChoiceKey,
+          source: { origin: 'species', id: 'human' } as const,
+          from: ['alert'] as unknown as readonly import('@/lib/dnd-helpers').FeatId[],
+          category: 'origin' as const,
+        },
+      ],
+    };
+
+    render(<OriginStep />);
+
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    const featRadio = radios.find((r) => r.name?.startsWith('choice-feat-'));
+    expect(featRadio).toBeDefined();
+    fireEvent.click(featRadio!);
+
+    expect(mockMakeChoice).toHaveBeenCalledWith(featChoiceKey, {
+      type: 'feat-choice',
+      featId: 'alert',
+    });
+  });
 });

--- a/src/components/character-builder/OriginStep.tsx
+++ b/src/components/character-builder/OriginStep.tsx
@@ -42,6 +42,14 @@ export function OriginStep() {
     );
   }, [resolved]);
 
+  // Pending species-origin feat-choices (e.g. Human Versatile origin feat picker).
+  const speciesFeatChoices = useMemo<readonly Extract<PendingChoice, { type: 'feat-choice' }>[]>(() => {
+    return (resolved?.pendingChoices ?? []).filter(
+      (c): c is Extract<PendingChoice, { type: 'feat-choice' }> =>
+        c.type === 'feat-choice' && c.source.origin === 'species'
+    );
+  }, [resolved]);
+
   // Synthesize tool-choice and language-choice PendingChoices from background grants
   const backgroundToolChoiceGrants = collectGrantsByType(bundles, 'proficiency-choice').filter(
     (tg) => tg.source.origin === 'background' && tg.grant.category === 'tool'
@@ -72,6 +80,22 @@ export function OriginStep() {
           makeChoice={context.makeChoice}
           clearChoice={context.clearChoice}
         />
+      )}
+
+      {/* Species-origin feat-choice picker (e.g. Human Versatile origin feat) */}
+      {speciesFeatChoices.length > 0 && (
+        <div className="space-y-4">
+          {speciesFeatChoices.map((choice) => (
+            <div key={choice.choiceKey}>
+              <ChoicePicker
+                choice={choice}
+                currentDecision={build?.choices[choice.choiceKey]}
+                onDecide={(choiceKey, decision) => context.makeChoice(choiceKey, decision)}
+                onClear={(choiceKey) => context.clearChoice(choiceKey)}
+              />
+            </div>
+          ))}
+        </div>
       )}
 
       {!background && (

--- a/src/lib/character-builder/has-later-choices.test.ts
+++ b/src/lib/character-builder/has-later-choices.test.ts
@@ -16,6 +16,11 @@ describe('has-later-choices', () => {
       expect(speciesHasLaterChoices('halfling')).toBe(false);
       expect(speciesHasLaterChoices('dwarf')).toBe(false);
     });
+
+    it('detects a pending feat-choice grant as a later choice (Human grants Versatile feat-choice)', () => {
+      // Human grants a feat-choice (Versatile) — must trigger the indicator
+      expect(speciesHasLaterChoices('human')).toBe(true);
+    });
   });
 
   describe('classHasLaterChoices', () => {

--- a/src/lib/character-builder/has-later-choices.ts
+++ b/src/lib/character-builder/has-later-choices.ts
@@ -10,6 +10,7 @@ const CHOICE_GRANT_TYPES = new Set<Grant['type']>([
   'weapon-mastery-choice',
   'bundle-choice',
   'lineage-choice',
+  'feat-choice',
 ]);
 
 // `proficiency-choice` categories that every option of a given kind already has

--- a/src/lib/resolver/combat.test.ts
+++ b/src/lib/resolver/combat.test.ts
@@ -71,6 +71,70 @@ describe('resolveHp', () => {
     // Level 2: 7 + (roll 4 + (-1)) = 7 + 3 = 10
     expect(resolveHp(bundles, [null, 4], -1, 2).max).toBe(10);
   });
+
+  it('applies hp-bonus perLevel × level (perLevel 2 at level 3 → +6)', () => {
+    const bundlesBase: GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'fighter', level: 1 },
+        grants: [{ type: 'hit-die', die: 10 }],
+      },
+    ];
+    const bundlesWithBonus: GrantBundle[] = [
+      ...bundlesBase,
+      {
+        source: { origin: 'feat', id: 'tough' },
+        grants: [{ type: 'hp-bonus', perLevel: 2 }],
+      },
+    ];
+    // L3 baseline (CON 0, avg rolls): 10 + 6 + 6 = 22
+    const baseline = resolveHp(bundlesBase, [null, null, null], 0, 3).max;
+    // L3 with perLevel:2 bonus: baseline + 2*3 = baseline + 6
+    const withBonus = resolveHp(bundlesWithBonus, [null, null, null], 0, 3).max;
+    expect(withBonus - baseline).toBe(6);
+  });
+
+  it('sums multiple hp-bonus grants (perLevel 1 + perLevel 2 at level 3 → +9)', () => {
+    const bundlesBase: GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'fighter', level: 1 },
+        grants: [{ type: 'hit-die', die: 10 }],
+      },
+    ];
+    const bundlesWithTwoBonus: GrantBundle[] = [
+      ...bundlesBase,
+      {
+        source: { origin: 'feat', id: 'tough' },
+        grants: [{ type: 'hp-bonus', perLevel: 2 }],
+      },
+      {
+        source: { origin: 'species', id: 'dwarf' },
+        grants: [{ type: 'hp-bonus', perLevel: 1 }],
+      },
+    ];
+    const baseline = resolveHp(bundlesBase, [null, null, null], 0, 3).max;
+    const withTwoBonus = resolveHp(bundlesWithTwoBonus, [null, null, null], 0, 3).max;
+    // (perLevel:2 × 3) + (perLevel:1 × 3) = 6 + 3 = 9
+    expect(withTwoBonus - baseline).toBe(9);
+  });
+
+  it('Dwarven Toughness adds +1 per level (level 3 → +3)', () => {
+    const bundlesBase: GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'fighter', level: 1 },
+        grants: [{ type: 'hit-die', die: 10 }],
+      },
+    ];
+    const bundlesWithDwarvenToughness: GrantBundle[] = [
+      ...bundlesBase,
+      {
+        source: { origin: 'species', id: 'dwarf' },
+        grants: [{ type: 'hp-bonus', perLevel: 1 }],
+      },
+    ];
+    const baseline = resolveHp(bundlesBase, [null, null, null], 0, 3).max;
+    const withToughness = resolveHp(bundlesWithDwarvenToughness, [null, null, null], 0, 3).max;
+    expect(withToughness - baseline).toBe(3);
+  });
 });
 
 describe('resolveSpeed', () => {

--- a/src/lib/resolver/combat.ts
+++ b/src/lib/resolver/combat.ts
@@ -30,6 +30,12 @@ export function resolveHp(
     max += value + conModifier;
   }
 
+  // Apply flat per-level HP bonuses (e.g. Tough feat grants +2 per level)
+  const hpBonusGrants = collectGrantsByType(bundles, 'hp-bonus');
+  for (const { grant } of hpBonusGrants) {
+    max += grant.perLevel * level;
+  }
+
   return { max };
 }
 

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -130,6 +130,8 @@ describe('Human Fighter L1 integration', () => {
       'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
       // Soldier language choice
       'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      // Human Versatile origin feat choice (2024 PHB)
+      'feat-choice:species:human:0': { type: 'feat-choice', featId: 'alert' },
       // Fighter bundle choices
       'bundle-choice:class:fighter:0': { type: 'bundle-choice', bundleId: 'fighter-chainmail', slotPicks: {} },
       'bundle-choice:class:fighter:1': {
@@ -217,14 +219,15 @@ describe('Human Fighter L1 integration', () => {
     expect(result.savingThrows.str.bonus).toBe(5);
   });
 
-  it('has 4 features: Resourceful (human), chosen fighting style, Second Wind, and savage-attacker feat (soldier background)', () => {
+  it('has 5 features: Resourceful (human), chosen fighting style, Second Wind, savage-attacker feat (soldier background), and alert feat (human Versatile choice)', () => {
     const result = resolveCharacter(input);
-    expect(result.features).toHaveLength(4);
+    expect(result.features).toHaveLength(5);
     const featureIds = result.features.map((f) => f.feature.id);
     expect(featureIds).toContain('human-resourceful');
     expect(featureIds).toContain('fighting-style-defense');
     expect(featureIds).toContain('fighter-second-wind');
     expect(featureIds).toContain('feat-savage-attacker');
+    expect(featureIds).toContain('feat-alert');
   });
 
   it('armor proficiencies include light, medium, heavy, shields', () => {
@@ -573,6 +576,8 @@ describe('Human Fighter L5 integration', () => {
       'asi:background:soldier:0': { type: 'asi', allocation: { str: 2, con: 1 } },
       'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
       'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+      // Human Versatile origin feat choice (2024 PHB)
+      'feat-choice:species:human:0': { type: 'feat-choice', featId: 'alert' },
       [subclassKey]: { type: 'subclass' as const, subclassId: 'champion' as SubclassId },
       [asiKey]: { type: 'asi' as const, allocation: { str: 2 } },
       // Fighter bundle choices

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -308,6 +308,20 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
     }
   }
 
+  // Unresolved feat-choice grants
+  for (const { grant, source } of collectGrantsByType(bundles, 'feat-choice')) {
+    const decision = choices[grant.key];
+    if (!decision || decision.type !== 'feat-choice') {
+      pendingChoices.push({
+        type: 'feat-choice',
+        choiceKey: grant.key,
+        source,
+        from: grant.from,
+        category: grant.category,
+      });
+    }
+  }
+
   // Unresolved subclass grants
   for (const { grant, source } of collectGrantsByType(bundles, 'subclass')) {
     const decision = choices[grant.key];

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -20,6 +20,7 @@ import { resolveSpellcasting } from '@/lib/resolver/spellcasting';
 import { resolveEquipment, resolveAttacks, resolveEquippedArmorAc } from '@/lib/resolver/equipment';
 import { resolveResourcePools } from '@/lib/resolver/resource-pools';
 import { getItemDef, WEAPON_CATALOG } from '@/lib/sources/items';
+import { getFeatSource } from '@/lib/sources';
 
 export interface PersistedItem {
   readonly itemId: string;
@@ -308,10 +309,11 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
     }
   }
 
-  // Unresolved feat-choice grants
+  // Unresolved feat-choice grants (or decided with an unresolvable featId — invalid/corrupted decision)
   for (const { grant, source } of collectGrantsByType(bundles, 'feat-choice')) {
     const decision = choices[grant.key];
-    if (!decision || decision.type !== 'feat-choice') {
+    const resolvedFeat = decision?.type === 'feat-choice' ? getFeatSource(decision.featId) : undefined;
+    if (!decision || decision.type !== 'feat-choice' || !resolvedFeat) {
       pendingChoices.push({
         type: 'feat-choice',
         choiceKey: grant.key,

--- a/src/lib/schemas/character-build.test.ts
+++ b/src/lib/schemas/character-build.test.ts
@@ -242,6 +242,26 @@ describe('ChoiceDecisionSchema', () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe('feat-choice', () => {
+    it('accepts a feat-choice decision with a known feat ID and round-trips correctly', () => {
+      const result = ChoiceDecisionSchema.safeParse({ type: 'feat-choice', featId: 'tough' });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ type: 'feat-choice', featId: 'tough' });
+      }
+    });
+
+    it('rejects feat-choice with an unknown feat ID', () => {
+      const result = ChoiceDecisionSchema.safeParse({ type: 'feat-choice', featId: 'nonexistent-feat' });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects feat-choice missing featId', () => {
+      const result = ChoiceDecisionSchema.safeParse({ type: 'feat-choice' });
+      expect(result.success).toBe(false);
+    });
+  });
 });
 
 describe('CharacterBuildSchemaStrict', () => {

--- a/src/lib/schemas/character-build.ts
+++ b/src/lib/schemas/character-build.ts
@@ -7,6 +7,7 @@ import {
   type SkillId,
   type ToolProficiencyId,
 } from '@/lib/dnd-helpers';
+import type { ChoiceDecision } from '@/types/choices';
 
 const SKILL_IDS = DND_SKILLS.map((s) => s.id) as [SkillId, ...SkillId[]];
 const TOOL_IDS = DND_TOOL_PROFICIENCIES as unknown as [ToolProficiencyId, ...ToolProficiencyId[]];
@@ -53,7 +54,19 @@ export const ChoiceDecisionSchema = z.discriminatedUnion('type', [
   }),
   z.object({ type: z.literal('lineage-choice'), lineageId: z.string().min(1) }),
   z.object({ type: z.literal('feature-choice'), optionId: z.string().min(1) }),
+  z.object({ type: z.literal('feat-choice'), featId: z.string().refine(isFeatId, { message: 'Unknown feat ID' }) }),
 ]);
+
+// Compile-time parity: every ChoiceDecision discriminant must have a schema arm.
+// If a new ChoiceDecision variant is added to @/types/choices without a matching arm here,
+// this assignment will fail to typecheck.
+type _AssertChoiceDecisionParity = [z.infer<typeof ChoiceDecisionSchema>['type']] extends [ChoiceDecision['type']]
+  ? [ChoiceDecision['type']] extends [z.infer<typeof ChoiceDecisionSchema>['type']]
+    ? true
+    : never
+  : never;
+const _choiceDecisionParity: _AssertChoiceDecisionParity = true;
+void _choiceDecisionParity;
 
 export const CharacterBuildSchema = z.object({
   speciesId: z.string().min(1),

--- a/src/lib/sources/backgrounds.ts
+++ b/src/lib/sources/backgrounds.ts
@@ -1,37 +1,6 @@
 import type { BackgroundSource } from '@/types/sources';
 import { createChoiceKey } from '@/types/choices';
-
-const ARTISAN_TOOLS = [
-  'smithstools',
-  'brewersupplies',
-  'masonstools',
-  'calligrapherstools',
-  'carpentertools',
-  'cartographerstools',
-  'cobblerstools',
-  'cooksutensils',
-  'glassblowerstools',
-  'jewelerstools',
-  'leatherworkerstools',
-  'painterstools',
-  'potterstools',
-  'tinkerstools',
-  'weaverstools',
-  'woodcarverstools',
-] as const;
-
-const MUSICAL_INSTRUMENTS = [
-  'bagpipes',
-  'drum',
-  'dulcimer',
-  'flute',
-  'lute',
-  'lyre',
-  'horn',
-  'panflute',
-  'shawm',
-  'viol',
-] as const;
+import { ARTISAN_TOOL_IDS, MUSICAL_INSTRUMENT_IDS } from '@/lib/sources/tool-groups';
 
 const GAMING_SETS = [
   'gaming-set-dice',
@@ -79,7 +48,7 @@ export const BACKGROUND_SOURCES: readonly BackgroundSource[] = [
         category: 'tool',
         key: createChoiceKey('tool-choice', 'background', 'artisan', 0),
         count: 1,
-        from: ARTISAN_TOOLS,
+        from: ARTISAN_TOOL_IDS,
       },
       {
         type: 'proficiency-choice',
@@ -151,7 +120,7 @@ export const BACKGROUND_SOURCES: readonly BackgroundSource[] = [
         category: 'tool',
         key: createChoiceKey('tool-choice', 'background', 'entertainer', 0),
         count: 1,
-        from: MUSICAL_INSTRUMENTS,
+        from: MUSICAL_INSTRUMENT_IDS,
       },
       {
         type: 'proficiency-choice',

--- a/src/lib/sources/feats.test.ts
+++ b/src/lib/sources/feats.test.ts
@@ -78,6 +78,68 @@ describe('FEAT_SOURCES', () => {
     expect(FEAT_SOURCES).toHaveLength(74);
   });
 
+  describe('mechanized origin feats', () => {
+    it('skilled grants a skill proficiency-choice (not feature) with count 3 and from null', () => {
+      const skilled = FEAT_SOURCES.find((f) => f.id === 'skilled');
+      expect(skilled).toBeDefined();
+      const skillChoice = skilled?.grants.find((g) => g.type === 'proficiency-choice' && g.category === 'skill');
+      expect(skillChoice).toBeDefined();
+      if (skillChoice?.type === 'proficiency-choice' && skillChoice.category === 'skill') {
+        expect(skillChoice.count).toBe(3);
+        expect(skillChoice.from).toBeNull();
+      }
+      // Skilled no longer has a feature grant — only the proficiency-choice
+      const featureGrant = skilled?.grants.find((g) => g.type === 'feature');
+      expect(featureGrant).toBeUndefined();
+    });
+
+    it('tough grants both a feature and an hp-bonus of perLevel 2', () => {
+      const tough = FEAT_SOURCES.find((f) => f.id === 'tough');
+      expect(tough).toBeDefined();
+      const feature = tough?.grants.find((g) => g.type === 'feature');
+      expect(feature).toBeDefined();
+      const hpBonus = tough?.grants.find((g) => g.type === 'hp-bonus');
+      expect(hpBonus).toBeDefined();
+      if (hpBonus?.type === 'hp-bonus') {
+        expect(hpBonus.perLevel).toBe(2);
+      }
+    });
+
+    it('crafter grants a feature and a tool proficiency-choice with count 3 and 16 artisan tool IDs', () => {
+      const crafter = FEAT_SOURCES.find((f) => f.id === 'crafter');
+      expect(crafter).toBeDefined();
+      const feature = crafter?.grants.find((g) => g.type === 'feature');
+      expect(feature).toBeDefined();
+      const toolChoice = crafter?.grants.find((g) => g.type === 'proficiency-choice' && g.category === 'tool');
+      expect(toolChoice).toBeDefined();
+      if (toolChoice?.type === 'proficiency-choice' && toolChoice.category === 'tool') {
+        expect(toolChoice.count).toBe(3);
+        expect(toolChoice.from).toHaveLength(16);
+        // Spot-check some artisan tools and ensure herbalismkit is not included
+        expect(toolChoice.from).toContain('smithstools');
+        expect(toolChoice.from).toContain('woodcarverstools');
+        expect(toolChoice.from).not.toContain('herbalismkit');
+        expect(toolChoice.from).not.toContain('bagpipes');
+      }
+    });
+
+    it('musician grants a feature and a tool proficiency-choice with count 3 and 10 musical instrument IDs', () => {
+      const musician = FEAT_SOURCES.find((f) => f.id === 'musician');
+      expect(musician).toBeDefined();
+      const feature = musician?.grants.find((g) => g.type === 'feature');
+      expect(feature).toBeDefined();
+      const toolChoice = musician?.grants.find((g) => g.type === 'proficiency-choice' && g.category === 'tool');
+      expect(toolChoice).toBeDefined();
+      if (toolChoice?.type === 'proficiency-choice' && toolChoice.category === 'tool') {
+        expect(toolChoice.count).toBe(3);
+        expect(toolChoice.from).toHaveLength(10);
+        expect(toolChoice.from).toContain('lute');
+        expect(toolChoice.from).toContain('viol');
+        expect(toolChoice.from).not.toContain('smithstools');
+      }
+    });
+  });
+
   it('all fightingStyle feats have no prerequisites', () => {
     const feats = FEAT_SOURCES.filter((f) => f.category === 'fightingStyle');
     expect(feats.length).toBeGreaterThan(0);

--- a/src/lib/sources/feats.ts
+++ b/src/lib/sources/feats.ts
@@ -1,5 +1,38 @@
 import { createChoiceKey } from '@/types/choices';
 import type { FeatSource } from '@/types/sources';
+import type { ToolProficiencyId } from '@/lib/dnd-helpers';
+
+const ARTISAN_TOOL_IDS: readonly ToolProficiencyId[] = [
+  'smithstools',
+  'brewersupplies',
+  'masonstools',
+  'calligrapherstools',
+  'carpentertools',
+  'cartographerstools',
+  'cobblerstools',
+  'cooksutensils',
+  'glassblowerstools',
+  'jewelerstools',
+  'leatherworkerstools',
+  'painterstools',
+  'potterstools',
+  'tinkerstools',
+  'weaverstools',
+  'woodcarverstools',
+] as const;
+
+const MUSICAL_INSTRUMENT_IDS: readonly ToolProficiencyId[] = [
+  'bagpipes',
+  'drum',
+  'dulcimer',
+  'flute',
+  'lute',
+  'lyre',
+  'horn',
+  'panflute',
+  'shawm',
+  'viol',
+] as const;
 
 export const FEAT_SOURCES: readonly FeatSource[] = [
   // Origin feats — no level prerequisite, granted by backgrounds
@@ -7,24 +40,36 @@ export const FEAT_SOURCES: readonly FeatSource[] = [
     id: 'alert',
     category: 'origin',
     prerequisites: [],
+    // TODO(#162-followup): needs initiative-bonus grant type — deferred
     grants: [{ type: 'feature', feature: { id: 'feat-alert' } }],
   },
   {
     id: 'crafter',
     category: 'origin',
     prerequisites: [],
-    grants: [{ type: 'feature', feature: { id: 'feat-crafter' } }],
+    grants: [
+      { type: 'feature', feature: { id: 'feat-crafter' } },
+      {
+        type: 'proficiency-choice',
+        category: 'tool',
+        key: createChoiceKey('tool-choice', 'feat', 'crafter', 0),
+        count: 3,
+        from: ARTISAN_TOOL_IDS,
+      },
+    ],
   },
   {
     id: 'healer',
     category: 'origin',
     prerequisites: [],
+    // TODO(#162-followup): needs healerskit ToolProficiencyId + bonus-action heal grant type — deferred
     grants: [{ type: 'feature', feature: { id: 'feat-healer' } }],
   },
   {
     id: 'lucky',
     category: 'origin',
     prerequisites: [],
+    // TODO(#162-followup): needs resource-pool with max=proficiency-bonus mode — deferred
     grants: [{ type: 'feature', feature: { id: 'feat-lucky' } }],
   },
   {
@@ -40,31 +85,37 @@ export const FEAT_SOURCES: readonly FeatSource[] = [
           {
             optionId: 'bard',
             featureId: 'feat-magic-initiate-bard',
+            // TODO(#82): spell grants deferred — spell catalog not yet built
             grants: [],
           },
           {
             optionId: 'cleric',
             featureId: 'feat-magic-initiate-cleric',
+            // TODO(#82): spell grants deferred — spell catalog not yet built
             grants: [],
           },
           {
             optionId: 'druid',
             featureId: 'feat-magic-initiate-druid',
+            // TODO(#82): spell grants deferred — spell catalog not yet built
             grants: [],
           },
           {
             optionId: 'sorcerer',
             featureId: 'feat-magic-initiate-sorcerer',
+            // TODO(#82): spell grants deferred — spell catalog not yet built
             grants: [],
           },
           {
             optionId: 'warlock',
             featureId: 'feat-magic-initiate-warlock',
+            // TODO(#82): spell grants deferred — spell catalog not yet built
             grants: [],
           },
           {
             optionId: 'wizard',
             featureId: 'feat-magic-initiate-wizard',
+            // TODO(#82): spell grants deferred — spell catalog not yet built
             grants: [],
           },
         ],
@@ -75,31 +126,53 @@ export const FEAT_SOURCES: readonly FeatSource[] = [
     id: 'musician',
     category: 'origin',
     prerequisites: [],
-    grants: [{ type: 'feature', feature: { id: 'feat-musician' } }],
+    grants: [
+      { type: 'feature', feature: { id: 'feat-musician' } },
+      {
+        type: 'proficiency-choice',
+        category: 'tool',
+        key: createChoiceKey('tool-choice', 'feat', 'musician', 0),
+        count: 3,
+        from: MUSICAL_INSTRUMENT_IDS,
+      },
+    ],
   },
   {
     id: 'savage-attacker',
     category: 'origin',
     prerequisites: [],
+    // TODO(#162-followup): needs damage-reroll grant type — deferred
     grants: [{ type: 'feature', feature: { id: 'feat-savage-attacker' } }],
   },
   {
     id: 'skilled',
     category: 'origin',
     prerequisites: [],
-    grants: [{ type: 'feature', feature: { id: 'feat-skilled' } }],
+    grants: [
+      {
+        type: 'proficiency-choice',
+        category: 'skill',
+        key: createChoiceKey('skill-choice', 'feat', 'skilled', 0),
+        count: 3,
+        from: null,
+      },
+    ],
   },
   {
     id: 'tavern-brawler',
     category: 'origin',
     prerequisites: [],
+    // TODO(#162-followup): needs unarmed-die upgrade + grapple grant types — deferred
     grants: [{ type: 'feature', feature: { id: 'feat-tavern-brawler' } }],
   },
   {
     id: 'tough',
     category: 'origin',
     prerequisites: [],
-    grants: [{ type: 'feature', feature: { id: 'feat-tough' } }],
+    grants: [
+      { type: 'feature', feature: { id: 'feat-tough' } },
+      { type: 'hp-bonus', perLevel: 2 },
+    ],
   },
 
   // Fighting Style feats — grants must be kept manually in sync with FIGHTING_STYLE_SOURCES

--- a/src/lib/sources/feats.ts
+++ b/src/lib/sources/feats.ts
@@ -1,38 +1,6 @@
 import { createChoiceKey } from '@/types/choices';
 import type { FeatSource } from '@/types/sources';
-import type { ToolProficiencyId } from '@/lib/dnd-helpers';
-
-const ARTISAN_TOOL_IDS: readonly ToolProficiencyId[] = [
-  'smithstools',
-  'brewersupplies',
-  'masonstools',
-  'calligrapherstools',
-  'carpentertools',
-  'cartographerstools',
-  'cobblerstools',
-  'cooksutensils',
-  'glassblowerstools',
-  'jewelerstools',
-  'leatherworkerstools',
-  'painterstools',
-  'potterstools',
-  'tinkerstools',
-  'weaverstools',
-  'woodcarverstools',
-] as const;
-
-const MUSICAL_INSTRUMENT_IDS: readonly ToolProficiencyId[] = [
-  'bagpipes',
-  'drum',
-  'dulcimer',
-  'flute',
-  'lute',
-  'lyre',
-  'horn',
-  'panflute',
-  'shawm',
-  'viol',
-] as const;
+import { ARTISAN_TOOL_IDS, MUSICAL_INSTRUMENT_IDS } from '@/lib/sources/tool-groups';
 
 export const FEAT_SOURCES: readonly FeatSource[] = [
   // Origin feats — no level prerequisite, granted by backgrounds

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -655,6 +655,136 @@ describe('feat-origin feature-choice pipeline (build.feats: magic-initiate)', ()
 });
 
 // ---------------------------------------------------------------------------
+// Human feat-choice (Versatile) pipeline
+// ---------------------------------------------------------------------------
+
+describe('Human feat-choice (Versatile) pipeline', () => {
+  const featChoiceKey = createChoiceKey('feat-choice', 'species', 'human', 0);
+
+  const humanBaseL1: CharacterBuild = {
+    speciesId: 'human' as SpeciesId,
+    backgroundId: null,
+    baseAbilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 },
+    abilityMethod: 'standard-array',
+    levels: [{ classId: 'fighter' as ClassId, classLevel: 1, hpRoll: null }],
+    choices: {},
+    feats: [],
+    activeItems: [],
+  };
+
+  it('(a) Human with no decision emits a feat-choice pending (category origin, source.origin species)', () => {
+    const { bundles, expandedFeats } = collectBundles(humanBaseL1);
+    const result = resolveCharacter({
+      baseAbilities: humanBaseL1.baseAbilities,
+      level: 1,
+      bundles,
+      choices: humanBaseL1.choices,
+      levels: humanBaseL1.levels,
+      expandedFeats,
+    });
+    const pending = result.pendingChoices.filter((c) => c.type === 'feat-choice' && c.source.origin === 'species');
+    expect(pending).toHaveLength(1);
+    expect(pending[0].type).toBe('feat-choice');
+    if (pending[0].type === 'feat-choice') {
+      expect(pending[0].category).toBe('origin');
+      expect(pending[0].source.origin).toBe('species');
+    }
+  });
+
+  it('(b) Human + Skilled decided: no feat-choice pending; a skill-choice pending with source.origin feat is emitted (count 3)', () => {
+    const buildWithSkilled: CharacterBuild = {
+      ...humanBaseL1,
+      choices: {
+        [featChoiceKey]: { type: 'feat-choice' as const, featId: 'skilled' as FeatId },
+      },
+    };
+    const { bundles, expandedFeats } = collectBundles(buildWithSkilled);
+    const result = resolveCharacter({
+      baseAbilities: buildWithSkilled.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithSkilled.choices,
+      levels: buildWithSkilled.levels,
+      expandedFeats,
+    });
+    // No pending feat-choice
+    expect(result.pendingChoices.filter((c) => c.type === 'feat-choice')).toHaveLength(0);
+    // A skill-choice pending with source.origin feat is emitted
+    const skillPending = result.pendingChoices.filter((c) => c.type === 'skill-choice' && c.source.origin === 'feat');
+    expect(skillPending).toHaveLength(1);
+    if (skillPending[0].type === 'skill-choice') {
+      expect(skillPending[0].count).toBe(3);
+    }
+  });
+
+  it('(c) Human + Tough decided: resolved hitPoints.max includes +2 per level', () => {
+    const buildWithTough: CharacterBuild = {
+      ...humanBaseL1,
+      choices: {
+        [featChoiceKey]: { type: 'feat-choice' as const, featId: 'tough' as FeatId },
+      },
+    };
+    const { bundles, expandedFeats } = collectBundles(buildWithTough);
+    const result = resolveCharacter({
+      baseAbilities: buildWithTough.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithTough.choices,
+      levels: buildWithTough.levels,
+      expandedFeats,
+    });
+    // CON is 10 → modifier 0, Fighter hit die 10, L1 HP = 10 + 0 con + 2 tough = 12
+    // Without Tough: 10 + 0 = 10
+    expect(result.hitPoints.max).toBe(12);
+  });
+
+  it('(d) Human + Crafter decided: a tool-choice pending with source.origin feat is emitted', () => {
+    const buildWithCrafter: CharacterBuild = {
+      ...humanBaseL1,
+      choices: {
+        [featChoiceKey]: { type: 'feat-choice' as const, featId: 'crafter' as FeatId },
+      },
+    };
+    const { bundles, expandedFeats } = collectBundles(buildWithCrafter);
+    const result = resolveCharacter({
+      baseAbilities: buildWithCrafter.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithCrafter.choices,
+      levels: buildWithCrafter.levels,
+      expandedFeats,
+    });
+    const toolPending = result.pendingChoices.filter((c) => c.type === 'tool-choice' && c.source.origin === 'feat');
+    expect(toolPending).toHaveLength(1);
+    if (toolPending[0].type === 'tool-choice') {
+      expect(toolPending[0].count).toBe(3);
+    }
+  });
+
+  it('(e) Human + Magic Initiate decided: a feature-choice pending with source.origin feat is emitted', () => {
+    const buildWithMagicInitiate: CharacterBuild = {
+      ...humanBaseL1,
+      choices: {
+        [featChoiceKey]: { type: 'feat-choice' as const, featId: 'magic-initiate' as FeatId },
+      },
+    };
+    const { bundles, expandedFeats } = collectBundles(buildWithMagicInitiate);
+    const result = resolveCharacter({
+      baseAbilities: buildWithMagicInitiate.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithMagicInitiate.choices,
+      levels: buildWithMagicInitiate.levels,
+      expandedFeats,
+    });
+    const featureChoicePending = result.pendingChoices.filter(
+      (c) => c.type === 'feature-choice' && c.source.origin === 'feat'
+    );
+    expect(featureChoicePending).toHaveLength(1);
+  });
+});
+
+// ---------------------------------------------------------------------------
 // Single-pass safety invariant
 // ---------------------------------------------------------------------------
 // collectBundles expands feature-choice options in a single pass (not a fixpoint).

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -738,6 +738,29 @@ describe('Human feat-choice (Versatile) pipeline', () => {
     expect(result.hitPoints.max).toBe(12);
   });
 
+  it('(c2) HP dedupe regression: Human + Farmer background (grants tough) + Versatile=tough → hp-bonus applied once, not twice', () => {
+    // Farmer background expands tough via the embedded-feat pass.
+    // Versatile feat-choice also picks tough — should be skipped (already expanded).
+    // CON 10 → mod 0, Fighter d10 L1 → base 10 + 2 tough = 12 (not 14).
+    const buildWithFarmerAndTough: CharacterBuild = {
+      ...humanBaseL1,
+      backgroundId: 'farmer' as BackgroundId,
+      choices: {
+        [featChoiceKey]: { type: 'feat-choice' as const, featId: 'tough' as FeatId },
+      },
+    };
+    const { bundles, expandedFeats } = collectBundles(buildWithFarmerAndTough);
+    const result = resolveCharacter({
+      baseAbilities: buildWithFarmerAndTough.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithFarmerAndTough.choices,
+      levels: buildWithFarmerAndTough.levels,
+      expandedFeats,
+    });
+    expect(result.hitPoints.max).toBe(12);
+  });
+
   it('(d) Human + Crafter decided: a tool-choice pending with source.origin feat is emitted', () => {
     const buildWithCrafter: CharacterBuild = {
       ...humanBaseL1,
@@ -781,6 +804,94 @@ describe('Human feat-choice (Versatile) pipeline', () => {
       (c) => c.type === 'feature-choice' && c.source.origin === 'feat'
     );
     expect(featureChoicePending).toHaveLength(1);
+  });
+
+  it('(f) feat-choice→skill END-TO-END: Human + Versatile=skilled + 3 skills decided → skill proficiencies with source.origin feat', () => {
+    const skillChoiceKey = createChoiceKey('skill-choice', 'feat', 'skilled', 0);
+    const buildWithSkilledDecided: CharacterBuild = {
+      ...humanBaseL1,
+      choices: {
+        [featChoiceKey]: { type: 'feat-choice' as const, featId: 'skilled' as FeatId },
+        [skillChoiceKey]: { type: 'skill-choice' as const, skills: ['arcana', 'history', 'nature'] as const },
+      },
+    };
+    const { bundles, expandedFeats } = collectBundles(buildWithSkilledDecided);
+    const result = resolveCharacter({
+      baseAbilities: buildWithSkilledDecided.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithSkilledDecided.choices,
+      levels: buildWithSkilledDecided.levels,
+      expandedFeats,
+    });
+    // All 3 picked skills must be proficient with at least one source from feat origin
+    for (const skillId of ['arcana', 'history', 'nature'] as const) {
+      const skill = result.skills[skillId];
+      expect(skill.proficient, `${skillId} should be proficient`).toBe(true);
+      expect(
+        skill.sources.some((s) => s.origin === 'feat'),
+        `${skillId} source should include feat origin`
+      ).toBe(true);
+    }
+    // No pending feat-choice or skill-choice from feat
+    expect(result.pendingChoices.filter((c) => c.type === 'feat-choice')).toHaveLength(0);
+    expect(result.pendingChoices.filter((c) => c.type === 'skill-choice' && c.source.origin === 'feat')).toHaveLength(
+      0
+    );
+  });
+
+  it('(g) Magic Initiate finalize-ready: Human + Versatile=magic-initiate + class decision cleric → no feature-choice or feat-choice pending', () => {
+    const magicInitiateFeatureChoiceKey = createChoiceKey('feature-choice', 'feat', 'magic-initiate', 0);
+    const buildWithMagicInitiateDecided: CharacterBuild = {
+      ...humanBaseL1,
+      choices: {
+        [featChoiceKey]: { type: 'feat-choice' as const, featId: 'magic-initiate' as FeatId },
+        [magicInitiateFeatureChoiceKey]: { type: 'feature-choice' as const, optionId: 'cleric' },
+      },
+    };
+    const { bundles, expandedFeats } = collectBundles(buildWithMagicInitiateDecided);
+    const result = resolveCharacter({
+      baseAbilities: buildWithMagicInitiateDecided.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithMagicInitiateDecided.choices,
+      levels: buildWithMagicInitiateDecided.levels,
+      expandedFeats,
+    });
+    const remainingFeatOrFeatureChoices = result.pendingChoices.filter(
+      (c) => c.type === 'feat-choice' || c.type === 'feature-choice'
+    );
+    expect(
+      remainingFeatOrFeatureChoices,
+      'build with magic-initiate fully decided should have no pending feat-choice or feature-choice'
+    ).toHaveLength(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// feat-choice invalid decision (Fix 6)
+// ---------------------------------------------------------------------------
+
+describe('feat-choice decision with unknown featId', () => {
+  it('collectBundles emits a warning and does not throw when decision.featId is unresolvable', () => {
+    const featChoiceKey = createChoiceKey('feat-choice', 'species', 'human', 0);
+    const buildWithBadFeat: CharacterBuild = {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: null,
+      baseAbilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 10 },
+      abilityMethod: 'standard-array',
+      levels: [{ classId: 'fighter' as ClassId, classLevel: 1, hpRoll: null }],
+      choices: {
+        [featChoiceKey]: { type: 'feat-choice' as const, featId: 'nonexistent-feat' as FeatId },
+      },
+      feats: [],
+      activeItems: [],
+    };
+    let result: ReturnType<typeof collectBundles>;
+    expect(() => {
+      result = collectBundles(buildWithBadFeat);
+    }).not.toThrow();
+    expect(result!.warnings.some((w) => w.includes('nonexistent-feat'))).toBe(true);
   });
 });
 

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -19,6 +19,7 @@ import type {
   LineageChoiceGrant,
   DamageTypeChoiceGrant,
   FeatureChoiceGrant,
+  FeatChoiceGrant,
 } from '@/types/grants';
 import type { CharacterBuild } from '@/types/choices';
 import { SPECIES_SOURCES, LINEAGE_GRANTS_REGISTRY } from '@/lib/sources/species';
@@ -283,6 +284,34 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
       const msg = `No source data found for feat "${featId}" — feat grants will be empty`;
       warnings.push(msg);
       logger.warn(msg);
+    }
+  }
+
+  // Feat-choice expansion — runs AFTER build.feats so that a chosen feat's own sub-grants
+  // (feature-choice, proficiency-choice, etc.) are visible to the feature-choice pass below.
+  // Snapshot bundles at the start of the pass to avoid iterating bundles added in this pass.
+  const allFeatChoiceGrants: { grant: FeatChoiceGrant; source: SourceTag }[] = [];
+  for (const bundle of bundles) {
+    for (const grant of bundle.grants) {
+      if (grant.type === 'feat-choice') {
+        allFeatChoiceGrants.push({ grant: grant as FeatChoiceGrant, source: bundle.source });
+      }
+    }
+  }
+
+  for (const { grant } of allFeatChoiceGrants) {
+    const decision = build.choices[grant.key];
+    if (decision?.type === 'feat-choice') {
+      const featSource = getFeatSource(decision.featId);
+      if (featSource) {
+        const tag: SourceTag = { origin: 'feat', id: decision.featId };
+        bundles.push({ source: tag, grants: featSource.grants });
+        expandedFeats.add(decision.featId);
+      } else {
+        const msg = `No source data found for feat-choice decision "${decision.featId}" — feat grants will be empty`;
+        warnings.push(msg);
+        logger.warn(msg);
+      }
     }
   }
 

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -276,10 +276,12 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
 
   // Feats explicitly listed in the build (manually chosen at level-up)
   for (const featId of build.feats) {
+    if (expandedFeats.has(featId)) continue; // already expanded by background or a prior pass
     const featSource = getFeatSource(featId);
     if (featSource) {
       const tag: SourceTag = { origin: 'feat', id: featId };
       bundles.push({ source: tag, grants: featSource.grants });
+      expandedFeats.add(featId);
     } else {
       const msg = `No source data found for feat "${featId}" — feat grants will be empty`;
       warnings.push(msg);
@@ -302,6 +304,7 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
   for (const { grant } of allFeatChoiceGrants) {
     const decision = build.choices[grant.key];
     if (decision?.type === 'feat-choice') {
+      if (expandedFeats.has(decision.featId)) continue; // already expanded by background or build.feats pass
       const featSource = getFeatSource(decision.featId);
       if (featSource) {
         const tag: SourceTag = { origin: 'feat', id: decision.featId };

--- a/src/lib/sources/species.ts
+++ b/src/lib/sources/species.ts
@@ -129,7 +129,8 @@ export const LINEAGE_GRANTS_REGISTRY = {
 } as const satisfies Partial<Record<SpeciesId, Readonly<Partial<Record<string, readonly Grant[]>>>>>;
 
 export const SPECIES_SOURCES: readonly SpeciesSource[] = [
-  // Human (2024 PHB) — no ASIs; gains Heroic Inspiration (Resourceful), skill + language choice
+  // Human (2024 PHB) — no ASIs; gains Heroic Inspiration (Resourceful), skill + language choice,
+  // plus one origin feat of choice (Versatile feature).
   {
     id: 'human',
     defaultSize: 'medium',
@@ -152,6 +153,12 @@ export const SPECIES_SOURCES: readonly SpeciesSource[] = [
         from: null,
       },
       { type: 'feature', feature: { id: 'human-resourceful' } },
+      {
+        type: 'feat-choice',
+        key: createChoiceKey('feat-choice', 'species', 'human', 0),
+        from: null,
+        category: 'origin',
+      },
     ],
   },
   // Dwarf (2024 PHB) — 30 ft speed, 120 ft darkvision, Dwarven Toughness (+1 HP/level)

--- a/src/lib/sources/tool-groups.ts
+++ b/src/lib/sources/tool-groups.ts
@@ -1,0 +1,40 @@
+import type { ToolProficiencyId } from '@/lib/dnd-helpers';
+
+/**
+ * Shared artisan tool ID list used by both backgrounds.ts and feats.ts.
+ * Declared once here to avoid divergence between the two files.
+ */
+export const ARTISAN_TOOL_IDS: readonly ToolProficiencyId[] = [
+  'smithstools',
+  'brewersupplies',
+  'masonstools',
+  'calligrapherstools',
+  'carpentertools',
+  'cartographerstools',
+  'cobblerstools',
+  'cooksutensils',
+  'glassblowerstools',
+  'jewelerstools',
+  'leatherworkerstools',
+  'painterstools',
+  'potterstools',
+  'tinkerstools',
+  'weaverstools',
+  'woodcarverstools',
+] as const satisfies readonly ToolProficiencyId[];
+
+/**
+ * Shared musical instrument ID list used by both backgrounds.ts and feats.ts.
+ */
+export const MUSICAL_INSTRUMENT_IDS: readonly ToolProficiencyId[] = [
+  'bagpipes',
+  'drum',
+  'dulcimer',
+  'flute',
+  'lute',
+  'lyre',
+  'horn',
+  'panflute',
+  'shawm',
+  'viol',
+] as const satisfies readonly ToolProficiencyId[];

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -158,6 +158,7 @@
       "weaponMasteryChoice": "Choose {{count}} weapon mastery",
       "damageChoice": "Choose {{count}} damage type(s)",
       "lineageChoice": "Choose your lineage",
+      "featChoice": "Choose an origin feat",
       "featureChoice": "Choose an option",
       "unsupported": "Choice not yet supported: {{type}}",
       "remaining": "remaining",

--- a/src/types/choices.ts
+++ b/src/types/choices.ts
@@ -35,6 +35,7 @@ const CHOICE_CATEGORIES = [
   'damage-choice',
   'bundle-choice',
   'lineage-choice',
+  'feat-choice',
   'feature-choice',
 ] as const;
 export type ChoiceCategory = (typeof CHOICE_CATEGORIES)[number];
@@ -102,6 +103,7 @@ export type ChoiceDecision =
       readonly slotPicks: Readonly<Record<string, string>>;
     }
   | { readonly type: 'lineage-choice'; readonly lineageId: string }
+  | { readonly type: 'feat-choice'; readonly featId: FeatId }
   | { readonly type: 'feature-choice'; readonly optionId: string };
 
 export interface BuildLevel {

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -12,6 +12,7 @@ import type {
 } from '@/lib/dnd-helpers';
 import type { ChoiceKey } from '@/types/choices';
 import type { BundleCategory } from '@/types/items';
+import type { FeatCategory } from '@/types/sources';
 
 // Supporting types
 
@@ -266,6 +267,13 @@ export interface LineageChoiceGrant {
   readonly from: readonly string[];
 }
 
+export interface FeatChoiceGrant {
+  readonly type: 'feat-choice';
+  readonly key: ChoiceKey;
+  readonly from: readonly FeatId[] | null;
+  readonly category: FeatCategory;
+}
+
 export type ResourcePoolMax =
   | { readonly mode: 'class-level'; readonly classId: ClassId }
   | { readonly mode: 'fixed'; readonly value: number };
@@ -304,6 +312,7 @@ export type Grant =
   | EquipmentGrant
   | BundleChoiceGrant
   | LineageChoiceGrant
+  | FeatChoiceGrant
   | FeatureChoiceGrant
   | FeatGrant
   | ResourcePoolGrant;

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -7,9 +7,10 @@ import type {
   ToolProficiencyId,
   LanguageId,
   ClassId,
+  FeatId,
 } from '@/lib/dnd-helpers';
 import type { FeatureDef, DamageTypeId, HitDie, SpeedMode, ResourcePoolRegen } from '@/types/grants';
-import type { SourceTag } from '@/types/sources';
+import type { SourceTag, FeatCategory } from '@/types/sources';
 import type { ChoiceKey } from '@/types/choices';
 import type {
   DamageDice,
@@ -206,6 +207,13 @@ export type PendingChoice =
       readonly source: SourceTag;
       readonly speciesId: SpeciesId;
       readonly from: readonly string[];
+    }
+  | {
+      readonly type: 'feat-choice';
+      readonly choiceKey: ChoiceKey;
+      readonly source: SourceTag;
+      readonly from: readonly FeatId[] | null;
+      readonly category: FeatCategory;
     }
   | {
       readonly type: 'feature-choice';


### PR DESCRIPTION
Closes #162

## Summary
Adds a `feat-choice` grant type (player chooses a feat from a category, mirroring `lineage-choice`) and wires it to Human's 2024 PHB *Versatile* trait, so picking Human surfaces an Origin-feat picker in the builder. Mechanizes four origin feats that map cleanly onto existing grant types; the rest stay as feature stubs with TODO comments pending new grant infrastructure.

## What Changed
**Part 1 — feat-choice infrastructure** (mirrors `lineage-choice` end-to-end):
- `src/types/grants.ts` — new `FeatChoiceGrant` in the `Grant` union.
- `src/types/choices.ts` — `'feat-choice'` choice category + `{ type:'feat-choice'; featId }` decision.
- `src/types/resolved.ts` — `feat-choice` `PendingChoice` variant.
- `src/lib/sources/index.ts` `collectBundles` — expands the chosen feat (source tag `{origin:'feat'}`) after the feats pass and before the feature-choice pass, so the chosen feat's own sub-choices (magic-initiate's class picker, Skilled's skill-choice) surface.
- `src/lib/resolver/index.ts` — emits a `feat-choice` pending when undecided.
- `src/components/character-builder/ChoicePicker.tsx` — feat-choice radio list.
- `src/components/character-builder/OriginStep.tsx` — renders the picker for Human's species-origin feat-choice.
- `src/lib/sources/species.ts` — Human gains the `feat-choice` (category `origin`) grant.
- `src/lib/character-builder/has-later-choices.ts` — recognizes `feat-choice`.

**Part 2 — origin feat library:**
- Mechanized: **Tough** (`hp-bonus` +2/level), **Skilled** (skill `proficiency-choice` ×3), **Crafter** (artisan-tool `proficiency-choice` ×3), **Musician** (instrument `proficiency-choice` ×3).
- Deferred (feature stubs + TODO): Alert, Healer, Lucky, Savage Attacker, Tavern Brawler — each needs a new grant type. Magic Initiate spell picks → #82.

**Incidental bug fix:** `src/lib/resolver/combat.ts` `resolveHp` previously ignored **all** `hp-bonus` grants — so Dwarf's Dwarven Toughness (+1/level) was also silently never applied. Fixed to sum `perLevel * level` for every `hp-bonus` grant. This was required for Tough and corrects that latent bug.

## Sub-choice surfacing (verified)
Skilled's skill-choice surfaces in the Skills step; Crafter/Musician's tool-choices in the Proficiencies step — both steps scan pending proficiency-choices with no `source.origin` filter.

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 1680 pass
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)