### PR TITLE
[5.5e] Sorcerer subclasses: subclass spells + Sorcery Points pool + Dragon Ancestor choice

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -74,9 +74,9 @@ missing: 0 · stub: 0 · partial: 45 · complete: 3 · golden-verified: 0/48
 | assassin | partial | has 3/9; missing 13/17 (rogue expects 3/9/13/17) | — |
 | arcanetrickster | partial | has 3/9; missing 13/17 (rogue expects 3/9/13/17) | — |
 | soulknife | partial | has 3/9; missing 13/17 (rogue expects 3/9/13/17) | — |
-| aberrantsorcery | partial | has 3/6; missing 14/18 (sorcerer expects 3/6/14/18) | — |
-| clockworksorcery | partial | has 3/6; missing 14/18 (sorcerer expects 3/6/14/18) | — |
-| draconicsorcery | partial | has 3/6; missing 14/18 (sorcerer expects 3/6/14/18) | — |
+| aberrantsorcery | partial | has 3/5/6/7/9; missing 14/18 (sorcerer expects 3/6/14/18) | — |
+| clockworksorcery | partial | has 3/5/6/7/9/14; missing 18 (sorcerer expects 3/6/14/18) | — |
+| draconicsorcery | partial | has 3/5/6/7/9; missing 14/18 (sorcerer expects 3/6/14/18) | — |
 | wildmagicsorcery | partial | has 3/6; missing 14/18 (sorcerer expects 3/6/14/18) | — |
 | archfeypatron | partial | has 3/6/10; missing 14 (warlock expects 3/6/10/14) | — |
 | celestialpatron | partial | has 3/6/10; missing 14 (warlock expects 3/6/10/14) | — |

--- a/src/lib/sources/classes.test.ts
+++ b/src/lib/sources/classes.test.ts
@@ -969,6 +969,19 @@ describe('Sorcerer class grant structures', () => {
       .map((g) => (g.type === 'feature' ? g.feature.id : ''));
     expect(featureIds).toContain('sorcerer-sorcerous-restoration');
   });
+
+  it('level 2 has resource-pool grant for sorcery-points with class-level max and long-rest regen', () => {
+    const grant = source?.levels[1].grants.find((g) => g.type === 'resource-pool');
+    expect(grant).toBeDefined();
+    if (grant?.type === 'resource-pool') {
+      expect(grant.poolId).toBe('sorcery-points');
+      expect(grant.max.mode).toBe('class-level');
+      if (grant.max.mode === 'class-level') {
+        expect(grant.max.classId).toBe('sorcerer');
+      }
+      expect(grant.regen).toBe('long-rest');
+    }
+  });
 });
 
 describe('Warlock class grant structures', () => {

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -948,6 +948,12 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
         grants: [
           { type: 'feature', feature: { id: 'sorcerer-font-of-magic' } },
           { type: 'feature', feature: { id: 'sorcerer-metamagic' } },
+          {
+            type: 'resource-pool',
+            poolId: 'sorcery-points',
+            max: { mode: 'class-level', classId: 'sorcerer' },
+            regen: 'long-rest',
+          },
         ],
       },
       { grants: [{ type: 'subclass', classId: 'sorcerer', key: createChoiceKey('subclass', 'class', 'sorcerer', 0) }] },

--- a/src/lib/sources/spells.ts
+++ b/src/lib/sources/spells.ts
@@ -1340,6 +1340,300 @@ export const SPELL_CATALOG = [
     // 2024 PHB: native to bard, sorcerer, wizard
     nativeClasses: ['bard', 'sorcerer', 'wizard'],
   },
+  // ─── Sorcerer subclass spells ─────────────────────────────────────────────
+  // Aberrant Sorcery L3
+  {
+    id: 'arms-of-hadar',
+    level: 1,
+    school: 'conjuration',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: 'Self',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Instantaneous',
+    // 2024 PHB: native to warlock
+    nativeClasses: ['warlock'],
+  },
+  {
+    id: 'calm-emotions',
+    level: 2,
+    school: 'enchantment',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: '60 feet',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Up to 1 minute',
+    // 2024 PHB: native to bard, cleric
+    nativeClasses: ['bard', 'cleric'],
+  },
+  {
+    id: 'detect-thoughts',
+    level: 2,
+    school: 'divination',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: 'Self',
+    components: { verbal: true, somatic: true, material: 'a copper piece' },
+    duration: 'Up to 1 minute',
+    // 2024 PHB: native to bard, sorcerer, wizard
+    nativeClasses: ['bard', 'sorcerer', 'wizard'],
+  },
+  {
+    id: 'dissonant-whispers',
+    level: 1,
+    school: 'enchantment',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: '60 feet',
+    components: { verbal: true, somatic: false, material: false },
+    duration: 'Instantaneous',
+    // 2024 PHB: native to bard, warlock, wizard
+    nativeClasses: ['bard', 'warlock', 'wizard'],
+  },
+  {
+    id: 'mind-sliver',
+    level: 0,
+    school: 'enchantment',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: '60 feet',
+    components: { verbal: true, somatic: false, material: false },
+    duration: 'Instantaneous',
+    // 2024 PHB: native to sorcerer, warlock, wizard
+    nativeClasses: ['sorcerer', 'warlock', 'wizard'],
+  },
+  // Aberrant Sorcery L5
+  {
+    id: 'hunger-of-hadar',
+    level: 3,
+    school: 'conjuration',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: '150 feet',
+    components: { verbal: true, somatic: true, material: 'a pickled octopus tentacle' },
+    duration: 'Up to 1 minute',
+    // 2024 PHB: native to warlock
+    nativeClasses: ['warlock'],
+  },
+  {
+    id: 'sending',
+    level: 3,
+    school: 'divination',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: 'Unlimited',
+    components: { verbal: true, somatic: true, material: 'a short piece of fine copper wire' },
+    duration: 'Instantaneous',
+    // 2024 PHB: native to bard, cleric, wizard
+    nativeClasses: ['bard', 'cleric', 'wizard'],
+  },
+  // Aberrant Sorcery L7
+  {
+    id: 'evards-black-tentacles',
+    level: 4,
+    school: 'conjuration',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: '90 feet',
+    components: { verbal: true, somatic: true, material: 'a piece of tentacle from a giant octopus or giant squid' },
+    duration: 'Up to 1 minute',
+    // 2024 PHB: native to wizard
+    nativeClasses: ['wizard'],
+  },
+  {
+    id: 'summon-aberration',
+    level: 4,
+    school: 'conjuration',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: '90 feet',
+    components: {
+      verbal: true,
+      somatic: true,
+      material: 'a pickled tentacle and an eyeball in a platinum-inlaid vial worth 400+ GP',
+    },
+    duration: 'Up to 1 hour',
+    // 2024 PHB: native to warlock, wizard
+    nativeClasses: ['warlock', 'wizard'],
+  },
+  // Aberrant Sorcery L9
+  {
+    id: 'rarys-telepathic-bond',
+    level: 5,
+    school: 'divination',
+    ritual: true,
+    concentration: false,
+    castingTime: 'Action',
+    range: '30 feet',
+    components: { verbal: true, somatic: true, material: 'two eggs' },
+    duration: '1 hour',
+    // 2024 PHB: native to wizard
+    nativeClasses: ['wizard'],
+  },
+  {
+    id: 'telekinesis',
+    level: 5,
+    school: 'transmutation',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: '60 feet',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Up to 10 minutes',
+    // 2024 PHB: native to sorcerer, wizard
+    nativeClasses: ['sorcerer', 'wizard'],
+  },
+  // Clockwork Sorcery L3
+  {
+    id: 'alarm',
+    level: 1,
+    school: 'abjuration',
+    ritual: true,
+    concentration: false,
+    castingTime: 'Action',
+    range: '30 feet',
+    components: { verbal: true, somatic: true, material: 'a tiny bell and a piece of fine silver wire' },
+    duration: '8 hours',
+    // 2024 PHB: native to ranger, wizard
+    nativeClasses: ['ranger', 'wizard'],
+  },
+  // Clockwork Sorcery L7
+  {
+    id: 'summon-construct',
+    level: 4,
+    school: 'conjuration',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: '90 feet',
+    components: { verbal: true, somatic: true, material: 'an ornate stone and metal lockbox worth 400+ GP' },
+    duration: 'Up to 1 hour',
+    // 2024 PHB: native to artificer, wizard
+    // Note: artificer is not a ClassId in this codebase; omitted; wizard confirmed native
+    nativeClasses: ['wizard'],
+  },
+  // Clockwork Sorcery L9
+  {
+    id: 'wall-of-force',
+    level: 5,
+    school: 'evocation',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: '120 feet',
+    components: { verbal: true, somatic: true, material: 'a pinch of powder made by crushing a clear gemstone' },
+    duration: 'Up to 10 minutes',
+    // 2024 PHB: native to wizard
+    nativeClasses: ['wizard'],
+  },
+  // Draconic Sorcery L3
+  {
+    id: 'alter-self',
+    level: 2,
+    school: 'transmutation',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: 'Self',
+    components: { verbal: true, somatic: true, material: false },
+    duration: 'Up to 1 hour',
+    // 2024 PHB: native to sorcerer, wizard
+    nativeClasses: ['sorcerer', 'wizard'],
+  },
+  {
+    id: 'chromatic-orb',
+    level: 1,
+    school: 'evocation',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: '90 feet',
+    components: { verbal: true, somatic: true, material: 'a diamond worth 50+ GP' },
+    duration: 'Instantaneous',
+    // 2024 PHB: native to sorcerer, wizard
+    nativeClasses: ['sorcerer', 'wizard'],
+  },
+  {
+    id: 'command',
+    level: 1,
+    school: 'enchantment',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: '60 feet',
+    components: { verbal: true, somatic: false, material: false },
+    duration: 'Instantaneous',
+    // 2024 PHB: native to bard, cleric, paladin
+    nativeClasses: ['bard', 'cleric', 'paladin'],
+  },
+  {
+    id: 'dragons-breath',
+    level: 2,
+    school: 'transmutation',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Bonus Action',
+    range: 'Touch',
+    components: { verbal: true, somatic: true, material: 'a hot pepper' },
+    duration: 'Up to 1 minute',
+    // 2024 PHB: native to sorcerer, wizard
+    nativeClasses: ['sorcerer', 'wizard'],
+  },
+  // Draconic Sorcery L5
+  {
+    id: 'fly',
+    level: 3,
+    school: 'transmutation',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: 'Touch',
+    components: { verbal: true, somatic: true, material: 'a wing feather from any bird' },
+    duration: 'Up to 10 minutes',
+    // 2024 PHB: native to sorcerer, warlock, wizard
+    nativeClasses: ['sorcerer', 'warlock', 'wizard'],
+  },
+  // Draconic Sorcery L7
+  {
+    id: 'charm-monster',
+    level: 4,
+    school: 'enchantment',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Action',
+    range: '30 feet',
+    components: { verbal: true, somatic: true, material: false },
+    duration: '1 hour',
+    // 2024 PHB: native to bard, druid, sorcerer, warlock, wizard
+    nativeClasses: ['bard', 'druid', 'sorcerer', 'warlock', 'wizard'],
+  },
+  // Draconic Sorcery L9
+  {
+    id: 'summon-dragon',
+    level: 5,
+    school: 'conjuration',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: '60 feet',
+    components: {
+      verbal: true,
+      somatic: true,
+      material: 'an object with the image of a dragon engraved on it worth 500+ GP',
+    },
+    duration: 'Up to 1 hour',
+    // 2024 PHB: native to wizard
+    nativeClasses: ['wizard'],
+  },
 ] as const satisfies readonly SpellDef[];
 
 export type SpellId = (typeof SPELL_CATALOG)[number]['id'];

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -2063,47 +2063,94 @@ describe('getSubclassSource — Aberrant Sorcery', () => {
     expect(getSubclassSource('aberrantsorcery')).toBeDefined();
   });
 
-  it('aberrantsorcery has 2 feature levels (L3, L6)', () => {
+  it('aberrantsorcery has 5 feature levels (L3, L5, L6, L7, L9)', () => {
     const source = getSubclassSource('aberrantsorcery');
-    expect(source?.features).toHaveLength(2);
-    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+    expect(source?.features).toHaveLength(5);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 5, 6, 7, 9]);
   });
 
-  it('aberrantsorcery level 3 grants 3 features: telepathic-speech, psionic-sorcery, subclass-spells', () => {
+  it('aberrantsorcery level 3 grants telepathic-speech feature and 4 L3 spell grants (no subclass-spells stub)', () => {
     const source = getSubclassSource('aberrantsorcery');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
-    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toHaveLength(6);
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: 'feature',
           feature: expect.objectContaining({ id: 'aberrantsorcery-telepathic-speech' }),
         }),
-        expect.objectContaining({
-          type: 'feature',
-          feature: expect.objectContaining({ id: 'aberrantsorcery-psionic-sorcery' }),
-        }),
-        expect.objectContaining({
-          type: 'feature',
-          feature: expect.objectContaining({ id: 'aberrantsorcery-subclass-spells' }),
-        }),
+        expect.objectContaining({ type: 'spell', spellId: 'arms-of-hadar', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'calm-emotions', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'detect-thoughts', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'dissonant-whispers', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'mind-sliver', alwaysPrepared: false }),
+      ])
+    );
+    // mind-sliver is a cantrip (alwaysPrepared:false routes it to cantrips list)
+    const mindSliver = level3?.grants.find((g) => g.type === 'spell' && g.spellId === 'mind-sliver');
+    expect(mindSliver).toMatchObject({ type: 'spell', spellId: 'mind-sliver', alwaysPrepared: false });
+    // no inert subclass-spells stub
+    expect(level3?.grants.some((g) => g.type === 'feature' && g.feature.id === 'aberrantsorcery-subclass-spells')).toBe(
+      false
+    );
+  });
+
+  it('aberrantsorcery level 5 has hunger-of-hadar and sending spell grants', () => {
+    const source = getSubclassSource('aberrantsorcery');
+    const level5 = source?.features.find((f) => f.classLevel === 5);
+    expect(level5).toBeDefined();
+    expect(level5?.grants).toHaveLength(2);
+    expect(level5?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'spell', spellId: 'hunger-of-hadar', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'sending', alwaysPrepared: true }),
       ])
     );
   });
 
-  it('aberrantsorcery level 6 grants 2 items: psychic resistance and psychic-defenses feature', () => {
+  it('aberrantsorcery level 6 grants psionic-sorcery feature, psychic resistance, and psychic-defenses (2024 PHB places psionic-sorcery at L6)', () => {
     const source = getSubclassSource('aberrantsorcery');
     const level6 = source?.features.find((f) => f.classLevel === 6);
     expect(level6).toBeDefined();
-    expect(level6?.grants).toHaveLength(2);
+    expect(level6?.grants).toHaveLength(3);
     expect(level6?.grants).toEqual(
       expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'aberrantsorcery-psionic-sorcery' }),
+        }),
         expect.objectContaining({ type: 'resistance', damageType: 'psychic' }),
         expect.objectContaining({
           type: 'feature',
           feature: expect.objectContaining({ id: 'aberrantsorcery-psychic-defenses' }),
         }),
+      ])
+    );
+  });
+
+  it('aberrantsorcery level 7 has evards-black-tentacles and summon-aberration spell grants', () => {
+    const source = getSubclassSource('aberrantsorcery');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(2);
+    expect(level7?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'spell', spellId: 'evards-black-tentacles', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'summon-aberration', alwaysPrepared: true }),
+      ])
+    );
+  });
+
+  it('aberrantsorcery level 9 has rarys-telepathic-bond and telekinesis spell grants', () => {
+    const source = getSubclassSource('aberrantsorcery');
+    const level9 = source?.features.find((f) => f.classLevel === 9);
+    expect(level9).toBeDefined();
+    expect(level9?.grants).toHaveLength(2);
+    expect(level9?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'spell', spellId: 'rarys-telepathic-bond', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'telekinesis', alwaysPrepared: true }),
       ])
     );
   });
@@ -2114,33 +2161,37 @@ describe('getSubclassSource — Clockwork Sorcery', () => {
     expect(getSubclassSource('clockworksorcery')).toBeDefined();
   });
 
-  it('clockworksorcery has 2 feature levels (L3, L6)', () => {
+  it('clockworksorcery has 6 feature levels (L3, L5, L6, L7, L9, L14)', () => {
     const source = getSubclassSource('clockworksorcery');
-    expect(source?.features).toHaveLength(2);
-    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+    expect(source?.features).toHaveLength(6);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 5, 6, 7, 9, 14]);
   });
 
-  it('clockworksorcery level 3 grants 3 features: restore-balance, trance-of-order, subclass-spells', () => {
+  it('clockworksorcery level 3 grants restore-balance feature and 4 L3 spell grants (no subclass-spells stub, no trance-of-order)', () => {
     const source = getSubclassSource('clockworksorcery');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
-    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toHaveLength(5);
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: 'feature',
           feature: expect.objectContaining({ id: 'clockworksorcery-restore-balance' }),
         }),
-        expect.objectContaining({
-          type: 'feature',
-          feature: expect.objectContaining({ id: 'clockworksorcery-trance-of-order' }),
-        }),
-        expect.objectContaining({
-          type: 'feature',
-          feature: expect.objectContaining({ id: 'clockworksorcery-subclass-spells' }),
-        }),
+        expect.objectContaining({ type: 'spell', spellId: 'aid', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'alarm', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'lesser-restoration', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'protection-from-evil-and-good', alwaysPrepared: true }),
       ])
     );
+    // no inert subclass-spells stub
+    expect(
+      level3?.grants.some((g) => g.type === 'feature' && g.feature.id === 'clockworksorcery-subclass-spells')
+    ).toBe(false);
+    // trance-of-order NOT at L3 (relocated to L14 per 2024 PHB)
+    expect(
+      level3?.grants.some((g) => g.type === 'feature' && g.feature.id === 'clockworksorcery-trance-of-order')
+    ).toBe(false);
   });
 
   it('clockworksorcery level 6 grants 1 feature: bastion-of-law', () => {
@@ -2153,6 +2204,17 @@ describe('getSubclassSource — Clockwork Sorcery', () => {
       feature: { id: 'clockworksorcery-bastion-of-law' },
     });
   });
+
+  it('clockworksorcery level 14 grants trance-of-order feature (2024 PHB placement)', () => {
+    const source = getSubclassSource('clockworksorcery');
+    const level14 = source?.features.find((f) => f.classLevel === 14);
+    expect(level14).toBeDefined();
+    expect(level14?.grants).toHaveLength(1);
+    expect(level14?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'clockworksorcery-trance-of-order' },
+    });
+  });
 });
 
 describe('getSubclassSource — Draconic Sorcery', () => {
@@ -2160,32 +2222,39 @@ describe('getSubclassSource — Draconic Sorcery', () => {
     expect(getSubclassSource('draconicsorcery')).toBeDefined();
   });
 
-  it('draconicsorcery has 2 feature levels (L3, L6)', () => {
+  it('draconicsorcery has 5 feature levels (L3, L5, L6, L7, L9)', () => {
     const source = getSubclassSource('draconicsorcery');
-    expect(source?.features).toHaveLength(2);
-    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
+    expect(source?.features).toHaveLength(5);
+    expect(source?.features.map((f) => f.classLevel)).toEqual([3, 5, 6, 7, 9]);
   });
 
-  it('draconicsorcery level 3 grants 5 items: hp-bonus, armor-class, draconic language, dragon-ancestor feature, subclass-spells feature', () => {
+  it('draconicsorcery level 3 grants 8 items: hp-bonus, armor-class, draconic language, 10-option feature-choice, 4 spell grants (no inert stubs)', () => {
     const source = getSubclassSource('draconicsorcery');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
-    expect(level3?.grants).toHaveLength(5);
+    expect(level3?.grants).toHaveLength(8);
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ type: 'hp-bonus', perLevel: 1 }),
         expect.objectContaining({ type: 'armor-class', calculation: { mode: 'natural', baseAc: 13 } }),
         expect.objectContaining({ type: 'proficiency', category: 'language', id: 'draconic' }),
-        expect.objectContaining({
-          type: 'feature',
-          feature: expect.objectContaining({ id: 'draconicsorcery-dragon-ancestor' }),
-        }),
-        expect.objectContaining({
-          type: 'feature',
-          feature: expect.objectContaining({ id: 'draconicsorcery-subclass-spells' }),
-        }),
+        expect.objectContaining({ type: 'feature-choice' }),
+        expect.objectContaining({ type: 'spell', spellId: 'alter-self', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'chromatic-orb', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'command', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'dragons-breath', alwaysPrepared: true }),
       ])
     );
+    // no inert feature stubs
+    expect(level3?.grants.some((g) => g.type === 'feature' && g.feature.id === 'draconicsorcery-dragon-ancestor')).toBe(
+      false
+    );
+    expect(level3?.grants.some((g) => g.type === 'feature' && g.feature.id === 'draconicsorcery-subclass-spells')).toBe(
+      false
+    );
+    // feature-choice has 10 options
+    const choice = level3?.grants.find((g) => g.type === 'feature-choice');
+    expect(choice?.type === 'feature-choice' && choice.options).toHaveLength(10);
   });
 
   it('draconicsorcery level 6 grants 1 feature: elemental-affinity', () => {
@@ -2211,11 +2280,11 @@ describe('getSubclassSource — Wild Magic Sorcery', () => {
     expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6]);
   });
 
-  it('wildmagicsorcery level 3 grants 3 features: wild-magic-surge, tides-of-chaos, subclass-spells', () => {
+  it('wildmagicsorcery level 3 grants 2 features: wild-magic-surge and tides-of-chaos (no subclass spells, no subclass-spells stub)', () => {
     const source = getSubclassSource('wildmagicsorcery');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
-    expect(level3?.grants).toHaveLength(3);
+    expect(level3?.grants).toHaveLength(2);
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -2226,12 +2295,14 @@ describe('getSubclassSource — Wild Magic Sorcery', () => {
           type: 'feature',
           feature: expect.objectContaining({ id: 'wildmagicsorcery-tides-of-chaos' }),
         }),
-        expect.objectContaining({
-          type: 'feature',
-          feature: expect.objectContaining({ id: 'wildmagicsorcery-subclass-spells' }),
-        }),
       ])
     );
+    // no spell grants — 2024 Wild Magic has no subclass spell list
+    expect(level3?.grants.some((g) => g.type === 'spell')).toBe(false);
+    // no inert subclass-spells stub
+    expect(
+      level3?.grants.some((g) => g.type === 'feature' && g.feature.id === 'wildmagicsorcery-subclass-spells')
+    ).toBe(false);
   });
 
   it('wildmagicsorcery level 6 grants 1 feature: bend-luck', () => {

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -3146,3 +3146,175 @@ describe('Ranger Gloom Stalker resolver integration', () => {
     expect(resolved.savingThrows.wis.proficient).toBe(false);
   });
 });
+
+// ── Resolver integration: Sorcerer subclasses ────────────────────────────────
+
+describe('Sorcerer Aberrant Sorcery resolver integration', () => {
+  const subclassKey = createChoiceKey('subclass', 'class', 'sorcerer', 0);
+
+  function makeAberrantBuild(classLevels: number): CharacterBuild {
+    const levels = Array.from({ length: classLevels }, (_, i) => ({
+      classId: 'sorcerer' as ClassId,
+      classLevel: i + 1,
+      hpRoll: i === 0 ? null : 4,
+    }));
+    return {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'acolyte' as BackgroundId,
+      baseAbilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 16 },
+      abilityMethod: 'standard-array',
+      levels,
+      choices: {
+        [subclassKey]: { type: 'subclass' as const, subclassId: 'aberrantsorcery' as SubclassId },
+      },
+      feats: [],
+      activeItems: [],
+    };
+  }
+
+  it('Sorcerer L5 Aberrant: alwaysPreparedSpells includes L3 spells (arms-of-hadar, dissonant-whispers) and L5 spells (hunger-of-hadar, sending)', () => {
+    const build = makeAberrantBuild(5);
+    const { bundles, expandedFeats } = collectBundles(build);
+    const resolved = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 5,
+      bundles,
+      choices: build.choices,
+      expandedFeats,
+    });
+    const prepared = resolved.spellcasting!.alwaysPreparedSpells;
+    expect(prepared).toContain('arms-of-hadar');
+    expect(prepared).toContain('calm-emotions');
+    expect(prepared).toContain('detect-thoughts');
+    expect(prepared).toContain('dissonant-whispers');
+    expect(prepared).toContain('hunger-of-hadar');
+    expect(prepared).toContain('sending');
+  });
+
+  it('Sorcerer L5 Aberrant: alwaysPreparedSpells does NOT include L7 spells (evards-black-tentacles)', () => {
+    const build = makeAberrantBuild(5);
+    const { bundles, expandedFeats } = collectBundles(build);
+    const resolved = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 5,
+      bundles,
+      choices: build.choices,
+      expandedFeats,
+    });
+    expect(resolved.spellcasting!.alwaysPreparedSpells).not.toContain('evards-black-tentacles');
+    expect(resolved.spellcasting!.alwaysPreparedSpells).not.toContain('summon-aberration');
+  });
+
+  it('Sorcerer L5 Aberrant: mind-sliver is in cantrips (not alwaysPreparedSpells)', () => {
+    const build = makeAberrantBuild(5);
+    const { bundles, expandedFeats } = collectBundles(build);
+    const resolved = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 5,
+      bundles,
+      choices: build.choices,
+      expandedFeats,
+    });
+    expect(resolved.spellcasting!.cantrips).toContain('mind-sliver');
+    expect(resolved.spellcasting!.alwaysPreparedSpells).not.toContain('mind-sliver');
+  });
+});
+
+describe('Sorcerer resource pool resolver integration', () => {
+  it('Sorcerer L2: resourcePools includes sorcery-points with max=2 and long-rest regen', () => {
+    const subclassKey = createChoiceKey('subclass', 'class', 'sorcerer', 0);
+    const build: CharacterBuild = {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'acolyte' as BackgroundId,
+      baseAbilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 16 },
+      abilityMethod: 'standard-array',
+      levels: [
+        { classId: 'sorcerer' as ClassId, classLevel: 1, hpRoll: null },
+        { classId: 'sorcerer' as ClassId, classLevel: 2, hpRoll: 4 },
+      ],
+      choices: {
+        [subclassKey]: { type: 'subclass' as const, subclassId: 'wildmagicsorcery' as SubclassId },
+      },
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles, expandedFeats } = collectBundles(build);
+    const resolved = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 2,
+      bundles,
+      choices: build.choices,
+      expandedFeats,
+    });
+    const pool = resolved.resourcePools.find((p) => p.poolId === 'sorcery-points');
+    expect(pool).toBeDefined();
+    expect(pool?.max).toBe(2);
+    expect(pool?.regen).toBe('long-rest');
+  });
+});
+
+describe('Sorcerer Draconic Sorcery Dragon Ancestor resolver integration', () => {
+  const subclassKey = createChoiceKey('subclass', 'class', 'sorcerer', 0);
+  const dragonAncestorKey = createChoiceKey('feature-choice', 'subclass', 'draconicsorcery', 0);
+
+  const baseBuild: CharacterBuild = {
+    speciesId: 'human' as SpeciesId,
+    backgroundId: 'acolyte' as BackgroundId,
+    baseAbilities: { str: 10, dex: 10, con: 10, int: 10, wis: 10, cha: 16 },
+    abilityMethod: 'standard-array',
+    levels: [
+      { classId: 'sorcerer' as ClassId, classLevel: 1, hpRoll: null },
+      { classId: 'sorcerer' as ClassId, classLevel: 2, hpRoll: 4 },
+      { classId: 'sorcerer' as ClassId, classLevel: 3, hpRoll: 4 },
+    ],
+    choices: {
+      [subclassKey]: { type: 'subclass' as const, subclassId: 'draconicsorcery' as SubclassId },
+    },
+    feats: [],
+    activeItems: [],
+  };
+
+  it('Draconic L3 undecided: emits a pending feature-choice for dragon ancestor (subclass origin)', () => {
+    const { bundles, expandedFeats } = collectBundles(baseBuild);
+    const resolved = resolveCharacter({
+      baseAbilities: baseBuild.baseAbilities,
+      level: 3,
+      bundles,
+      choices: baseBuild.choices,
+      expandedFeats,
+    });
+    const pending = resolved.pendingChoices.find(
+      (c) => c.type === 'feature-choice' && c.choiceKey === dragonAncestorKey
+    );
+    expect(pending).toBeDefined();
+    if (pending?.type === 'feature-choice') {
+      expect(pending.options).toHaveLength(10);
+      const optionIds = pending.options.map((o) => o.optionId);
+      expect(optionIds).toContain('red');
+      expect(optionIds).toContain('gold');
+      expect(optionIds).toContain('silver');
+    }
+  });
+
+  it('Draconic L3 with red dragon choice: no pending dragon-ancestor feature-choice', () => {
+    const build: CharacterBuild = {
+      ...baseBuild,
+      choices: {
+        ...baseBuild.choices,
+        [dragonAncestorKey]: { type: 'feature-choice' as const, optionId: 'red' },
+      },
+    };
+    const { bundles, expandedFeats } = collectBundles(build);
+    const resolved = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 3,
+      bundles,
+      choices: build.choices,
+      expandedFeats,
+    });
+    const pending = resolved.pendingChoices.find(
+      (c) => c.type === 'feature-choice' && c.choiceKey === dragonAncestorKey
+    );
+    expect(pending).toBeUndefined();
+  });
+});

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -2094,6 +2094,10 @@ describe('getSubclassSource — Aberrant Sorcery', () => {
     expect(level3?.grants.some((g) => g.type === 'feature' && g.feature.id === 'aberrantsorcery-subclass-spells')).toBe(
       false
     );
+    // psionic-sorcery NOT at L3 (relocated to L6 per 2024 PHB)
+    expect(level3?.grants.some((g) => g.type === 'feature' && g.feature.id === 'aberrantsorcery-psionic-sorcery')).toBe(
+      false
+    );
   });
 
   it('aberrantsorcery level 5 has hunger-of-hadar and sending spell grants', () => {
@@ -2205,6 +2209,45 @@ describe('getSubclassSource — Clockwork Sorcery', () => {
     });
   });
 
+  it('clockworksorcery level 5 has dispel-magic and protection-from-energy spell grants', () => {
+    const source = getSubclassSource('clockworksorcery');
+    const level5 = source?.features.find((f) => f.classLevel === 5);
+    expect(level5).toBeDefined();
+    expect(level5?.grants).toHaveLength(2);
+    expect(level5?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'spell', spellId: 'dispel-magic', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'protection-from-energy', alwaysPrepared: true }),
+      ])
+    );
+  });
+
+  it('clockworksorcery level 7 has freedom-of-movement and summon-construct spell grants', () => {
+    const source = getSubclassSource('clockworksorcery');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(2);
+    expect(level7?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'spell', spellId: 'freedom-of-movement', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'summon-construct', alwaysPrepared: true }),
+      ])
+    );
+  });
+
+  it('clockworksorcery level 9 has greater-restoration and wall-of-force spell grants', () => {
+    const source = getSubclassSource('clockworksorcery');
+    const level9 = source?.features.find((f) => f.classLevel === 9);
+    expect(level9).toBeDefined();
+    expect(level9?.grants).toHaveLength(2);
+    expect(level9?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'spell', spellId: 'greater-restoration', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'wall-of-force', alwaysPrepared: true }),
+      ])
+    );
+  });
+
   it('clockworksorcery level 14 grants trance-of-order feature (2024 PHB placement)', () => {
     const source = getSubclassSource('clockworksorcery');
     const level14 = source?.features.find((f) => f.classLevel === 14);
@@ -2255,6 +2298,45 @@ describe('getSubclassSource — Draconic Sorcery', () => {
     // feature-choice has 10 options
     const choice = level3?.grants.find((g) => g.type === 'feature-choice');
     expect(choice?.type === 'feature-choice' && choice.options).toHaveLength(10);
+  });
+
+  it('draconicsorcery level 5 has fear and fly spell grants', () => {
+    const source = getSubclassSource('draconicsorcery');
+    const level5 = source?.features.find((f) => f.classLevel === 5);
+    expect(level5).toBeDefined();
+    expect(level5?.grants).toHaveLength(2);
+    expect(level5?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'spell', spellId: 'fear', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'fly', alwaysPrepared: true }),
+      ])
+    );
+  });
+
+  it('draconicsorcery level 7 has arcane-eye and charm-monster spell grants', () => {
+    const source = getSubclassSource('draconicsorcery');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    expect(level7).toBeDefined();
+    expect(level7?.grants).toHaveLength(2);
+    expect(level7?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'spell', spellId: 'arcane-eye', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'charm-monster', alwaysPrepared: true }),
+      ])
+    );
+  });
+
+  it('draconicsorcery level 9 has legend-lore and summon-dragon spell grants', () => {
+    const source = getSubclassSource('draconicsorcery');
+    const level9 = source?.features.find((f) => f.classLevel === 9);
+    expect(level9).toBeDefined();
+    expect(level9?.grants).toHaveLength(2);
+    expect(level9?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'spell', spellId: 'legend-lore', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'summon-dragon', alwaysPrepared: true }),
+      ])
+    );
   });
 
   it('draconicsorcery level 6 grants 1 feature: elemental-affinity', () => {
@@ -3316,5 +3398,25 @@ describe('Sorcerer Draconic Sorcery Dragon Ancestor resolver integration', () =>
       (c) => c.type === 'feature-choice' && c.choiceKey === dragonAncestorKey
     );
     expect(pending).toBeUndefined();
+  });
+
+  it('Draconic L3 with red dragon choice: result.features contains draconicsorcery-dragon-ancestor-red', () => {
+    const build: CharacterBuild = {
+      ...baseBuild,
+      choices: {
+        ...baseBuild.choices,
+        [dragonAncestorKey]: { type: 'feature-choice' as const, optionId: 'red' },
+      },
+    };
+    const { bundles, expandedFeats } = collectBundles(build);
+    const resolved = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 3,
+      bundles,
+      choices: build.choices,
+      expandedFeats,
+    });
+    const featureIds = resolved.features.map((f) => f.feature.id);
+    expect(featureIds).toContain('draconicsorcery-dragon-ancestor-red');
   });
 });

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -1197,19 +1197,45 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
         grants: [
           // Telepathic Speech: speak telepathically to one willing creature within 30 ft for 10 min (Intelligence-focused)
           { type: 'feature', feature: { id: 'aberrantsorcery-telepathic-speech' } },
-          // Psionic Sorcery: cast subclass spells without V/M components by spending additional Sorcery Points
-          { type: 'feature', feature: { id: 'aberrantsorcery-psionic-sorcery' } },
-          // TODO #93: model as spell grants when spell id system is available
-          { type: 'feature', feature: { id: 'aberrantsorcery-subclass-spells' } },
+          // Expanded spells (always prepared); mind-sliver is a cantrip (alwaysPrepared:false routes it to cantrips)
+          { type: 'spell', spellId: 'arms-of-hadar', alwaysPrepared: true },
+          { type: 'spell', spellId: 'calm-emotions', alwaysPrepared: true },
+          { type: 'spell', spellId: 'detect-thoughts', alwaysPrepared: true },
+          { type: 'spell', spellId: 'dissonant-whispers', alwaysPrepared: true },
+          { type: 'spell', spellId: 'mind-sliver', alwaysPrepared: false },
+        ],
+      },
+      {
+        classLevel: 5,
+        grants: [
+          { type: 'spell', spellId: 'hunger-of-hadar', alwaysPrepared: true },
+          { type: 'spell', spellId: 'sending', alwaysPrepared: true },
         ],
       },
       {
         classLevel: 6,
         grants: [
+          // Psionic Sorcery: cast subclass spells without V/M components by spending additional Sorcery Points
+          // (2024 PHB places this at L6, not L3)
+          { type: 'feature', feature: { id: 'aberrantsorcery-psionic-sorcery' } },
           // Resistance to psychic damage (structural grant)
           { type: 'resistance', damageType: 'psychic' },
           // Psychic Defenses: advantage on saving throws vs Charmed and Frightened conditions
           { type: 'feature', feature: { id: 'aberrantsorcery-psychic-defenses' } },
+        ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          { type: 'spell', spellId: 'evards-black-tentacles', alwaysPrepared: true },
+          { type: 'spell', spellId: 'summon-aberration', alwaysPrepared: true },
+        ],
+      },
+      {
+        classLevel: 9,
+        grants: [
+          { type: 'spell', spellId: 'rarys-telepathic-bond', alwaysPrepared: true },
+          { type: 'spell', spellId: 'telekinesis', alwaysPrepared: true },
         ],
       },
     ] satisfies readonly SubclassFeature[],
@@ -1221,10 +1247,18 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
         grants: [
           // Restore Balance: Reaction within 60 ft — cancel Advantage or Disadvantage on a roll (PB/long rest)
           { type: 'feature', feature: { id: 'clockworksorcery-restore-balance' } },
-          // Trance of Order: 1 min — no crits against you; treat 9-or-lower d20 as 10 once per turn
-          { type: 'feature', feature: { id: 'clockworksorcery-trance-of-order' } },
-          // TODO #93: model as spell grants when spell id system is available
-          { type: 'feature', feature: { id: 'clockworksorcery-subclass-spells' } },
+          // Expanded spells (always prepared)
+          { type: 'spell', spellId: 'aid', alwaysPrepared: true },
+          { type: 'spell', spellId: 'alarm', alwaysPrepared: true },
+          { type: 'spell', spellId: 'lesser-restoration', alwaysPrepared: true },
+          { type: 'spell', spellId: 'protection-from-evil-and-good', alwaysPrepared: true },
+        ],
+      },
+      {
+        classLevel: 5,
+        grants: [
+          { type: 'spell', spellId: 'dispel-magic', alwaysPrepared: true },
+          { type: 'spell', spellId: 'protection-from-energy', alwaysPrepared: true },
         ],
       },
       {
@@ -1233,6 +1267,25 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
           // Bastion of Law: spend 1–5 Sorcery Points to create d8-per-SP ward on a creature within 30 ft
           { type: 'feature', feature: { id: 'clockworksorcery-bastion-of-law' } },
         ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          { type: 'spell', spellId: 'freedom-of-movement', alwaysPrepared: true },
+          { type: 'spell', spellId: 'summon-construct', alwaysPrepared: true },
+        ],
+      },
+      {
+        classLevel: 9,
+        grants: [
+          { type: 'spell', spellId: 'greater-restoration', alwaysPrepared: true },
+          { type: 'spell', spellId: 'wall-of-force', alwaysPrepared: true },
+        ],
+      },
+      {
+        // Trance of Order: 2024 PHB places this at L14 (not L3)
+        classLevel: 14,
+        grants: [{ type: 'feature', feature: { id: 'clockworksorcery-trance-of-order' } }],
       },
     ] satisfies readonly SubclassFeature[],
   },
@@ -1247,11 +1300,35 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
           { type: 'armor-class', calculation: { mode: 'natural', baseAc: 13 } },
           // Dragon Ancestor: gain proficiency in Draconic language
           { type: 'proficiency', category: 'language', id: 'draconic' },
-          // Dragon Ancestor: free-form 1-of-10 ancestry choice (Black/Blue/Brass/Bronze/Copper/Gold/Green/Red/Silver/White);
-          // no pending-choice mechanism for arbitrary dragon type options — modeled as inert feature grant
-          { type: 'feature', feature: { id: 'draconicsorcery-dragon-ancestor' } },
-          // TODO #93: model as spell grants when spell id system is available
-          { type: 'feature', feature: { id: 'draconicsorcery-subclass-spells' } },
+          // Dragon Ancestor: 1-of-10 ancestry choice (Black/Blue/Brass/Bronze/Copper/Gold/Green/Red/Silver/White)
+          {
+            type: 'feature-choice',
+            key: createChoiceKey('feature-choice', 'subclass', 'draconicsorcery', 0),
+            options: [
+              { optionId: 'black', featureId: 'draconicsorcery-dragon-ancestor-black', grants: [] },
+              { optionId: 'blue', featureId: 'draconicsorcery-dragon-ancestor-blue', grants: [] },
+              { optionId: 'brass', featureId: 'draconicsorcery-dragon-ancestor-brass', grants: [] },
+              { optionId: 'bronze', featureId: 'draconicsorcery-dragon-ancestor-bronze', grants: [] },
+              { optionId: 'copper', featureId: 'draconicsorcery-dragon-ancestor-copper', grants: [] },
+              { optionId: 'gold', featureId: 'draconicsorcery-dragon-ancestor-gold', grants: [] },
+              { optionId: 'green', featureId: 'draconicsorcery-dragon-ancestor-green', grants: [] },
+              { optionId: 'red', featureId: 'draconicsorcery-dragon-ancestor-red', grants: [] },
+              { optionId: 'silver', featureId: 'draconicsorcery-dragon-ancestor-silver', grants: [] },
+              { optionId: 'white', featureId: 'draconicsorcery-dragon-ancestor-white', grants: [] },
+            ],
+          },
+          // Expanded spells (always prepared)
+          { type: 'spell', spellId: 'alter-self', alwaysPrepared: true },
+          { type: 'spell', spellId: 'chromatic-orb', alwaysPrepared: true },
+          { type: 'spell', spellId: 'command', alwaysPrepared: true },
+          { type: 'spell', spellId: 'dragons-breath', alwaysPrepared: true },
+        ],
+      },
+      {
+        classLevel: 5,
+        grants: [
+          { type: 'spell', spellId: 'fear', alwaysPrepared: true },
+          { type: 'spell', spellId: 'fly', alwaysPrepared: true },
         ],
       },
       {
@@ -1259,6 +1336,20 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
         grants: [
           // Elemental Affinity: add CHA mod to one damage roll of ancestor's element; spend 1 SP for 1hr resistance
           { type: 'feature', feature: { id: 'draconicsorcery-elemental-affinity' } },
+        ],
+      },
+      {
+        classLevel: 7,
+        grants: [
+          { type: 'spell', spellId: 'arcane-eye', alwaysPrepared: true },
+          { type: 'spell', spellId: 'charm-monster', alwaysPrepared: true },
+        ],
+      },
+      {
+        classLevel: 9,
+        grants: [
+          { type: 'spell', spellId: 'legend-lore', alwaysPrepared: true },
+          { type: 'spell', spellId: 'summon-dragon', alwaysPrepared: true },
         ],
       },
     ] satisfies readonly SubclassFeature[],
@@ -1273,8 +1364,7 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
           // Tides of Chaos: gain Advantage on one attack roll, ability check, or saving throw per long rest;
           // automatically replenishes when you experience a Wild Magic Surge
           { type: 'feature', feature: { id: 'wildmagicsorcery-tides-of-chaos' } },
-          // TODO #93: model as spell grants when spell id system is available
-          { type: 'feature', feature: { id: 'wildmagicsorcery-subclass-spells' } },
+          // 2024 Wild Magic has no subclass spell list
         ],
       },
       {

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -2414,6 +2414,10 @@
     "focus-points": {
       "name": "Focus Points",
       "description": "Fuel Monk techniques. Regain on a Short Rest."
+    },
+    "sorcery-points": {
+      "name": "Sorcery Points",
+      "description": "Fuel Metamagic and subclass features. Regain on a Long Rest; maximum equals your Sorcerer level."
     }
   },
   "spells": {

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -2816,6 +2816,90 @@
     "seeming": {
       "name": "Seeming",
       "description": "You change the appearance of any number of creatures that you can see within range. Each target receives an illusory disguise for the duration. A creature can make an Investigation check against your Spell Save DC to discern the illusion."
+    },
+    "arms-of-hadar": {
+      "name": "Arms of Hadar",
+      "description": "Tendrils of dark energy erupt from you in a 10-foot-radius sphere. Each creature in the area must succeed on a Strength save or take 2d6 Necrotic damage and lose its Reaction until its next turn."
+    },
+    "calm-emotions": {
+      "name": "Calm Emotions",
+      "description": "Each Humanoid in a 20-foot-radius sphere centered on a point you choose must succeed on a Charisma save or have its Charmed or Frightened condition suppressed, or become indifferent about creatures it is hostile to, for the duration."
+    },
+    "detect-thoughts": {
+      "name": "Detect Thoughts",
+      "description": "You can read the surface thoughts of creatures within 30 feet. As an action you can probe deeper, requiring a Wisdom save, or you can search for a particular creature's thoughts."
+    },
+    "dissonant-whispers": {
+      "name": "Dissonant Whispers",
+      "description": "A creature you choose within 60 feet must succeed on a Wisdom save or take 3d6 Psychic damage and move away from you using its Reaction, provoking opportunity attacks."
+    },
+    "mind-sliver": {
+      "name": "Mind Sliver",
+      "description": "You drive a disorienting spike of psychic energy into the mind of one creature you can see within 60 feet. The target must succeed on an Intelligence save or take 1d6 Psychic damage and subtract 1d4 from its next saving throw."
+    },
+    "hunger-of-hadar": {
+      "name": "Hunger of Hadar",
+      "description": "A 20-foot-radius sphere of blackness and bitter cold appears centered on a point within range. Creatures inside are Blinded and take cold or acid damage at the start and end of each turn for the duration."
+    },
+    "sending": {
+      "name": "Sending",
+      "description": "You send a short message of twenty-five words or fewer to a creature you are familiar with. The target can reply with a message of twenty-five words or fewer."
+    },
+    "evards-black-tentacles": {
+      "name": "Evard's Black Tentacles",
+      "description": "Squirming tentacles fill a 20-foot square within range. Creatures in the area must succeed on a Dexterity save or take 3d6 Bludgeoning damage and have the Restrained condition while in the area."
+    },
+    "summon-aberration": {
+      "name": "Summon Aberration",
+      "description": "You call forth an aberrant spirit. Choose Beholderkin, Slaad, or Star Spawn. The creature obeys your commands and acts on your initiative for the duration."
+    },
+    "rarys-telepathic-bond": {
+      "name": "Rary's Telepathic Bond",
+      "description": "You forge a telepathic link among up to eight willing creatures you can see within range. While linked, they can communicate telepathically with each other regardless of language."
+    },
+    "telekinesis": {
+      "name": "Telekinesis",
+      "description": "You gain the ability to move or manipulate creatures or objects by thought. Each turn you can move one Large-or-smaller creature or object up to 30 feet."
+    },
+    "alarm": {
+      "name": "Alarm",
+      "description": "You set an alarm against unwanted intrusion. When a creature of Tiny or larger size enters the warded area, the alarm sounds — either mentally or audibly."
+    },
+    "summon-construct": {
+      "name": "Summon Construct",
+      "description": "You call forth a construct spirit. Choose Clay, Metal, or Stone. The creature obeys your commands and acts on your initiative for the duration."
+    },
+    "wall-of-force": {
+      "name": "Wall of Force",
+      "description": "An invisible wall of force springs into existence at a point you choose within range. The wall is immune to all damage and can't be dispelled by Dispel Magic."
+    },
+    "alter-self": {
+      "name": "Alter Self",
+      "description": "You alter your appearance. Choose Aquatic Adaptation, Change Appearance, or Natural Weapons. You can change which option you have as a Magic action."
+    },
+    "chromatic-orb": {
+      "name": "Chromatic Orb",
+      "description": "You hurl a 4-inch-diameter sphere of energy at a creature. Choose acid, cold, fire, lightning, poison, or thunder. The target must succeed on a Dexterity save or take 3d8 damage of the chosen type."
+    },
+    "command": {
+      "name": "Command",
+      "description": "You speak a one-word command to a creature within 60 feet. It must succeed on a Wisdom save or follow that command on its next turn. Commands include Approach, Drop, Flee, Grovel, and Halt."
+    },
+    "dragons-breath": {
+      "name": "Dragon's Breath",
+      "description": "You imbue a willing creature's mouth with the destructive power of a dragon. Until the spell ends, the creature can exhale a 15-foot cone dealing 3d6 damage of a chosen type (acid, cold, fire, lightning, or poison)."
+    },
+    "fly": {
+      "name": "Fly",
+      "description": "You touch a willing creature. The target gains a Fly Speed of 60 feet for the duration. When the spell ends, the target falls if it is still aloft."
+    },
+    "charm-monster": {
+      "name": "Charm Monster",
+      "description": "You attempt to charm a creature you can see within 30 feet. It must succeed on a Wisdom save or have the Charmed condition for 1 hour or until you or your companions harm it."
+    },
+    "summon-dragon": {
+      "name": "Summon Dragon",
+      "description": "You call forth a draconic spirit. Choose Chromatic, Metallic, or Gem. The creature obeys your commands and acts on your initiative for the duration."
     }
   }
 }

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -567,10 +567,6 @@
       "name": "Psionic Sorcery",
       "description": "When you cast a spell from your Aberrant Sorcery expanded spell list, you can expend Sorcery Points equal to the spell's level to cast it without any Verbal or Material components, provided you have no Concentration on a spell."
     },
-    "aberrantsorcery-subclass-spells": {
-      "name": "Aberrant Sorcery Spells",
-      "description": "You have access to additional spells from your aberrant connection. These spells are always prepared and don't count against your Spells Prepared total."
-    },
     "aberrantsorcery-psychic-defenses": {
       "name": "Psychic Defenses",
       "description": "You gain Resistance to Psychic damage, and you have Advantage on saving throws to avoid or end the Charmed or Frightened condition."
@@ -583,25 +579,53 @@
       "name": "Trance of Order",
       "description": "As a Bonus Action, you enter a state of clockwork consciousness for 1 minute. While in this trance, attack rolls against you can't benefit from Advantage, and whenever you make an attack roll, ability check, or saving throw and roll a 9 or lower on the d20, you can treat the d20 as a 10. This feature ends early if you are incapacitated. Once you use it, you can't use it again until you finish a Long Rest, unless you spend 5 Sorcery Points to use it again."
     },
-    "clockworksorcery-subclass-spells": {
-      "name": "Clockwork Sorcery Spells",
-      "description": "You have access to additional spells from your clockwork connection. These spells are always prepared and don't count against your Spells Prepared total."
-    },
     "clockworksorcery-bastion-of-law": {
       "name": "Bastion of Law",
       "description": "As a Magic action, you can expend 1–5 Sorcery Points to create a shimmering ward on a creature you can see within 30 feet of you, including yourself. The ward is represented by a number of d8s equal to the Sorcery Points spent. When the warded creature takes damage, it can expend any number of those dice, rolling them and reducing the damage taken by the total rolled. The ward lasts until you finish a Long Rest or until all dice are expended."
     },
-    "draconicsorcery-dragon-ancestor": {
-      "name": "Dragon Ancestor",
-      "description": "Choose one type of dragon as your ancestor: Black (Acid), Blue (Lightning), Brass (Fire), Bronze (Lightning), Copper (Acid), Gold (Fire), Green (Poison), Red (Fire), Silver (Cold), or White (Cold). Your choice determines the damage type for several of your other features. You also gain the ability to speak, read, and write Draconic, and you have Advantage on Charisma checks made to interact with dragons."
-    },
-    "draconicsorcery-subclass-spells": {
-      "name": "Draconic Sorcery Spells",
-      "description": "You have access to additional spells from your draconic bloodline. These spells are always prepared and don't count against your Spells Prepared total."
-    },
     "draconicsorcery-elemental-affinity": {
       "name": "Elemental Affinity",
       "description": "When you cast a spell that deals damage of the type associated with your Dragon Ancestor, you can add your Charisma modifier to one damage roll of that spell. In addition, you can spend 1 Sorcery Point to gain Resistance to that damage type for 1 hour."
+    },
+    "draconicsorcery-dragon-ancestor-black": {
+      "name": "Dragon Ancestor: Black",
+      "description": "Your draconic ancestor is a Black dragon. Your damage type is Acid."
+    },
+    "draconicsorcery-dragon-ancestor-blue": {
+      "name": "Dragon Ancestor: Blue",
+      "description": "Your draconic ancestor is a Blue dragon. Your damage type is Lightning."
+    },
+    "draconicsorcery-dragon-ancestor-brass": {
+      "name": "Dragon Ancestor: Brass",
+      "description": "Your draconic ancestor is a Brass dragon. Your damage type is Fire."
+    },
+    "draconicsorcery-dragon-ancestor-bronze": {
+      "name": "Dragon Ancestor: Bronze",
+      "description": "Your draconic ancestor is a Bronze dragon. Your damage type is Lightning."
+    },
+    "draconicsorcery-dragon-ancestor-copper": {
+      "name": "Dragon Ancestor: Copper",
+      "description": "Your draconic ancestor is a Copper dragon. Your damage type is Acid."
+    },
+    "draconicsorcery-dragon-ancestor-gold": {
+      "name": "Dragon Ancestor: Gold",
+      "description": "Your draconic ancestor is a Gold dragon. Your damage type is Fire."
+    },
+    "draconicsorcery-dragon-ancestor-green": {
+      "name": "Dragon Ancestor: Green",
+      "description": "Your draconic ancestor is a Green dragon. Your damage type is Poison."
+    },
+    "draconicsorcery-dragon-ancestor-red": {
+      "name": "Dragon Ancestor: Red",
+      "description": "Your draconic ancestor is a Red dragon. Your damage type is Fire."
+    },
+    "draconicsorcery-dragon-ancestor-silver": {
+      "name": "Dragon Ancestor: Silver",
+      "description": "Your draconic ancestor is a Silver dragon. Your damage type is Cold."
+    },
+    "draconicsorcery-dragon-ancestor-white": {
+      "name": "Dragon Ancestor: White",
+      "description": "Your draconic ancestor is a White dragon. Your damage type is Cold."
     },
     "wildmagicsorcery-wild-magic-surge": {
       "name": "Wild Magic Surge",
@@ -610,10 +634,6 @@
     "wildmagicsorcery-tides-of-chaos": {
       "name": "Tides of Chaos",
       "description": "You can manipulate the forces of chance to gain Advantage on one attack roll, ability check, or saving throw. Once you do so, you must finish a Long Rest before you can use this feature again. If you use Wild Magic Surge before you regain use of this feature, you immediately regain use of it."
-    },
-    "wildmagicsorcery-subclass-spells": {
-      "name": "Wild Magic Sorcery Spells",
-      "description": "You have access to additional spells tied to the wild, unpredictable magic that flows through you. These spells are always prepared and don't count against your Spells Prepared total."
     },
     "wildmagicsorcery-bend-luck": {
       "name": "Bend Luck",


### PR DESCRIPTION
Closes #155

## Summary
Completes the achievable Sorcerer subclass gaps from #121 using the established subclass-spell (#142), resource-pool (Monk #148), and feature-choice (#144/#152) patterns.

## What Changed
- **Subclass spells (Gap 1)** — Aberrant, Clockwork, and Draconic Sorcery get always-prepared subclass spells at sorcerer L3/5/7/9 (21 new catalog spells). Wild Magic Sorcery correctly has no subclass spell list. Aberrant's Mind Sliver (cantrip) routes to cantrips.
- **Sorcery Points (Gap 3)** — Sorcerer L2 Font of Magic now grants a `resource-pool` (`poolId: sorcery-points`, `max: class-level`, `regen: long-rest`), mirroring Monk Focus Points. Renders on the sheet. Spend mechanics stay descriptive (play-time).
- **Dragon Ancestor (Gap 2)** — Draconic Sorcery L3 modeled as a 10-option `feature-choice` (one per chromatic/metallic ancestry, with its damage type in the description). Surfaces in the builder.
- **2014 holdover relocations** — Psionic Sorcery moved L3→L6; Trance of Order moved L3→L14 (both were misplaced stub artifacts).

## Deferred (follow-ups will be filed)
SP spend mechanics, Elemental Affinity conditional resistance (Gap 4), Wild Magic Surge table (Gap 5), Elemental Affinity↔ancestry damage-type link, and L14/L18 subclass features.

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 1847 pass (SP pool, per-subclass spells, Dragon Ancestor choice, resolver integration, catalog invariant)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)