### PR TITLE
feat(spells): spell catalog + spell-choice grant (cantrip picker)

### DIFF
--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -537,6 +537,30 @@ describe('ChoicePicker spell-choice', () => {
     expect(onClear).toHaveBeenCalledWith(DRUID_CANTRIP_CHOICE.choiceKey);
   });
 
+  it('appends a second cantrip to an existing selection', () => {
+    const onDecide = vi.fn();
+    const currentDecision: ChoiceDecision = {
+      type: 'spell-choice',
+      spellIds: ['guidance'] as readonly import('@/types/spells').SpellId[],
+    };
+    render(
+      <ChoicePicker
+        choice={DRUID_CANTRIP_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={onDecide}
+        onClear={vi.fn()}
+      />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    // druidcraft is index 0 in SPELL_CATALOG; guidance is index 1 (already selected)
+    // clicking druidcraft (index 0) should append — result: ['guidance', 'druidcraft']
+    fireEvent.click(checkboxes[0]);
+    expect(onDecide).toHaveBeenCalledWith(DRUID_CANTRIP_CHOICE.choiceKey, {
+      type: 'spell-choice',
+      spellIds: ['guidance', 'druidcraft'],
+    });
+  });
+
   it('shows count badge with selected / total', () => {
     const currentDecision: ChoiceDecision = {
       type: 'spell-choice',

--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -389,3 +389,167 @@ describe('ChoicePicker feature-choice', () => {
     expect(onClear).toHaveBeenCalledWith(FEATURE_CHOICE.choiceKey);
   });
 });
+
+// ---------------------------------------------------------------------------
+// ChoicePicker — spell-choice branch
+// ---------------------------------------------------------------------------
+
+const DRUID_SOURCE = { origin: 'class' as const, id: 'druid' as const, level: 1 };
+
+const DRUID_CANTRIP_CHOICE: PendingChoice & { type: 'spell-choice' } = {
+  type: 'spell-choice',
+  choiceKey: 'spell-choice:class:druid:0' as ChoiceKey,
+  source: DRUID_SOURCE,
+  count: 2,
+  spellList: 'druid',
+  spellLevel: 0,
+};
+
+describe('ChoicePicker spell-choice', () => {
+  it('renders one checkbox per druid cantrip (10 total)', () => {
+    render(
+      <ChoicePicker choice={DRUID_CANTRIP_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(10);
+  });
+
+  it('no checkbox is checked when currentDecision is undefined', () => {
+    render(
+      <ChoicePicker choice={DRUID_CANTRIP_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    const checkboxes = screen.getAllByRole('checkbox') as HTMLInputElement[];
+    expect(checkboxes.every((cb) => !cb.checked)).toBe(true);
+  });
+
+  it('checking a cantrip calls onDecide with { type: spell-choice, spellIds: [id] }', () => {
+    const onDecide = vi.fn();
+    render(
+      <ChoicePicker choice={DRUID_CANTRIP_CHOICE} currentDecision={undefined} onDecide={onDecide} onClear={vi.fn()} />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    // Click the first checkbox (druidcraft)
+    fireEvent.click(checkboxes[0]);
+    expect(onDecide).toHaveBeenCalledWith(
+      DRUID_CANTRIP_CHOICE.choiceKey,
+      expect.objectContaining({ type: 'spell-choice', spellIds: expect.arrayContaining(['druidcraft']) })
+    );
+  });
+
+  it('unchecking a selected cantrip calls onClear when the result would be empty', () => {
+    const onClear = vi.fn();
+    const currentDecision: ChoiceDecision = {
+      type: 'spell-choice',
+      spellIds: ['druidcraft'] as readonly import('@/types/spells').SpellId[],
+    };
+    render(
+      <ChoicePicker
+        choice={DRUID_CANTRIP_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        onClear={onClear}
+      />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    // druidcraft is first in SPELL_CATALOG; uncheck it
+    fireEvent.click(checkboxes[0]);
+    expect(onClear).toHaveBeenCalledWith(DRUID_CANTRIP_CHOICE.choiceKey);
+  });
+
+  it('at-max (2 selected): unchecked checkboxes have aria-disabled=true', () => {
+    const currentDecision: ChoiceDecision = {
+      type: 'spell-choice',
+      spellIds: ['druidcraft', 'thorn-whip'] as readonly import('@/types/spells').SpellId[],
+    };
+    render(
+      <ChoicePicker
+        choice={DRUID_CANTRIP_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    const unselectedDisabled = checkboxes.filter(
+      (cb) => cb.getAttribute('aria-checked') !== 'true' && cb.getAttribute('aria-disabled') === 'true'
+    );
+    expect(unselectedDisabled.length).toBeGreaterThan(0);
+  });
+
+  it('selected checkboxes remain enabled even at max', () => {
+    const currentDecision: ChoiceDecision = {
+      type: 'spell-choice',
+      spellIds: ['druidcraft', 'thorn-whip'] as readonly import('@/types/spells').SpellId[],
+    };
+    render(
+      <ChoicePicker
+        choice={DRUID_CANTRIP_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    const selectedEnabled = checkboxes.filter(
+      (cb) => cb.getAttribute('aria-checked') === 'true' && cb.getAttribute('aria-disabled') !== 'true'
+    );
+    expect(selectedEnabled).toHaveLength(2);
+  });
+
+  it('Clear button does NOT appear when no cantrips are selected', () => {
+    render(
+      <ChoicePicker choice={DRUID_CANTRIP_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    expect(screen.queryByRole('button', { name: /clear/i })).toBeNull();
+  });
+
+  it('Clear button appears when cantrips are selected', () => {
+    const currentDecision: ChoiceDecision = {
+      type: 'spell-choice',
+      spellIds: ['guidance'] as readonly import('@/types/spells').SpellId[],
+    };
+    render(
+      <ChoicePicker
+        choice={DRUID_CANTRIP_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /clear/i })).toBeTruthy();
+  });
+
+  it('clicking Clear calls onClear with the correct choiceKey', () => {
+    const onClear = vi.fn();
+    const currentDecision: ChoiceDecision = {
+      type: 'spell-choice',
+      spellIds: ['guidance'] as readonly import('@/types/spells').SpellId[],
+    };
+    render(
+      <ChoicePicker
+        choice={DRUID_CANTRIP_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        onClear={onClear}
+      />
+    );
+    fireEvent.click(screen.getByRole('button', { name: /clear/i }));
+    expect(onClear).toHaveBeenCalledWith(DRUID_CANTRIP_CHOICE.choiceKey);
+  });
+
+  it('shows count badge with selected / total', () => {
+    const currentDecision: ChoiceDecision = {
+      type: 'spell-choice',
+      spellIds: ['druidcraft'] as readonly import('@/types/spells').SpellId[],
+    };
+    render(
+      <ChoicePicker
+        choice={DRUID_CANTRIP_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+    expect(screen.getByText('1 / 2')).toBeTruthy();
+  });
+});

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -10,6 +10,8 @@ import type { FeatId } from '@/lib/dnd-helpers';
 import { getItemDef, getItemNameKey, WEAPON_CATALOG } from '@/lib/sources/items';
 import { getBundleDef, getBundleNameKey, getItemsForSlot, resolveBundleRef } from '@/lib/sources/bundles';
 import { FEAT_SOURCES } from '@/lib/sources';
+import { getSpellsForList } from '@/lib/sources/spells';
+import type { SpellId } from '@/types/spells';
 import type { ChoiceDecision, ChoiceKey } from '@/types/choices';
 import type { BundleSlot, ItemDef, SlotFilter } from '@/types/items';
 import type { PendingChoice } from '@/types/resolved';
@@ -460,6 +462,62 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear }: Cho
             );
           })}
         </div>
+      </div>
+    );
+  }
+
+  if (choice.type === 'spell-choice') {
+    const pool = getSpellsForList(choice.spellList, choice.spellLevel);
+    const current = currentDecision?.type === 'spell-choice' ? currentDecision.spellIds : [];
+    const atMax = current.length >= choice.count;
+
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <p className="text-sm text-muted-foreground">
+            {tc('characterBuilder.pendingChoices.spellChoice', { count: choice.count })}
+          </p>
+          <Badge variant="outline" className="text-xs">
+            {current.length} / {choice.count}
+          </Badge>
+        </div>
+        <div className="space-y-1">
+          {pool.map((spell) => {
+            const isSelected = (current as readonly string[]).includes(spell.id);
+            const isDisabled = atMax && !isSelected;
+            const nameKey = `spells.${spell.id}.name` as `spells.${string}.name`;
+            return (
+              <div
+                key={spell.id}
+                className="flex items-center gap-3 px-2 py-1.5 rounded-md transition-colors hover:bg-muted/50"
+              >
+                <Checkbox
+                  id={`choice-spell-${choice.choiceKey}-${spell.id}`}
+                  checked={isSelected}
+                  disabled={isDisabled}
+                  onCheckedChange={(checked) => {
+                    const next = checked
+                      ? ([...current, spell.id] as readonly SpellId[])
+                      : (current.filter((id) => id !== spell.id) as readonly SpellId[]);
+                    if (next.length === 0) {
+                      onClear(choice.choiceKey);
+                    } else {
+                      onDecide(choice.choiceKey, { type: 'spell-choice', spellIds: next });
+                    }
+                  }}
+                />
+                <Label htmlFor={`choice-spell-${choice.choiceKey}-${spell.id}`} className="flex-1 cursor-pointer">
+                  {t(nameKey, { defaultValue: spell.id })}
+                </Label>
+              </div>
+            );
+          })}
+        </div>
+        {current.length > 0 && (
+          <Button variant="ghost" size="sm" onClick={() => onClear(choice.choiceKey)}>
+            {tc('characterBuilder.equipment.clearSelection')}
+          </Button>
+        )}
       </div>
     );
   }

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -471,12 +471,21 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear }: Cho
     const current = currentDecision?.type === 'spell-choice' ? currentDecision.spellIds : [];
     const atMax = current.length >= choice.count;
 
+    const choiceLabel =
+      choice.spellLevel === 0
+        ? tc('characterBuilder.pendingChoices.spellChoice', { count: choice.count })
+        : tc('characterBuilder.pendingChoices.spellChoiceLeveled', { count: choice.count, level: choice.spellLevel });
+
+    if (pool.length === 0) {
+      return (
+        <p className="text-sm text-muted-foreground italic">{tc('characterBuilder.pendingChoices.spellChoiceEmpty')}</p>
+      );
+    }
+
     return (
       <div className="space-y-2">
         <div className="flex items-center gap-2">
-          <p className="text-sm text-muted-foreground">
-            {tc('characterBuilder.pendingChoices.spellChoice', { count: choice.count })}
-          </p>
+          <p className="text-sm text-muted-foreground">{choiceLabel}</p>
           <Badge variant="outline" className="text-xs">
             {current.length} / {choice.count}
           </Badge>

--- a/src/components/character-builder/ClassStep.tsx
+++ b/src/components/character-builder/ClassStep.tsx
@@ -67,6 +67,14 @@ export function ClassStep() {
   }, [resolved]);
   const hasFeatureChoices = featureChoices.length > 0;
 
+  const spellChoices = useMemo<readonly Extract<PendingChoice, { type: 'spell-choice' }>[]>(() => {
+    return (resolved?.pendingChoices ?? []).filter(
+      (c): c is Extract<PendingChoice, { type: 'spell-choice' }> =>
+        c.type === 'spell-choice' && c.source.origin === 'class'
+    );
+  }, [resolved]);
+  const hasSpellChoices = spellChoices.length > 0;
+
   const levelOneClassFeatures = useMemo(() => {
     if (!resolved?.features) return [];
     return resolved.features.filter((f) => f.source.origin === 'class' && f.source.level === 1);
@@ -74,7 +82,12 @@ export function ClassStep() {
   const hasLevelOneFeatures = levelOneClassFeatures.length > 0;
 
   const hasAnyContent =
-    hasFightingStyles || hasSpellcasting || hasLevelOneFeatures || hasSubclassChoices || hasFeatureChoices;
+    hasFightingStyles ||
+    hasSpellcasting ||
+    hasLevelOneFeatures ||
+    hasSubclassChoices ||
+    hasFeatureChoices ||
+    hasSpellChoices;
 
   return (
     <div className="space-y-6">
@@ -192,6 +205,26 @@ export function ClassStep() {
       {hasFeatureChoices && (
         <div className="space-y-4">
           {featureChoices.map((choice) => (
+            <div key={choice.choiceKey}>
+              <p className="text-xs text-muted-foreground mb-1">
+                {tc('characterBuilder.pendingChoices.fromSource', {
+                  source: getChoiceSourceName(choice.choiceKey, t),
+                })}
+              </p>
+              <ChoicePicker
+                choice={choice}
+                currentDecision={build?.choices[choice.choiceKey]}
+                onDecide={(choiceKey, decision) => context.makeChoice(choiceKey, decision)}
+                onClear={(choiceKey) => context.clearChoice(choiceKey)}
+              />
+            </div>
+          ))}
+        </div>
+      )}
+
+      {hasSpellChoices && (
+        <div className="space-y-4">
+          {spellChoices.map((choice) => (
             <div key={choice.choiceKey}>
               <p className="text-xs text-muted-foreground mb-1">
                 {tc('characterBuilder.pendingChoices.fromSource', {

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -2481,3 +2481,63 @@ describe('collapsed repeatable feat resolver integration', () => {
     });
   });
 });
+
+describe('spell-choice pending-gate counts only pool-valid ids', () => {
+  // The wizard cantrip pool (spellLevel 0) includes mending/message/poison-spray but NOT guidance
+  // (guidance is cleric+druid only). This lets us construct a decision where raw size >= count
+  // but pool-valid size < count — exactly the divergence the fix closes.
+  const spellChoiceKey = createChoiceKey('spell-choice', 'class', 'wizard', 0);
+
+  const spellChoiceBundle: GrantBundle = {
+    source: { origin: 'class', id: 'wizard', level: 1 },
+    grants: [
+      {
+        type: 'spell-choice',
+        key: spellChoiceKey,
+        count: 2,
+        spellList: 'wizard' as ClassId,
+        spellLevel: 0,
+      },
+    ],
+  };
+
+  it('emits pending when decision contains one pool-valid + one out-of-pool spell id (raw count satisfies, pool-valid does not)', () => {
+    // mending is in the wizard cantrip pool; guidance is NOT (cleric/druid only).
+    // Raw distinct size = 2, pool-valid size = 1 → should still be pending.
+    const result = resolveCharacter({
+      ...baseInput,
+      bundles: [spellChoiceBundle],
+      choices: {
+        [spellChoiceKey]: { type: 'spell-choice' as const, spellIds: ['mending', 'guidance'] as const },
+      },
+    });
+    const pending = result.pendingChoices.find((c) => c.type === 'spell-choice');
+    expect(pending).toBeDefined();
+    expect(pending?.choiceKey).toBe(spellChoiceKey);
+  });
+
+  it('does not emit pending when decision contains two distinct pool-valid wizard cantrips', () => {
+    // mending and message are both in the wizard cantrip pool → pool-valid size = 2 = count → complete
+    const result = resolveCharacter({
+      ...baseInput,
+      bundles: [spellChoiceBundle],
+      choices: {
+        [spellChoiceKey]: { type: 'spell-choice' as const, spellIds: ['mending', 'message'] as const },
+      },
+    });
+    const pending = result.pendingChoices.find((c) => c.type === 'spell-choice');
+    expect(pending).toBeUndefined();
+  });
+
+  it('emits pending when no decision is provided', () => {
+    const result = resolveCharacter({ ...baseInput, bundles: [spellChoiceBundle], choices: {} });
+    const pending = result.pendingChoices.find((c) => c.type === 'spell-choice');
+    expect(pending).toBeDefined();
+    expect(pending?.choiceKey).toBe(spellChoiceKey);
+    if (pending?.type === 'spell-choice') {
+      expect(pending.count).toBe(2);
+      expect(pending.spellList).toBe('wizard');
+      expect(pending.spellLevel).toBe(0);
+    }
+  });
+});

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -324,6 +324,22 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
     }
   }
 
+  // Unresolved or underfilled spell-choice grants
+  for (const { grant, source } of collectGrantsByType(bundles, 'spell-choice')) {
+    const decision = choices[grant.key];
+    const chosenIds = decision?.type === 'spell-choice' ? decision.spellIds : [];
+    if (!decision || decision.type !== 'spell-choice' || chosenIds.length < grant.count) {
+      pendingChoices.push({
+        type: 'spell-choice',
+        choiceKey: grant.key,
+        source,
+        count: grant.count,
+        spellList: grant.spellList,
+        spellLevel: grant.spellLevel,
+      });
+    }
+  }
+
   // Unresolved subclass grants
   for (const { grant, source } of collectGrantsByType(bundles, 'subclass')) {
     const decision = choices[grant.key];

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -21,6 +21,7 @@ import { resolveEquipment, resolveAttacks, resolveEquippedArmorAc } from '@/lib/
 import { resolveResourcePools } from '@/lib/resolver/resource-pools';
 import { getItemDef, WEAPON_CATALOG } from '@/lib/sources/items';
 import { getFeatSource } from '@/lib/sources';
+import { getSpellsForList } from '@/lib/sources/spells';
 
 export interface PersistedItem {
   readonly itemId: string;
@@ -328,7 +329,9 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
   for (const { grant, source } of collectGrantsByType(bundles, 'spell-choice')) {
     const decision = choices[grant.key];
     const chosenIds = decision?.type === 'spell-choice' ? decision.spellIds : [];
-    if (!decision || decision.type !== 'spell-choice' || new Set(chosenIds).size < grant.count) {
+    const inPool = getSpellsForList(grant.spellList, grant.spellLevel);
+    const validDistinct = new Set(chosenIds.filter((id) => inPool.some((s) => s.id === id)));
+    if (!decision || decision.type !== 'spell-choice' || validDistinct.size < grant.count) {
       pendingChoices.push({
         type: 'spell-choice',
         choiceKey: grant.key,

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -328,7 +328,7 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
   for (const { grant, source } of collectGrantsByType(bundles, 'spell-choice')) {
     const decision = choices[grant.key];
     const chosenIds = decision?.type === 'spell-choice' ? decision.spellIds : [];
-    if (!decision || decision.type !== 'spell-choice' || chosenIds.length < grant.count) {
+    if (!decision || decision.type !== 'spell-choice' || new Set(chosenIds).size < grant.count) {
       pendingChoices.push({
         type: 'spell-choice',
         choiceKey: grant.key,

--- a/src/lib/resolver/spellcasting.test.ts
+++ b/src/lib/resolver/spellcasting.test.ts
@@ -376,11 +376,72 @@ describe('resolveSpellcasting', () => {
   });
 
   describe('cantrips behavior', () => {
-    it('cleric L1: cantrips is always []', () => {
-      // TODO(#93 followup): cantrip detection requires SpellGrant.level field; deferred.
+    it('cleric L1 with no spell grants: cantrips is []', () => {
       const abilities = makeAbilities({ wis: 14 });
       const result = resolveSpellcasting(makeClericBundles(1), abilities, 2, 1);
       expect(result!.cantrips).toEqual([]);
+    });
+
+    it('level-0 catalog spell routes to cantrips, not knownSpells', () => {
+      const bundles: GrantBundle[] = [
+        ...makeDruidBundles(1),
+        {
+          source: { origin: 'class', id: 'druid', level: 1 },
+          grants: [{ type: 'spell', spellId: 'guidance', alwaysPrepared: false }],
+        },
+      ];
+      const abilities = makeAbilities({ wis: 14 });
+      const result = resolveSpellcasting(bundles, abilities, 2, 1);
+      expect(result!.cantrips).toContain('guidance');
+      expect(result!.knownSpells).not.toContain('guidance');
+    });
+
+    it('level-0 catalog spell does not go to alwaysPreparedSpells even when alwaysPrepared=true', () => {
+      // alwaysPrepared takes priority regardless of spell level
+      const bundles: GrantBundle[] = [
+        ...makeClericBundles(1),
+        {
+          source: { origin: 'class', id: 'cleric', level: 1 },
+          grants: [{ type: 'spell', spellId: 'guidance', alwaysPrepared: true }],
+        },
+      ];
+      const abilities = makeAbilities({ wis: 14 });
+      const result = resolveSpellcasting(bundles, abilities, 2, 1);
+      expect(result!.alwaysPreparedSpells).toContain('guidance');
+      expect(result!.cantrips).not.toContain('guidance');
+    });
+
+    it('unknown spell id (not in catalog) with alwaysPrepared=false routes to knownSpells', () => {
+      const bundles: GrantBundle[] = [
+        ...makeClericBundles(1),
+        {
+          source: { origin: 'class', id: 'cleric', level: 1 },
+          grants: [{ type: 'spell', spellId: 'guiding-bolt', alwaysPrepared: false }],
+        },
+      ];
+      const abilities = makeAbilities({ wis: 14 });
+      const result = resolveSpellcasting(bundles, abilities, 2, 1);
+      expect(result!.knownSpells).toContain('guiding-bolt');
+      expect(result!.cantrips).not.toContain('guiding-bolt');
+    });
+
+    it('multiple druid cantrips all route to cantrips array', () => {
+      const bundles: GrantBundle[] = [
+        ...makeDruidBundles(1),
+        {
+          source: { origin: 'class', id: 'druid', level: 1 },
+          grants: [
+            { type: 'spell', spellId: 'druidcraft', alwaysPrepared: false },
+            { type: 'spell', spellId: 'thorn-whip', alwaysPrepared: false },
+          ],
+        },
+      ];
+      const abilities = makeAbilities({ wis: 14 });
+      const result = resolveSpellcasting(bundles, abilities, 2, 1);
+      expect(result!.cantrips).toContain('druidcraft');
+      expect(result!.cantrips).toContain('thorn-whip');
+      expect(result!.knownSpells).not.toContain('druidcraft');
+      expect(result!.knownSpells).not.toContain('thorn-whip');
     });
   });
 });

--- a/src/lib/resolver/spellcasting.test.ts
+++ b/src/lib/resolver/spellcasting.test.ts
@@ -425,6 +425,20 @@ describe('resolveSpellcasting', () => {
       expect(result!.cantrips).not.toContain('guiding-bolt');
     });
 
+    it('uncatalogued spell with alwaysPrepared=false routes to knownSpells (not cantrips)', () => {
+      const bundles: GrantBundle[] = [
+        ...makeClericBundles(1),
+        {
+          source: { origin: 'class', id: 'cleric', level: 1 },
+          grants: [{ type: 'spell', spellId: 'totally-unknown-spell', alwaysPrepared: false }],
+        },
+      ];
+      const abilities = makeAbilities({ wis: 14 });
+      const result = resolveSpellcasting(bundles, abilities, 2, 1);
+      expect(result!.knownSpells).toContain('totally-unknown-spell');
+      expect(result!.cantrips).not.toContain('totally-unknown-spell');
+    });
+
     it('multiple druid cantrips all route to cantrips array', () => {
       const bundles: GrantBundle[] = [
         ...makeDruidBundles(1),

--- a/src/lib/resolver/spellcasting.ts
+++ b/src/lib/resolver/spellcasting.ts
@@ -3,6 +3,7 @@ import type { AbilityKey } from '@/lib/dnd-helpers';
 import type { ResolvedAbility, ResolvedSpellcasting } from '@/types/resolved';
 import { getPactMagicSlots, getPreparedSpellCount, getSpellSlots } from '@/lib/dnd-helpers';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
+import { getSpellDef } from '@/lib/sources/spells';
 
 export function resolveSpellcasting(
   bundles: readonly GrantBundle[],
@@ -27,6 +28,8 @@ export function resolveSpellcasting(
   for (const { grant } of collectGrantsByType(bundles, 'spell')) {
     if (grant.alwaysPrepared) {
       alwaysPreparedSpells.push(grant.spellId);
+    } else if (getSpellDef(grant.spellId)?.level === 0) {
+      cantrips.push(grant.spellId);
     } else {
       knownSpells.push(grant.spellId);
     }

--- a/src/lib/resolver/spellcasting.ts
+++ b/src/lib/resolver/spellcasting.ts
@@ -4,6 +4,9 @@ import type { ResolvedAbility, ResolvedSpellcasting } from '@/types/resolved';
 import { getPactMagicSlots, getPreparedSpellCount, getSpellSlots } from '@/lib/dnd-helpers';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
 import { getSpellDef } from '@/lib/sources/spells';
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('resolver');
 
 export function resolveSpellcasting(
   bundles: readonly GrantBundle[],
@@ -28,10 +31,16 @@ export function resolveSpellcasting(
   for (const { grant } of collectGrantsByType(bundles, 'spell')) {
     if (grant.alwaysPrepared) {
       alwaysPreparedSpells.push(grant.spellId);
-    } else if (getSpellDef(grant.spellId)?.level === 0) {
-      cantrips.push(grant.spellId);
     } else {
-      knownSpells.push(grant.spellId);
+      const def = getSpellDef(grant.spellId);
+      if (!def) {
+        logger.warn(`spell grant references uncatalogued spell "${grant.spellId}"`);
+        knownSpells.push(grant.spellId);
+      } else if (def.level === 0) {
+        cantrips.push(grant.spellId);
+      } else {
+        knownSpells.push(grant.spellId);
+      }
     }
   }
 

--- a/src/lib/schemas/character-build.test.ts
+++ b/src/lib/schemas/character-build.test.ts
@@ -262,6 +262,45 @@ describe('ChoiceDecisionSchema', () => {
       expect(result.success).toBe(false);
     });
   });
+
+  describe('spell-choice', () => {
+    it('accepts a spell-choice decision with known spell IDs and round-trips correctly', () => {
+      const result = ChoiceDecisionSchema.safeParse({
+        type: 'spell-choice',
+        spellIds: ['druidcraft', 'thorn-whip'],
+      });
+      expect(result.success).toBe(true);
+      if (result.success) {
+        expect(result.data).toEqual({ type: 'spell-choice', spellIds: ['druidcraft', 'thorn-whip'] });
+      }
+    });
+
+    it('rejects spell-choice with an unknown spell ID', () => {
+      const result = ChoiceDecisionSchema.safeParse({
+        type: 'spell-choice',
+        spellIds: ['fireball'],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects spell-choice with an empty string spell ID', () => {
+      const result = ChoiceDecisionSchema.safeParse({
+        type: 'spell-choice',
+        spellIds: [''],
+      });
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects spell-choice missing spellIds field', () => {
+      const result = ChoiceDecisionSchema.safeParse({ type: 'spell-choice' });
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts spell-choice with an empty array', () => {
+      const result = ChoiceDecisionSchema.safeParse({ type: 'spell-choice', spellIds: [] });
+      expect(result.success).toBe(true);
+    });
+  });
 });
 
 describe('CharacterBuildSchemaStrict', () => {

--- a/src/lib/schemas/character-build.ts
+++ b/src/lib/schemas/character-build.ts
@@ -7,6 +7,7 @@ import {
   type SkillId,
   type ToolProficiencyId,
 } from '@/lib/dnd-helpers';
+import { isSpellId } from '@/lib/sources/spells';
 import type { ChoiceDecision } from '@/types/choices';
 
 const SKILL_IDS = DND_SKILLS.map((s) => s.id) as [SkillId, ...SkillId[]];
@@ -55,7 +56,10 @@ export const ChoiceDecisionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('lineage-choice'), lineageId: z.string().min(1) }),
   z.object({ type: z.literal('feature-choice'), optionId: z.string().min(1) }),
   z.object({ type: z.literal('feat-choice'), featId: z.string().refine(isFeatId, { message: 'Unknown feat ID' }) }),
-  z.object({ type: z.literal('spell-choice'), spellIds: z.array(z.string()).readonly() }),
+  z.object({
+    type: z.literal('spell-choice'),
+    spellIds: z.array(z.string().refine(isSpellId, { message: 'Unknown spell ID' })).readonly(),
+  }),
 ]);
 
 // Compile-time parity: every ChoiceDecision discriminant must have a schema arm.

--- a/src/lib/schemas/character-build.ts
+++ b/src/lib/schemas/character-build.ts
@@ -55,6 +55,7 @@ export const ChoiceDecisionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('lineage-choice'), lineageId: z.string().min(1) }),
   z.object({ type: z.literal('feature-choice'), optionId: z.string().min(1) }),
   z.object({ type: z.literal('feat-choice'), featId: z.string().refine(isFeatId, { message: 'Unknown feat ID' }) }),
+  z.object({ type: z.literal('spell-choice'), spellIds: z.array(z.string()).readonly() }),
 ]);
 
 // Compile-time parity: every ChoiceDecision discriminant must have a schema arm.

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -336,6 +336,13 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
           },
           { type: 'spellcasting', ability: 'wis', source: 'class' },
           {
+            type: 'spell-choice',
+            key: createChoiceKey('spell-choice', 'class', 'druid', 0),
+            count: 2,
+            spellList: 'druid',
+            spellLevel: 0,
+          },
+          {
             type: 'feature-choice',
             key: createChoiceKey('feature-choice', 'class', 'druid', 0),
             options: [

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -27,10 +27,11 @@ import {
   FEAT_SOURCES,
 } from '@/lib/sources';
 import { resolveCharacter } from '@/lib/resolver';
-import type { CharacterBuild } from '@/types/choices';
+import type { CharacterBuild, ChoiceDecision, ChoiceKey } from '@/types/choices';
 import { createChoiceKey } from '@/types/choices';
 import type { SpeciesId, BackgroundId, ClassId, FeatId } from '@/lib/dnd-helpers';
 import type { SubclassId } from '@/types/sources';
+import type { SpellId } from '@/types/spells';
 
 const humanFighterL1Build: CharacterBuild = {
   speciesId: 'human' as SpeciesId,
@@ -963,5 +964,89 @@ describe('feature-choice single-pass safety invariant', () => {
         'collectBundles expands options in a single pass and would silently drop these. ' +
         'Promote to a fixpoint loop before adding such an option.'
     ).toHaveLength(0);
+  });
+});
+
+describe('Druid L1 cantrip spell-choice (end-to-end)', () => {
+  const druidL1Build: CharacterBuild = {
+    speciesId: 'human' as SpeciesId,
+    backgroundId: null,
+    baseAbilities: { str: 10, dex: 10, con: 10, int: 10, wis: 14, cha: 10 },
+    abilityMethod: 'standard-array',
+    levels: [{ classId: 'druid' as ClassId, classLevel: 1, hpRoll: null }],
+    choices: {},
+    feats: [],
+    activeItems: [],
+  };
+
+  it('no decision → pendingChoices includes a spell-choice with count=2, spellList=druid, spellLevel=0', () => {
+    const { bundles, expandedFeats } = collectBundles(druidL1Build);
+    const resolved = resolveCharacter({
+      baseAbilities: druidL1Build.baseAbilities,
+      level: 1,
+      bundles,
+      choices: {},
+      expandedFeats,
+    });
+    const spellChoicePending = resolved.pendingChoices.filter((c) => c.type === 'spell-choice');
+    expect(spellChoicePending.length).toBe(1);
+    const pending = spellChoicePending[0];
+    if (pending.type === 'spell-choice') {
+      expect(pending.count).toBe(2);
+      expect(pending.spellList).toBe('druid');
+      expect(pending.spellLevel).toBe(0);
+    }
+  });
+
+  it('with 2 cantrip decisions → resolved.spellcasting.cantrips contains those 2, no spell-choice pending', () => {
+    const choiceKey = createChoiceKey('spell-choice', 'class', 'druid', 0);
+    const spellDecision: ChoiceDecision = {
+      type: 'spell-choice',
+      spellIds: ['druidcraft', 'thorn-whip'] as readonly SpellId[],
+    };
+    const buildWithDecision: CharacterBuild = {
+      ...druidL1Build,
+      choices: { [choiceKey]: spellDecision } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    };
+
+    const { bundles, expandedFeats } = collectBundles(buildWithDecision);
+    const resolved = resolveCharacter({
+      baseAbilities: buildWithDecision.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithDecision.choices,
+      expandedFeats,
+    });
+
+    expect(resolved.spellcasting).not.toBeNull();
+    expect(resolved.spellcasting!.cantrips).toContain('druidcraft');
+    expect(resolved.spellcasting!.cantrips).toContain('thorn-whip');
+
+    const spellChoicePending = resolved.pendingChoices.filter((c) => c.type === 'spell-choice');
+    expect(spellChoicePending.length).toBe(0);
+  });
+
+  it('with only 1 cantrip decision → still has spell-choice pending (underfilled)', () => {
+    const choiceKey = createChoiceKey('spell-choice', 'class', 'druid', 0);
+    const partialDecision: ChoiceDecision = {
+      type: 'spell-choice',
+      spellIds: ['guidance'] as readonly SpellId[],
+    };
+    const buildWithPartialDecision: CharacterBuild = {
+      ...druidL1Build,
+      choices: { [choiceKey]: partialDecision } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    };
+
+    const { bundles, expandedFeats } = collectBundles(buildWithPartialDecision);
+    const resolved = resolveCharacter({
+      baseAbilities: buildWithPartialDecision.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithPartialDecision.choices,
+      expandedFeats,
+    });
+
+    const spellChoicePending = resolved.pendingChoices.filter((c) => c.type === 'spell-choice');
+    expect(spellChoicePending.length).toBe(1);
   });
 });

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -967,6 +967,109 @@ describe('feature-choice single-pass safety invariant', () => {
   });
 });
 
+describe('spell-choice validation in collectBundles', () => {
+  const druidL1Build: CharacterBuild = {
+    speciesId: 'human' as SpeciesId,
+    backgroundId: null,
+    baseAbilities: { str: 10, dex: 10, con: 10, int: 10, wis: 14, cha: 10 },
+    abilityMethod: 'standard-array',
+    levels: [{ classId: 'druid' as ClassId, classLevel: 1, hpRoll: null }],
+    choices: {},
+    feats: [],
+    activeItems: [],
+  };
+
+  it('invalid spellId emits a warning and is absent from resolved cantrips', () => {
+    const choiceKey = createChoiceKey('spell-choice', 'class', 'druid', 0);
+    const buildWithInvalid: CharacterBuild = {
+      ...druidL1Build,
+      choices: {
+        [choiceKey]: {
+          type: 'spell-choice',
+          spellIds: ['druidcraft', 'fireball'] as readonly SpellId[],
+        },
+      } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    };
+
+    const { bundles, warnings, expandedFeats } = collectBundles(buildWithInvalid);
+    expect(warnings.some((w) => w.includes('fireball'))).toBe(true);
+
+    const resolved = resolveCharacter({
+      baseAbilities: buildWithInvalid.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithInvalid.choices,
+      expandedFeats,
+    });
+    expect(resolved.spellcasting?.cantrips).toContain('druidcraft');
+    expect(resolved.spellcasting?.cantrips).not.toContain('fireball');
+  });
+
+  it('valid spellIds still resolve normally when mixed with an invalid id', () => {
+    const choiceKey = createChoiceKey('spell-choice', 'class', 'druid', 0);
+    const buildWithMixed: CharacterBuild = {
+      ...druidL1Build,
+      choices: {
+        [choiceKey]: {
+          type: 'spell-choice',
+          spellIds: ['guidance', 'fireball'] as readonly SpellId[],
+        },
+      } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    };
+
+    const { bundles, warnings, expandedFeats } = collectBundles(buildWithMixed);
+    expect(warnings.some((w) => w.includes('fireball'))).toBe(true);
+
+    const resolved = resolveCharacter({
+      baseAbilities: buildWithMixed.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithMixed.choices,
+      expandedFeats,
+    });
+    expect(resolved.spellcasting?.cantrips).toContain('guidance');
+    expect(resolved.spellcasting?.cantrips).not.toContain('fireball');
+  });
+});
+
+describe('spell-choice duplicate-id gate (resolver)', () => {
+  const druidL1Build: CharacterBuild = {
+    speciesId: 'human' as SpeciesId,
+    backgroundId: null,
+    baseAbilities: { str: 10, dex: 10, con: 10, int: 10, wis: 14, cha: 10 },
+    abilityMethod: 'standard-array',
+    levels: [{ classId: 'druid' as ClassId, classLevel: 1, hpRoll: null }],
+    choices: {},
+    feats: [],
+    activeItems: [],
+  };
+
+  it('two duplicate spellIds with count=2 still emits spell-choice pending', () => {
+    const choiceKey = createChoiceKey('spell-choice', 'class', 'druid', 0);
+    const buildWithDupes: CharacterBuild = {
+      ...druidL1Build,
+      choices: {
+        [choiceKey]: {
+          type: 'spell-choice',
+          spellIds: ['guidance', 'guidance'] as readonly SpellId[],
+        },
+      } as Readonly<Record<ChoiceKey, ChoiceDecision>>,
+    };
+
+    const { bundles, expandedFeats } = collectBundles(buildWithDupes);
+    const resolved = resolveCharacter({
+      baseAbilities: buildWithDupes.baseAbilities,
+      level: 1,
+      bundles,
+      choices: buildWithDupes.choices,
+      expandedFeats,
+    });
+
+    const spellChoicePending = resolved.pendingChoices.filter((c) => c.type === 'spell-choice');
+    expect(spellChoicePending.length).toBe(1);
+  });
+});
+
 describe('Druid L1 cantrip spell-choice (end-to-end)', () => {
   const druidL1Build: CharacterBuild = {
     speciesId: 'human' as SpeciesId,

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -20,6 +20,7 @@ import type {
   DamageTypeChoiceGrant,
   FeatureChoiceGrant,
   FeatChoiceGrant,
+  SpellChoiceGrant,
 } from '@/types/grants';
 import type { CharacterBuild } from '@/types/choices';
 import { SPECIES_SOURCES, LINEAGE_GRANTS_REGISTRY } from '@/lib/sources/species';
@@ -189,6 +190,29 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
           warnings.push(msg);
           logger.warn(msg);
         }
+      }
+    }
+  }
+
+  // Spell-choice decisions — expand chosen spellIds into individual spell grants so the
+  // resolver's collectGrantsByType('spell') loop picks them up.
+  const allSpellChoiceGrants: { grant: SpellChoiceGrant; source: SourceTag }[] = [];
+  for (const bundle of bundles) {
+    for (const grant of bundle.grants) {
+      if (grant.type === 'spell-choice') {
+        allSpellChoiceGrants.push({ grant: grant as SpellChoiceGrant, source: bundle.source });
+      }
+    }
+  }
+
+  for (const { grant, source } of allSpellChoiceGrants) {
+    const decision = build.choices[grant.key];
+    if (decision?.type === 'spell-choice') {
+      for (const spellId of decision.spellIds) {
+        bundles.push({
+          source,
+          grants: [{ type: 'spell', spellId, alwaysPrepared: false }],
+        });
       }
     }
   }

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -30,6 +30,7 @@ import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
 import { FEAT_SOURCES } from '@/lib/sources/feats';
 import { ITEM_SOURCES } from '@/lib/sources/items';
 import { FIGHTING_STYLE_SOURCES, getFightingStyleSource } from '@/lib/sources/fighting-styles';
+import { getSpellsForList } from '@/lib/sources/spells';
 import type { FightingStyleId } from '@/lib/dnd-helpers';
 
 export type {
@@ -208,7 +209,14 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
   for (const { grant, source } of allSpellChoiceGrants) {
     const decision = build.choices[grant.key];
     if (decision?.type === 'spell-choice') {
+      const pool = getSpellsForList(grant.spellList, grant.spellLevel);
       for (const spellId of decision.spellIds) {
+        if (!pool.some((s) => s.id === spellId)) {
+          const msg = `spell-choice "${grant.key}" decision references spell "${spellId}" not in ${grant.spellList} list at level ${grant.spellLevel}`;
+          warnings.push(msg);
+          logger.warn(msg);
+          continue;
+        }
         bundles.push({
           source,
           grants: [{ type: 'spell', spellId, alwaysPrepared: false }],

--- a/src/lib/sources/spells.test.ts
+++ b/src/lib/sources/spells.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest';
+import { SPELL_CATALOG, getSpellDef, requireSpellDef, getSpellsForList } from '@/lib/sources/spells';
+import gamedata from '@/locales/en/gamedata.json';
+
+describe('SPELL_CATALOG', () => {
+  it('has no duplicate ids', () => {
+    const ids = SPELL_CATALOG.map((s) => s.id);
+    const unique = new Set(ids);
+    expect(unique.size).toBe(ids.length);
+  });
+
+  it('every catalog spell has a non-empty spells.<id>.name in gamedata', () => {
+    for (const spell of SPELL_CATALOG) {
+      const entry = (gamedata.spells as Record<string, { name: string; description: string } | undefined>)[spell.id];
+      expect(entry, `Missing gamedata entry for spell "${spell.id}"`).toBeDefined();
+      expect(entry!.name.length, `Empty name for spell "${spell.id}"`).toBeGreaterThan(0);
+    }
+  });
+
+  it("every spell's nativeClasses is non-empty", () => {
+    for (const spell of SPELL_CATALOG) {
+      expect(spell.nativeClasses.length, `nativeClasses is empty for spell "${spell.id}"`).toBeGreaterThan(0);
+    }
+  });
+});
+
+describe('getSpellsForList', () => {
+  it("returns all druid cantrips when filtered by classId='druid' and level=0", () => {
+    const druidCantrips = getSpellsForList('druid', 0);
+    // All 10 catalog spells are druid cantrips
+    expect(druidCantrips.length).toBe(10);
+  });
+
+  it('returns spells that include druid in nativeClasses', () => {
+    const druidCantrips = getSpellsForList('druid', 0);
+    for (const spell of druidCantrips) {
+      expect(spell.nativeClasses).toContain('druid');
+    }
+  });
+
+  it('filters by level correctly', () => {
+    const druidCantrips = getSpellsForList('druid', 0);
+    for (const spell of druidCantrips) {
+      expect(spell.level).toBe(0);
+    }
+  });
+
+  it('returns all druid spells when no level filter', () => {
+    const allDruid = getSpellsForList('druid');
+    expect(allDruid.length).toBeGreaterThanOrEqual(10);
+  });
+
+  it('returns empty array for class with no matching spells', () => {
+    // No level-9 spells in the catalog
+    const result = getSpellsForList('druid', 9);
+    expect(result).toEqual([]);
+  });
+});
+
+describe('getSpellDef', () => {
+  it('returns the SpellDef for a known id', () => {
+    const def = getSpellDef('guidance');
+    expect(def).toBeDefined();
+    expect(def!.id).toBe('guidance');
+    expect(def!.level).toBe(0);
+    expect(def!.school).toBe('divination');
+  });
+
+  it('returns undefined for an unknown id', () => {
+    expect(getSpellDef('nonexistent-spell')).toBeUndefined();
+  });
+});
+
+describe('requireSpellDef', () => {
+  it('returns the SpellDef for a known id', () => {
+    const def = requireSpellDef('thorn-whip');
+    expect(def.id).toBe('thorn-whip');
+  });
+
+  it('throws for an unknown id', () => {
+    expect(() => requireSpellDef('not-a-spell')).toThrowError(/Unknown spell id/);
+  });
+});

--- a/src/lib/sources/spells.ts
+++ b/src/lib/sources/spells.ts
@@ -1,0 +1,153 @@
+import type { ClassId } from '@/lib/dnd-helpers';
+import type { SpellDef } from '@/types/spells';
+
+export const SPELL_CATALOG = [
+  {
+    id: 'druidcraft',
+    level: 0,
+    school: 'transmutation',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: '30 feet',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Instantaneous',
+    nativeClasses: ['druid'] as readonly ClassId[],
+  },
+  {
+    id: 'guidance',
+    level: 0,
+    school: 'divination',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: 'Touch',
+    components: { verbal: true, somatic: true, material: false },
+    duration: '1 minute',
+    nativeClasses: ['cleric', 'druid'] as readonly ClassId[],
+  },
+  {
+    id: 'mending',
+    level: 0,
+    school: 'transmutation',
+    ritual: false,
+    concentration: false,
+    castingTime: '1 minute',
+    range: 'Touch',
+    components: {
+      verbal: true,
+      somatic: true,
+      material: 'two lodestones',
+    },
+    duration: 'Instantaneous',
+    nativeClasses: ['bard', 'cleric', 'druid', 'sorcerer', 'wizard'] as readonly ClassId[],
+  },
+  {
+    id: 'message',
+    level: 0,
+    school: 'transmutation',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: '120 feet',
+    components: { verbal: true, somatic: true, material: 'a copper wire' },
+    duration: '1 round',
+    nativeClasses: ['bard', 'druid', 'sorcerer', 'wizard'] as readonly ClassId[],
+  },
+  {
+    id: 'poison-spray',
+    level: 0,
+    school: 'necromancy',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: '30 feet',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Instantaneous',
+    nativeClasses: ['druid', 'sorcerer', 'warlock', 'wizard'] as readonly ClassId[],
+  },
+  {
+    id: 'produce-flame',
+    level: 0,
+    school: 'conjuration',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Bonus Action',
+    range: 'Self',
+    components: { verbal: true, somatic: true, material: false },
+    duration: '10 minutes',
+    nativeClasses: ['druid'] as readonly ClassId[],
+  },
+  {
+    id: 'resistance',
+    level: 0,
+    school: 'abjuration',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: 'Touch',
+    components: { verbal: true, somatic: true, material: 'a miniature cloak' },
+    duration: '1 minute',
+    nativeClasses: ['cleric', 'druid'] as readonly ClassId[],
+  },
+  {
+    id: 'shillelagh',
+    level: 0,
+    school: 'transmutation',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Bonus Action',
+    range: 'Self',
+    components: { verbal: true, somatic: true, material: 'mistletoe and shamrock leaves, plus a club or quarterstaff' },
+    duration: '1 minute',
+    nativeClasses: ['druid'] as readonly ClassId[],
+  },
+  {
+    id: 'spare-the-dying',
+    level: 0,
+    school: 'necromancy',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: '15 feet',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Instantaneous',
+    nativeClasses: ['cleric', 'druid'] as readonly ClassId[],
+  },
+  {
+    id: 'thorn-whip',
+    level: 0,
+    school: 'transmutation',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: '30 feet',
+    components: { verbal: true, somatic: true, material: 'the stem of a plant with thorns' },
+    duration: 'Instantaneous',
+    nativeClasses: ['druid'] as readonly ClassId[],
+  },
+] as const satisfies readonly SpellDef[];
+
+export type SpellId = (typeof SPELL_CATALOG)[number]['id'];
+
+export function isSpellId(id: string): id is SpellId {
+  return (SPELL_CATALOG as readonly { id: string }[]).some((s) => s.id === id);
+}
+
+export function getSpellDef(id: string): SpellDef | undefined {
+  return (SPELL_CATALOG as readonly SpellDef[]).find((s) => s.id === id);
+}
+
+export function requireSpellDef(id: string): SpellDef {
+  const def = getSpellDef(id);
+  if (!def) {
+    throw new Error(`Unknown spell id "${id}" — no entry in SPELL_CATALOG`);
+  }
+  return def;
+}
+
+export function getSpellsForList(classId: ClassId, level?: number): readonly SpellDef[] {
+  return (SPELL_CATALOG as readonly SpellDef[]).filter(
+    (s) => (s.nativeClasses as readonly string[]).includes(classId) && (level === undefined || s.level === level)
+  );
+}

--- a/src/lib/sources/spells.ts
+++ b/src/lib/sources/spells.ts
@@ -12,7 +12,7 @@ export const SPELL_CATALOG = [
     range: '30 feet',
     components: { verbal: true, somatic: true, material: false },
     duration: 'Instantaneous',
-    nativeClasses: ['druid'] as readonly ClassId[],
+    nativeClasses: ['druid'],
   },
   {
     id: 'guidance',
@@ -24,7 +24,7 @@ export const SPELL_CATALOG = [
     range: 'Touch',
     components: { verbal: true, somatic: true, material: false },
     duration: '1 minute',
-    nativeClasses: ['cleric', 'druid'] as readonly ClassId[],
+    nativeClasses: ['cleric', 'druid'],
   },
   {
     id: 'mending',
@@ -40,7 +40,7 @@ export const SPELL_CATALOG = [
       material: 'two lodestones',
     },
     duration: 'Instantaneous',
-    nativeClasses: ['bard', 'cleric', 'druid', 'sorcerer', 'wizard'] as readonly ClassId[],
+    nativeClasses: ['bard', 'cleric', 'druid', 'sorcerer', 'wizard'],
   },
   {
     id: 'message',
@@ -52,7 +52,7 @@ export const SPELL_CATALOG = [
     range: '120 feet',
     components: { verbal: true, somatic: true, material: 'a copper wire' },
     duration: '1 round',
-    nativeClasses: ['bard', 'druid', 'sorcerer', 'wizard'] as readonly ClassId[],
+    nativeClasses: ['bard', 'druid', 'sorcerer', 'wizard'],
   },
   {
     id: 'poison-spray',
@@ -64,7 +64,7 @@ export const SPELL_CATALOG = [
     range: '30 feet',
     components: { verbal: true, somatic: true, material: false },
     duration: 'Instantaneous',
-    nativeClasses: ['druid', 'sorcerer', 'warlock', 'wizard'] as readonly ClassId[],
+    nativeClasses: ['druid', 'sorcerer', 'warlock', 'wizard'],
   },
   {
     id: 'produce-flame',
@@ -72,11 +72,11 @@ export const SPELL_CATALOG = [
     school: 'conjuration',
     ritual: false,
     concentration: false,
-    castingTime: 'Bonus Action',
+    castingTime: 'Action',
     range: 'Self',
     components: { verbal: true, somatic: true, material: false },
     duration: '10 minutes',
-    nativeClasses: ['druid'] as readonly ClassId[],
+    nativeClasses: ['druid'],
   },
   {
     id: 'resistance',
@@ -88,7 +88,7 @@ export const SPELL_CATALOG = [
     range: 'Touch',
     components: { verbal: true, somatic: true, material: 'a miniature cloak' },
     duration: '1 minute',
-    nativeClasses: ['cleric', 'druid'] as readonly ClassId[],
+    nativeClasses: ['cleric', 'druid'],
   },
   {
     id: 'shillelagh',
@@ -100,7 +100,7 @@ export const SPELL_CATALOG = [
     range: 'Self',
     components: { verbal: true, somatic: true, material: 'mistletoe and shamrock leaves, plus a club or quarterstaff' },
     duration: '1 minute',
-    nativeClasses: ['druid'] as readonly ClassId[],
+    nativeClasses: ['druid'],
   },
   {
     id: 'spare-the-dying',
@@ -112,7 +112,7 @@ export const SPELL_CATALOG = [
     range: '15 feet',
     components: { verbal: true, somatic: true, material: false },
     duration: 'Instantaneous',
-    nativeClasses: ['cleric', 'druid'] as readonly ClassId[],
+    nativeClasses: ['cleric', 'druid'],
   },
   {
     id: 'thorn-whip',
@@ -124,7 +124,7 @@ export const SPELL_CATALOG = [
     range: '30 feet',
     components: { verbal: true, somatic: true, material: 'the stem of a plant with thorns' },
     duration: 'Instantaneous',
-    nativeClasses: ['druid'] as readonly ClassId[],
+    nativeClasses: ['druid'],
   },
 ] as const satisfies readonly SpellDef[];
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -156,6 +156,8 @@
       "expertiseChoice": "Choose {{count}} expertise",
       "fightingStyleChoice": "Choose {{count}} fighting style(s)",
       "spellChoice": "Choose {{count}} cantrip(s)",
+      "spellChoiceLeveled": "Choose {{count}} level-{{level}} spell(s)",
+      "spellChoiceEmpty": "No spells available for this list and level.",
       "weaponMasteryChoice": "Choose {{count}} weapon mastery",
       "damageChoice": "Choose {{count}} damage type(s)",
       "lineageChoice": "Choose your lineage",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -155,6 +155,7 @@
       "toolChoice": "Choose {{count}} tool(s)",
       "expertiseChoice": "Choose {{count}} expertise",
       "fightingStyleChoice": "Choose {{count}} fighting style(s)",
+      "spellChoice": "Choose {{count}} cantrip(s)",
       "weaponMasteryChoice": "Choose {{count}} weapon mastery",
       "damageChoice": "Choose {{count}} damage type(s)",
       "lineageChoice": "Choose your lineage",

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -2435,5 +2435,47 @@
       "name": "Focus Points",
       "description": "Fuel Monk techniques. Regain on a Short Rest."
     }
+  },
+  "spells": {
+    "druidcraft": {
+      "name": "Druidcraft",
+      "description": "Whispering to the spirits of nature, you create one of the following effects: a tiny weather prediction, a harmless sensory effect, instant plant bloom or seed pod opening, or a lit or snuffed torch or campfire."
+    },
+    "guidance": {
+      "name": "Guidance",
+      "description": "You touch one willing creature. Once before the spell ends, the target can roll a d4 and add the number rolled to one ability check of its choice, potentially turning a failure into a success."
+    },
+    "mending": {
+      "name": "Mending",
+      "description": "This spell repairs a single break or tear in an object you touch, such as a broken chain link, two halves of a broken key, a torn cloak, or a leaking wineskin. As long as the break or tear is no longer than 1 foot in any dimension, you mend it."
+    },
+    "message": {
+      "name": "Message",
+      "description": "You point your finger toward a creature within range and whisper a message. The target (and only the target) hears the message and can reply in a whisper that only you can hear."
+    },
+    "poison-spray": {
+      "name": "Poison Spray",
+      "description": "You extend your hand toward a creature you can see within range and project a puff of noxious gas. The creature must succeed on a Constitution saving throw or take 1d12 Poison damage."
+    },
+    "produce-flame": {
+      "name": "Produce Flame",
+      "description": "A flickering flame appears in your hand and remains there for the duration, shedding bright light in a 20-foot radius and dim light for an additional 20 feet. The flame harms neither you nor your equipment. On subsequent turns you can use a Magic action to hurl the fire at a creature or object within 60 feet."
+    },
+    "resistance": {
+      "name": "Resistance",
+      "description": "You touch one willing creature. Once before the spell ends, the target can roll a d4 and add the number rolled to one saving throw of its choice, potentially turning a failure into a success."
+    },
+    "shillelagh": {
+      "name": "Shillelagh",
+      "description": "A Club or Quarterstaff you are holding is imbued with nature's power. For the duration, you can use your Spellcasting ability for the weapon's attack rolls and damage rolls, and the weapon's damage die becomes a d8."
+    },
+    "spare-the-dying": {
+      "name": "Spare the Dying",
+      "description": "Choose a creature within range that has 0 Hit Points and isn't dead. The creature becomes Stable."
+    },
+    "thorn-whip": {
+      "name": "Thorn Whip",
+      "description": "You create a long, vine-like whip covered in thorns that lashes out at your command toward a creature in range. Make a melee spell attack against the target. On a hit, the target takes 1d6 Piercing damage, and if it is Large or smaller, you pull the creature up to 10 feet closer to you."
+    }
   }
 }

--- a/src/types/choices.ts
+++ b/src/types/choices.ts
@@ -12,6 +12,7 @@ import type {
 import type { SubclassId } from '@/types/sources';
 import type { AbilityScores } from '@/types/database';
 import type { DamageTypeId } from '@/types/grants';
+import type { SpellId } from '@/types/spells';
 
 /**
  * Choice key format: `category:origin:id:index`
@@ -37,6 +38,7 @@ const CHOICE_CATEGORIES = [
   'lineage-choice',
   'feat-choice',
   'feature-choice',
+  'spell-choice',
 ] as const;
 export type ChoiceCategory = (typeof CHOICE_CATEGORIES)[number];
 
@@ -104,7 +106,8 @@ export type ChoiceDecision =
     }
   | { readonly type: 'lineage-choice'; readonly lineageId: string }
   | { readonly type: 'feat-choice'; readonly featId: FeatId }
-  | { readonly type: 'feature-choice'; readonly optionId: string };
+  | { readonly type: 'feature-choice'; readonly optionId: string }
+  | { readonly type: 'spell-choice'; readonly spellIds: readonly SpellId[] };
 
 export interface BuildLevel {
   readonly classId: ClassId;

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -13,6 +13,7 @@ import type {
 import type { ChoiceKey } from '@/types/choices';
 import type { BundleCategory } from '@/types/items';
 import type { FeatCategory } from '@/types/sources';
+import type { SpellDef } from '@/types/spells';
 
 // Supporting types
 
@@ -292,7 +293,7 @@ export interface SpellChoiceGrant {
   readonly key: ChoiceKey;
   readonly count: number;
   readonly spellList: ClassId;
-  readonly spellLevel: number;
+  readonly spellLevel: SpellDef['level'];
 }
 
 export type Grant =

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -287,6 +287,14 @@ export interface ResourcePoolGrant {
   readonly regen: ResourcePoolRegen;
 }
 
+export interface SpellChoiceGrant {
+  readonly type: 'spell-choice';
+  readonly key: ChoiceKey;
+  readonly count: number;
+  readonly spellList: ClassId;
+  readonly spellLevel: number;
+}
+
 export type Grant =
   | AbilityBonusGrant
   | AbilityChoiceGrant
@@ -315,4 +323,5 @@ export type Grant =
   | FeatChoiceGrant
   | FeatureChoiceGrant
   | FeatGrant
-  | ResourcePoolGrant;
+  | ResourcePoolGrant
+  | SpellChoiceGrant;

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -223,6 +223,14 @@ export type PendingChoice =
         { readonly optionId: string; readonly featureId: string },
         ...{ readonly optionId: string; readonly featureId: string }[],
       ];
+    }
+  | {
+      readonly type: 'spell-choice';
+      readonly choiceKey: ChoiceKey;
+      readonly source: SourceTag;
+      readonly count: number;
+      readonly spellList: ClassId;
+      readonly spellLevel: number;
     };
 
 export interface ResolvedCharacter {

--- a/src/types/spells.ts
+++ b/src/types/spells.ts
@@ -1,0 +1,33 @@
+import type { ClassId } from '@/lib/dnd-helpers';
+import type { SpellId } from '@/lib/sources/spells';
+
+export type { SpellId };
+
+export type SpellSchool =
+  | 'abjuration'
+  | 'conjuration'
+  | 'divination'
+  | 'enchantment'
+  | 'evocation'
+  | 'illusion'
+  | 'necromancy'
+  | 'transmutation';
+
+export interface SpellComponents {
+  readonly verbal: boolean;
+  readonly somatic: boolean;
+  readonly material: string | false;
+}
+
+export interface SpellDef {
+  readonly id: string;
+  readonly level: 0 | 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
+  readonly school: SpellSchool;
+  readonly ritual: boolean;
+  readonly concentration: boolean;
+  readonly castingTime: string;
+  readonly range: string;
+  readonly components: SpellComponents;
+  readonly duration: string;
+  readonly nativeClasses: readonly ClassId[];
+}

--- a/src/types/spells.ts
+++ b/src/types/spells.ts
@@ -29,5 +29,5 @@ export interface SpellDef {
   readonly range: string;
   readonly components: SpellComponents;
   readonly duration: string;
-  readonly nativeClasses: readonly ClassId[];
+  readonly nativeClasses: readonly [ClassId, ...ClassId[]];
 }


### PR DESCRIPTION
Closes #82

## Summary
Adds the spell data catalog and the `spell-choice` grant — the shared blocker behind every cantrip / domain / oath / circle / patron spell follow-up. The spellcasting *resolver* already existed (#93); this adds the missing spell *data* and the *choice* mechanism. A Druid can now pick its level-1 cantrips end-to-end through the real pipeline.

## What Changed
**Spell data:**
- `src/types/spells.ts` (new) — `SpellDef`, `SpellSchool`, `SpellComponents`, derived `SpellId`.
- `src/lib/sources/spells.ts` (new) — `SPELL_CATALOG` (the 10 2024 PHB Druid cantrips, each tagged with full `nativeClasses`) + helpers `getSpellDef` / `requireSpellDef` / `getSpellsForList`.
- `src/locales/en/gamedata.json` — `spells.<id>.name`/`.description` for every catalog entry.

**`spell-choice` grant** (mirrors the multi-select `skill-choice` pattern):
- Threaded through `grants.ts` (Grant union), `choices.ts` (`CHOICE_CATEGORIES` + `ChoiceDecision`), `resolved.ts` (`PendingChoice`), `character-build.ts` (Zod arm — satisfies the compile-time parity assertion).
- `collectBundles` expands decided spell choices into spell grants; `resolveCharacter` emits a `PendingChoice` when underfilled.
- `resolveSpellcasting` now routes `level === 0` spells into `cantrips` (previously hard-coded `[]`).

**Cantrip wiring + UI:**
- Druid L1 gains a `spell-choice` grant (count 2, druid list, level 0).
- `ChoicePicker.tsx` — new count-capped multi-select branch; `ClassStep.tsx` renders class-origin spell choices. Verified the Druid cantrip picker surfaces in the builder.

## Scope (deferred to follow-ups)
Only the Druid cantrip list + Druid L1 wiring are included (satisfies acceptance). Other caster classes' cantrip grants, leveled `spell-choice`, full PHB catalog, and per-class always-prepared lists (#142/#144/#150/#152/#155/#157/#159/#161) are follow-ups — the catalog's `nativeClasses` tags mean adding a class is a grant-only change.

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 1720 pass (catalog integrity, spell-choice expansion, Druid L1 cantrip end-to-end, ChoicePicker branch)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)