### PR TITLE
[5.5e] Surface always-prepared (innate) spells on character sheets

### DIFF
--- a/src/components/character-builder/ClassStep.test.tsx
+++ b/src/components/character-builder/ClassStep.test.tsx
@@ -160,6 +160,22 @@ describe('ClassStep', () => {
     expect(screen.getByText(/Fire Bolt, Mage Hand, Prestidigitation/)).toBeTruthy();
   });
 
+  it('renders always-prepared section with translated spell names', () => {
+    mockContextValue.resolved = {
+      spellcasting: {
+        ...wizardSpellcasting(),
+        alwaysPreparedSpells: ['speak-with-animals'],
+      },
+    } as Partial<ResolvedCharacter>;
+
+    render(<ClassStep />);
+
+    // The i18n mock returns the last segment: spells.speak-with-animals.name -> "name"
+    // The alwaysPrepared label renders as "alwaysPrepared: " (with trailing colon+space)
+    expect(screen.getByText(/alwaysPrepared/)).toBeTruthy();
+    expect(screen.getByText('name')).toBeTruthy();
+  });
+
   it('renders fallback when class has no fighting styles and no spellcasting', () => {
     // default context: no bundles, no spellcasting
     render(<ClassStep />);

--- a/src/components/character-builder/ClassStep.tsx
+++ b/src/components/character-builder/ClassStep.tsx
@@ -10,6 +10,7 @@ import { FIGHTING_STYLE_SOURCES } from '@/lib/sources/fighting-styles';
 import type { PendingChoice } from '@/types/resolved';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { isSpellId } from '@/lib/sources/spells';
 
 interface FightingStyleChoiceInfo {
   readonly choiceKey: ChoiceKey;
@@ -163,13 +164,19 @@ export function ClassStep() {
           {spellcasting.cantrips.length > 0 && (
             <div>
               <span className="text-sm font-semibold">{tc('characterBuilder.classFeatures.cantrips')}: </span>
-              <span className="text-sm">{spellcasting.cantrips.join(', ')}</span>
+              <span className="text-sm">
+                {spellcasting.cantrips.map((id) => (isSpellId(id) ? t(`spells.${id}.name`) : id)).join(', ')}
+              </span>
             </div>
           )}
           {spellcasting.alwaysPreparedSpells.length > 0 && (
             <div>
               <span className="text-sm font-semibold">{tc('characterSheet.sections.alwaysPrepared')}: </span>
-              <span className="text-sm">{spellcasting.alwaysPreparedSpells.join(', ')}</span>
+              <span className="text-sm">
+                {spellcasting.alwaysPreparedSpells
+                  .map((id) => (isSpellId(id) ? t(`spells.${id}.name`) : id))
+                  .join(', ')}
+              </span>
             </div>
           )}
         </div>

--- a/src/components/character-builder/ClassStep.tsx
+++ b/src/components/character-builder/ClassStep.tsx
@@ -166,6 +166,12 @@ export function ClassStep() {
               <span className="text-sm">{spellcasting.cantrips.join(', ')}</span>
             </div>
           )}
+          {spellcasting.alwaysPreparedSpells.length > 0 && (
+            <div>
+              <span className="text-sm font-semibold">{tc('characterSheet.sections.alwaysPrepared')}: </span>
+              <span className="text-sm">{spellcasting.alwaysPreparedSpells.join(', ')}</span>
+            </div>
+          )}
         </div>
       )}
 

--- a/src/lib/resolver/spellcasting.test.ts
+++ b/src/lib/resolver/spellcasting.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect } from 'vitest';
+import { describe, it, expect, vi } from 'vitest';
 import { resolveSpellcasting } from '@/lib/resolver/spellcasting';
 import type { GrantBundle } from '@/types/sources';
 import type { AbilityKey } from '@/lib/dnd-helpers';
@@ -119,6 +119,14 @@ describe('resolveSpellcasting', () => {
   });
 
   describe('innate-only (non-spellcaster) with always-prepared spell grant', () => {
+    it('uncatalogued spell with alwaysPrepared=true still routes to alwaysPreparedSpells (and warns)', () => {
+      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {});
+      const result = resolveSpellcasting(makeInnateOnlyBundles('totally-unknown-spell'), defaultAbilities, 2, 3);
+      expect(result).not.toBeNull();
+      expect(result!.alwaysPreparedSpells).toContain('totally-unknown-spell');
+      warnSpy.mockRestore();
+    });
+
     it('returns non-null for non-spellcaster with alwaysPrepared spell grant', () => {
       const result = resolveSpellcasting(makeInnateOnlyBundles('speak-with-animals'), defaultAbilities, 2, 3);
       expect(result).not.toBeNull();

--- a/src/lib/resolver/spellcasting.test.ts
+++ b/src/lib/resolver/spellcasting.test.ts
@@ -98,6 +98,15 @@ function makeBardBundles(level: number): GrantBundle[] {
 
 const NO_BUNDLES: readonly GrantBundle[] = [];
 
+function makeInnateOnlyBundles(spellId: string): GrantBundle[] {
+  return [
+    {
+      source: { origin: 'subclass', id: 'wildheart', classId: 'barbarian', level: 3 },
+      grants: [{ type: 'spell', spellId, alwaysPrepared: true }],
+    },
+  ];
+}
+
 // ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
@@ -105,8 +114,40 @@ const NO_BUNDLES: readonly GrantBundle[] = [];
 describe('resolveSpellcasting', () => {
   const defaultAbilities = makeAbilities();
 
-  it('returns null when no spellcasting grants', () => {
+  it('returns null when no spellcasting grants and no spell grants', () => {
     expect(resolveSpellcasting(NO_BUNDLES, defaultAbilities, 2, 1)).toBeNull();
+  });
+
+  describe('innate-only (non-spellcaster) with always-prepared spell grant', () => {
+    it('returns non-null for non-spellcaster with alwaysPrepared spell grant', () => {
+      const result = resolveSpellcasting(makeInnateOnlyBundles('speak-with-animals'), defaultAbilities, 2, 3);
+      expect(result).not.toBeNull();
+    });
+
+    it('alwaysPreparedSpells contains the granted spell id', () => {
+      const result = resolveSpellcasting(makeInnateOnlyBundles('speak-with-animals'), defaultAbilities, 2, 3);
+      expect(result!.alwaysPreparedSpells).toEqual(['speak-with-animals']);
+    });
+
+    it('ability is null for innate-only caster', () => {
+      const result = resolveSpellcasting(makeInnateOnlyBundles('speak-with-animals'), defaultAbilities, 2, 3);
+      expect(result!.ability).toBeNull();
+    });
+
+    it('spellSaveDC is null for innate-only caster', () => {
+      const result = resolveSpellcasting(makeInnateOnlyBundles('speak-with-animals'), defaultAbilities, 2, 3);
+      expect(result!.spellSaveDC).toBeNull();
+    });
+
+    it('spellAttackBonus is null for innate-only caster', () => {
+      const result = resolveSpellcasting(makeInnateOnlyBundles('speak-with-animals'), defaultAbilities, 2, 3);
+      expect(result!.spellAttackBonus).toBeNull();
+    });
+
+    it('cantrips is empty array for innate-only caster', () => {
+      const result = resolveSpellcasting(makeInnateOnlyBundles('speak-with-animals'), defaultAbilities, 2, 3);
+      expect(result!.cantrips).toEqual([]);
+    });
   });
 
   it('computes spellSaveDC = 8 + proficiencyBonus + abilityMod', () => {

--- a/src/lib/resolver/spellcasting.ts
+++ b/src/lib/resolver/spellcasting.ts
@@ -1,5 +1,5 @@
 import type { GrantBundle } from '@/types/sources';
-import type { AbilityKey } from '@/lib/dnd-helpers';
+import type { AbilityKey, ClassId } from '@/lib/dnd-helpers';
 import type { ResolvedAbility, ResolvedSpellcasting } from '@/types/resolved';
 import { getPactMagicSlots, getPreparedSpellCount, getSpellSlots } from '@/lib/dnd-helpers';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
@@ -15,21 +15,33 @@ export function resolveSpellcasting(
   level: number
 ): ResolvedSpellcasting | null {
   const spellcastingGrants = collectGrantsByType(bundles, 'spellcasting');
-  if (spellcastingGrants.length === 0) return null;
+  const spellGrants = collectGrantsByType(bundles, 'spell');
 
-  const primary = spellcastingGrants.find((g) => g.grant.source === 'class') ?? spellcastingGrants[0];
-  const ability = primary.grant.ability;
-  const abilityMod = abilities[ability].modifier;
-  const spellSaveDC = 8 + proficiencyBonus + abilityMod;
-  const spellAttackBonus = proficiencyBonus + abilityMod;
+  if (spellcastingGrants.length === 0 && spellGrants.length === 0) return null;
 
-  const classId = primary.source.origin === 'class' ? primary.source.id : null;
+  let ability: AbilityKey | null = null;
+  let spellSaveDC: number | null = null;
+  let spellAttackBonus: number | null = null;
+  let classId: ClassId | null = null;
+  let abilityMod = 0;
+
+  if (spellcastingGrants.length > 0) {
+    const primary = spellcastingGrants.find((g) => g.grant.source === 'class') ?? spellcastingGrants[0];
+    ability = primary.grant.ability;
+    abilityMod = abilities[ability].modifier;
+    spellSaveDC = 8 + proficiencyBonus + abilityMod;
+    spellAttackBonus = proficiencyBonus + abilityMod;
+    classId = primary.source.origin === 'class' ? primary.source.id : null;
+  }
 
   const cantrips: string[] = [];
   const knownSpells: string[] = [];
   const alwaysPreparedSpells: string[] = [];
-  for (const { grant } of collectGrantsByType(bundles, 'spell')) {
+  for (const { grant } of spellGrants) {
     if (grant.alwaysPrepared) {
+      if (!getSpellDef(grant.spellId)) {
+        logger.warn(`always-prepared spell grant references uncatalogued spell "${grant.spellId}"`);
+      }
       alwaysPreparedSpells.push(grant.spellId);
     } else {
       const def = getSpellDef(grant.spellId);

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -1153,3 +1153,90 @@ describe('Druid L1 cantrip spell-choice (end-to-end)', () => {
     expect(spellChoicePending.length).toBe(1);
   });
 });
+
+// ---------------------------------------------------------------------------
+// Wildheart Barbarian — innate always-prepared spells e2e
+// ---------------------------------------------------------------------------
+
+describe('Wildheart Barbarian innate spells e2e', () => {
+  const subclassKey = createChoiceKey('subclass', 'class', 'barbarian', 0);
+
+  function makeWildheart(classLevel: number): CharacterBuild {
+    const levels = Array.from({ length: classLevel }, (_, i) => ({
+      classId: 'barbarian' as ClassId,
+      classLevel: i + 1,
+      hpRoll: i === 0 ? (null as null) : 7,
+    }));
+    return {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'soldier' as BackgroundId,
+      baseAbilities: { str: 16, dex: 13, con: 14, int: 8, wis: 12, cha: 10 },
+      abilityMethod: 'standard-array',
+      levels,
+      choices: {
+        [subclassKey]: { type: 'subclass' as const, subclassId: 'wildheart' as SubclassId },
+      },
+      feats: [],
+      activeItems: [],
+    };
+  }
+
+  it('Wildheart L3: resolved.spellcasting is non-null', () => {
+    const build = makeWildheart(3);
+    const { bundles, expandedFeats } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 3,
+      bundles,
+      choices: build.choices,
+      levels: build.levels,
+      expandedFeats,
+    });
+    expect(result.spellcasting).not.toBeNull();
+  });
+
+  it('Wildheart L3: alwaysPreparedSpells contains speak-with-animals', () => {
+    const build = makeWildheart(3);
+    const { bundles, expandedFeats } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 3,
+      bundles,
+      choices: build.choices,
+      levels: build.levels,
+      expandedFeats,
+    });
+    expect(result.spellcasting?.alwaysPreparedSpells).toContain('speak-with-animals');
+  });
+
+  it('Wildheart L3: ability/spellSaveDC/spellAttackBonus are null (no spellcasting grant)', () => {
+    const build = makeWildheart(3);
+    const { bundles, expandedFeats } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 3,
+      bundles,
+      choices: build.choices,
+      levels: build.levels,
+      expandedFeats,
+    });
+    expect(result.spellcasting?.ability).toBeNull();
+    expect(result.spellcasting?.spellSaveDC).toBeNull();
+    expect(result.spellcasting?.spellAttackBonus).toBeNull();
+  });
+
+  it('Wildheart L10: alwaysPreparedSpells contains both speak-with-animals and commune-with-nature', () => {
+    const build = makeWildheart(10);
+    const { bundles, expandedFeats } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 10,
+      bundles,
+      choices: build.choices,
+      levels: build.levels,
+      expandedFeats,
+    });
+    expect(result.spellcasting?.alwaysPreparedSpells).toContain('speak-with-animals');
+    expect(result.spellcasting?.alwaysPreparedSpells).toContain('commune-with-nature');
+  });
+});

--- a/src/lib/sources/spells.ts
+++ b/src/lib/sources/spells.ts
@@ -132,7 +132,7 @@ export const SPELL_CATALOG = [
     school: 'divination',
     ritual: true,
     concentration: false,
-    castingTime: '1 minute',
+    castingTime: 'Action',
     range: 'Self',
     components: { verbal: true, somatic: true, material: false },
     duration: '10 minutes',

--- a/src/lib/sources/spells.ts
+++ b/src/lib/sources/spells.ts
@@ -126,6 +126,30 @@ export const SPELL_CATALOG = [
     duration: 'Instantaneous',
     nativeClasses: ['druid'],
   },
+  {
+    id: 'speak-with-animals',
+    level: 1,
+    school: 'divination',
+    ritual: true,
+    concentration: false,
+    castingTime: '1 minute',
+    range: 'Self',
+    components: { verbal: true, somatic: true, material: false },
+    duration: '10 minutes',
+    nativeClasses: ['bard', 'druid', 'ranger'],
+  },
+  {
+    id: 'commune-with-nature',
+    level: 5,
+    school: 'divination',
+    ritual: true,
+    concentration: false,
+    castingTime: '1 minute',
+    range: 'Self',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Instantaneous',
+    nativeClasses: ['druid', 'ranger'],
+  },
 ] as const satisfies readonly SpellDef[];
 
 export type SpellId = (typeof SPELL_CATALOG)[number]['id'];

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -165,7 +165,7 @@ describe('getSubclassSource — Wild Heart', () => {
     expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
   });
 
-  it('wildheart level 3 grants 2 features: animal-speaker and rage-of-the-wilds', () => {
+  it('wildheart level 3 grants 2 grants: speak-with-animals spell and rage-of-the-wilds', () => {
     const source = getSubclassSource('wildheart');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
@@ -173,8 +173,9 @@ describe('getSubclassSource — Wild Heart', () => {
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
-          type: 'feature',
-          feature: expect.objectContaining({ id: 'wildheart-animal-speaker' }),
+          type: 'spell',
+          spellId: 'speak-with-animals',
+          alwaysPrepared: true,
         }),
         expect.objectContaining({
           type: 'feature',
@@ -195,14 +196,15 @@ describe('getSubclassSource — Wild Heart', () => {
     });
   });
 
-  it('wildheart level 10 grants nature-speaker feature', () => {
+  it('wildheart level 10 grants commune-with-nature spell (always prepared)', () => {
     const source = getSubclassSource('wildheart');
     const level10 = source?.features.find((f) => f.classLevel === 10);
     expect(level10).toBeDefined();
     expect(level10?.grants).toHaveLength(1);
     expect(level10?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'wildheart-nature-speaker' },
+      type: 'spell',
+      spellId: 'commune-with-nature',
+      alwaysPrepared: true,
     });
   });
 });

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -47,8 +47,7 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 3,
         grants: [
-          // TODO #93: model as spell grant when spell id system supports 'speak-with-animals'
-          { type: 'feature', feature: { id: 'wildheart-animal-speaker' } },
+          { type: 'spell', spellId: 'speak-with-animals', alwaysPrepared: true },
           // Beast Spirit (Bear/Eagle/Elk/Tiger/Wolf) is a free-form choice; no pending-choice
           // mechanism exists for arbitrary string options — modeled as inert feature grant for now
           { type: 'feature', feature: { id: 'wildheart-rage-of-the-wilds' } },
@@ -63,10 +62,7 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       },
       {
         classLevel: 10,
-        grants: [
-          // TODO #93: model as spell grant when spell id system supports 'commune-with-nature'
-          { type: 'feature', feature: { id: 'wildheart-nature-speaker' } },
-        ],
+        grants: [{ type: 'spell', spellId: 'commune-with-nature', alwaysPrepared: true }],
       },
     ] satisfies readonly SubclassFeature[],
   },

--- a/src/lib/spell-display.test.ts
+++ b/src/lib/spell-display.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import { getSpellDisplayMeta } from '@/lib/spell-display';
+
+describe('getSpellDisplayMeta', () => {
+  it('returns correct level and school for a catalogued spell id', () => {
+    const meta = getSpellDisplayMeta('speak-with-animals');
+    expect(meta).not.toBeNull();
+    expect(meta!.level).toBe(1);
+    expect(meta!.school).toBe('divination');
+  });
+
+  it('returns correct level and school for a cantrip', () => {
+    const meta = getSpellDisplayMeta('guidance');
+    expect(meta).not.toBeNull();
+    expect(meta!.level).toBe(0);
+    expect(meta!.school).toBe('divination');
+  });
+
+  it('returns null for an uncatalogued spell id', () => {
+    expect(getSpellDisplayMeta('totally-unknown-spell')).toBeNull();
+  });
+
+  it('returns null for an empty string', () => {
+    expect(getSpellDisplayMeta('')).toBeNull();
+  });
+});

--- a/src/lib/spell-display.ts
+++ b/src/lib/spell-display.ts
@@ -1,0 +1,18 @@
+import type { SpellSchool } from '@/types/spells';
+import { getSpellDef } from '@/lib/sources/spells';
+
+export interface SpellDisplayMeta {
+  readonly level: number;
+  readonly school: SpellSchool;
+}
+
+/**
+ * Returns catalog-level metadata for a spell by id, or null when the id is not
+ * in SPELL_CATALOG.  Name translation is intentionally left to the caller
+ * so this helper stays pure and framework-free.
+ */
+export function getSpellDisplayMeta(id: string): SpellDisplayMeta | null {
+  const def = getSpellDef(id);
+  if (!def) return null;
+  return { level: def.level, school: def.school };
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -372,6 +372,7 @@
       "backstory": "Backstory",
       "appearance": "Appearance",
       "cantrips": "CANTRIPS",
+      "alwaysPrepared": "ALWAYS PREPARED",
       "physicalTraits": "Physical Traits",
       "proficiencies": "Proficiencies",
       "attacks": "Attacks",

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -2476,6 +2476,14 @@
     "thorn-whip": {
       "name": "Thorn Whip",
       "description": "You create a long, vine-like whip covered in thorns that lashes out at your command toward a creature in range. Make a melee spell attack against the target. On a hit, the target takes 1d6 Piercing damage, and if it is Large or smaller, you pull the creature up to 10 feet closer to you."
+    },
+    "speak-with-animals": {
+      "name": "Speak with Animals",
+      "description": "For the duration, you can comprehend and verbally communicate with Beasts, and you can use the Influence action's skill options to alter their attitude."
+    },
+    "commune-with-nature": {
+      "name": "Commune with Nature",
+      "description": "You briefly become one with nature and gain knowledge of the surrounding territory (3 miles outdoors, 300 feet underground): learn up to three facts about terrain, creatures, water, plants, minerals, or magical effects nearby."
     }
   }
 }

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -715,10 +715,6 @@
       "name": "Intimidating Presence",
       "description": "As an Action, you can cause one creature you can see within 30 feet of you to make a WIS save (DC = 8 + your proficiency bonus + your STR or CHA modifier). On a failed save, the creature has the Frightened condition until the start of your next turn."
     },
-    "wildheart-animal-speaker": {
-      "name": "Animal Speaker",
-      "description": "You can cast Speak with Animals as a Ritual. Wisdom is your spellcasting ability for this spell."
-    },
     "wildheart-rage-of-the-wilds": {
       "name": "Rage of the Wilds",
       "description": "When you activate your Rage, you choose a Beast Spirit (Bear, Eagle, Elk, Tiger, or Wolf) and gain its associated benefit for the duration of your Rage."
@@ -726,10 +722,6 @@
     "wildheart-aspect-of-the-wilds": {
       "name": "Aspect of the Wilds",
       "description": "You gain an ongoing benefit based on the Beast Spirit you chose at level 3; this benefit can be changed on a Long Rest. Bear: resistance to one damage type. Eagle: you don't need to sleep and can't be forced to sleep. Elk: your Speed increases by 15 feet. Tiger: add d6 to one damage roll per turn. Wolf: knock a creature prone when you hit it with an opportunity attack."
-    },
-    "wildheart-nature-speaker": {
-      "name": "Nature Speaker",
-      "description": "You can cast Commune with Nature as a Ritual. Wisdom is your spellcasting ability for this spell."
     },
     "worldtree-vitality-of-the-tree": {
       "name": "Vitality of the Tree",

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -18,7 +18,8 @@ import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
 import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
 import { getGrantIcon, getSourceDisplayName } from '@/lib/class-icons';
 import { getItemDef, getItemNameKey } from '@/lib/sources/items';
-import { getSpellDef, isSpellId } from '@/lib/sources/spells';
+import { isSpellId } from '@/lib/sources/spells';
+import { getSpellDisplayMeta } from '@/lib/spell-display';
 import { useCharacter, useCharacterMutations } from '@/hooks/useCharacters';
 import { useCharacterBuildLevels, useCharacterItems } from '@/hooks/useCharacterBuild';
 import { usePageTitle } from '@/hooks/usePageTitle';
@@ -630,6 +631,9 @@ function CharacterSheetInner({
             )}
 
             {/* Spells */}
+            {/* knownSpells is not yet rendered — no UI surface exists for it.
+                When leveled known-spell grants land, extend this guard to include
+                resolved.spellcasting.knownSpells.length > 0 as well. */}
             {resolved?.spellcasting &&
               (resolved.spellcasting.cantrips.length > 0 || resolved.spellcasting.alwaysPreparedSpells.length > 0) && (
                 <div className="bg-card border border-purple-200 rounded-lg p-6">
@@ -656,13 +660,13 @@ function CharacterSheetInner({
                         </div>
                         <div className="space-y-1">
                           {resolved.spellcasting.alwaysPreparedSpells.map((id, i) => {
-                            const def = isSpellId(id) ? getSpellDef(id) : undefined;
+                            const meta = getSpellDisplayMeta(id);
                             return (
                               <div key={i} className="text-sm text-foreground">
                                 &bull; {isSpellId(id) ? t(`spells.${id}.name`) : id}
-                                {def && (
+                                {meta && (
                                   <span className="text-xs text-muted-foreground ml-2">
-                                    {`(lvl ${def.level} ${def.school})`}
+                                    {`(lvl ${meta.level} ${meta.school})`}
                                   </span>
                                 )}
                               </div>

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -18,6 +18,7 @@ import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
 import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
 import { getGrantIcon, getSourceDisplayName } from '@/lib/class-icons';
 import { getItemDef, getItemNameKey } from '@/lib/sources/items';
+import { getSpellDef, isSpellId } from '@/lib/sources/spells';
 import { useCharacter, useCharacterMutations } from '@/hooks/useCharacters';
 import { useCharacterBuildLevels, useCharacterItems } from '@/hooks/useCharacterBuild';
 import { usePageTitle } from '@/hooks/usePageTitle';
@@ -629,25 +630,50 @@ function CharacterSheetInner({
             )}
 
             {/* Spells */}
-            {resolved?.spellcasting && resolved.spellcasting.cantrips.length > 0 && (
-              <div className="bg-card border border-purple-200 rounded-lg p-6">
-                <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.spells')}</h2>
-                <div className="space-y-3">
-                  <div>
-                    <div className="text-xs font-bold text-muted-foreground mb-2">
-                      {tc('characterSheet.sections.cantrips')}
-                    </div>
-                    <div className="space-y-1">
-                      {resolved.spellcasting.cantrips.map((cantrip, i) => (
-                        <div key={i} className="text-sm text-foreground">
-                          &bull; {cantrip}
+            {resolved?.spellcasting &&
+              (resolved.spellcasting.cantrips.length > 0 || resolved.spellcasting.alwaysPreparedSpells.length > 0) && (
+                <div className="bg-card border border-purple-200 rounded-lg p-6">
+                  <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.spells')}</h2>
+                  <div className="space-y-3">
+                    {resolved.spellcasting.cantrips.length > 0 && (
+                      <div>
+                        <div className="text-xs font-bold text-muted-foreground mb-2">
+                          {tc('characterSheet.sections.cantrips')}
                         </div>
-                      ))}
-                    </div>
+                        <div className="space-y-1">
+                          {resolved.spellcasting.cantrips.map((cantrip, i) => (
+                            <div key={i} className="text-sm text-foreground">
+                              &bull; {cantrip}
+                            </div>
+                          ))}
+                        </div>
+                      </div>
+                    )}
+                    {resolved.spellcasting.alwaysPreparedSpells.length > 0 && (
+                      <div>
+                        <div className="text-xs font-bold text-muted-foreground mb-2">
+                          {tc('characterSheet.sections.alwaysPrepared')}
+                        </div>
+                        <div className="space-y-1">
+                          {resolved.spellcasting.alwaysPreparedSpells.map((id, i) => {
+                            const def = isSpellId(id) ? getSpellDef(id) : undefined;
+                            return (
+                              <div key={i} className="text-sm text-foreground">
+                                &bull; {isSpellId(id) ? t(`spells.${id}.name`) : id}
+                                {def && (
+                                  <span className="text-xs text-muted-foreground ml-2">
+                                    {`(lvl ${def.level} ${def.school})`}
+                                  </span>
+                                )}
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    )}
                   </div>
                 </div>
-              </div>
-            )}
+              )}
 
             {/* Personality */}
             {(character.personality_traits || character.ideals || character.bonds || character.flaws) && (

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -111,9 +111,9 @@ export interface ResolvedPactMagic {
  * casters (bard, sorcerer, warlock) and non-class spellcasting sources.
  */
 export interface ResolvedSpellcasting {
-  readonly ability: AbilityKey;
-  readonly spellSaveDC: number;
-  readonly spellAttackBonus: number;
+  readonly ability: AbilityKey | null;
+  readonly spellSaveDC: number | null;
+  readonly spellAttackBonus: number | null;
   readonly cantrips: readonly string[];
   readonly knownSpells: readonly string[];
   readonly alwaysPreparedSpells: readonly string[];


### PR DESCRIPTION
Closes #161

## Summary
Surfaces always-prepared (innate) spells on the character sheet, including for non-spellcasters, and wires the Wildheart Barbarian's ritual spells as the first real consumer. Builds on the #82 spell catalog (spells now have names/metadata to render).

## What Changed
**Resolver semantics (Blocker 1):** `resolveSpellcasting` previously returned `null` for any non-spellcaster, silently dropping `SpellGrant`s. It now returns a *partial* `ResolvedSpellcasting` when there are `spell` grants but no `SpellcastingGrant` — `alwaysPreparedSpells` is populated while `ability`/`spellSaveDC`/`spellAttackBonus` are `null` (so it doesn't pretend to be a full caster). Those three fields are now `number|null`/`AbilityKey|null` in `ResolvedSpellcasting`. Added a warning when an always-prepared spell id isn't in the catalog.

**Sheet UI (Blocker 2):** new "Always Prepared" section on `CharacterSheet.tsx` (and an inline display in the builder's `ClassStep`) listing each always-prepared spell by name + level/school. Previously nothing rendered `alwaysPreparedSpells`.

**Wildheart wiring (Blocker 3):** Wildheart Barbarian L3 → Speak with Animals, L10 → Commune with Nature, both as `{ type:'spell', alwaysPrepared:true }`. Catalog extended with `speak-with-animals` (L1) and `commune-with-nature` (L5) + i18n.

## Scope
Source attribution on `alwaysPreparedSpells` (would need a `Sourced<>` field), spell-slot UI (#49), and per-class domain/circle/oath spell *lists* (#142/#144/#150/...) are out of scope — this issue is the display layer they'll render through.

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 1743 pass (innate-only resolver, Wildheart wiring, e2e)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)