### PR TITLE
[5.5e] Wizard schools: correctness fixes + Portent/Illusory Self resource pools

### DIFF
--- a/src/lib/sources/spells.ts
+++ b/src/lib/sources/spells.ts
@@ -1021,6 +1021,19 @@ export const SPELL_CATALOG = [
     // 2024 PHB: native to bard, cleric, druid, paladin, sorcerer, warlock, wizard
     nativeClasses: ['bard', 'cleric', 'druid', 'paladin', 'sorcerer', 'warlock', 'wizard'],
   },
+  {
+    id: 'counterspell',
+    level: 3,
+    school: 'abjuration',
+    ritual: false,
+    concentration: false,
+    castingTime: 'Reaction',
+    range: '60 feet',
+    components: { verbal: false, somatic: true, material: false },
+    duration: 'Instantaneous',
+    // 2024 PHB: native to bard, sorcerer, warlock, wizard
+    nativeClasses: ['bard', 'sorcerer', 'warlock', 'wizard'],
+  },
   // Devotion L13
   {
     id: 'guardian-of-faith',

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -2868,15 +2868,27 @@ describe('getSubclassSource — Abjurer', () => {
     });
   });
 
-  it('abjurer level 10 grants 1 feature: improved-abjuration', () => {
+  it('abjurer level 10 grants spellbreaker feature + counterspell + dispel-magic always-prepared (NOT improved-abjuration)', () => {
     const source = getSubclassSource('abjurer');
     const level10 = source?.features.find((f) => f.classLevel === 10);
     expect(level10).toBeDefined();
-    expect(level10?.grants).toHaveLength(1);
-    expect(level10?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'abjurer-improved-abjuration' },
-    });
+    expect(level10?.grants).toHaveLength(3);
+    expect(level10?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'feature', feature: expect.objectContaining({ id: 'abjurer-spellbreaker' }) }),
+        expect.objectContaining({ type: 'spell', spellId: 'counterspell', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'dispel-magic', alwaysPrepared: true }),
+      ])
+    );
+    // Regression guard: improved-abjuration (2014) must NOT appear
+    expect(level10?.grants).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'abjurer-improved-abjuration' }),
+        }),
+      ])
+    );
   });
 });
 
@@ -2891,11 +2903,11 @@ describe('getSubclassSource — Diviner', () => {
     expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
   });
 
-  it('diviner level 3 grants 2 features: divination-savant and portent', () => {
+  it('diviner level 3 grants 3 grants: divination-savant, portent, and portent resource pool', () => {
     const source = getSubclassSource('diviner');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
-    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toHaveLength(3);
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -2905,6 +2917,12 @@ describe('getSubclassSource — Diviner', () => {
         expect.objectContaining({
           type: 'feature',
           feature: expect.objectContaining({ id: 'diviner-portent' }),
+        }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'portent',
+          max: { mode: 'fixed', value: 2 },
+          regen: 'long-rest',
         }),
       ])
     );
@@ -2944,7 +2962,7 @@ describe('getSubclassSource — Evoker', () => {
     expect(source?.features.map((f) => f.classLevel)).toEqual([3, 6, 10]);
   });
 
-  it('evoker level 3 grants 2 features: evocation-savant and sculpt-spells', () => {
+  it('evoker level 3 grants 2 features: evocation-savant and potent-cantrip (2024 PHB — NOT sculpt-spells)', () => {
     const source = getSubclassSource('evoker');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
@@ -2957,18 +2975,29 @@ describe('getSubclassSource — Evoker', () => {
         }),
         expect.objectContaining({
           type: 'feature',
-          feature: expect.objectContaining({ id: 'evoker-sculpt-spells' }),
+          feature: expect.objectContaining({ id: 'evoker-potent-cantrip' }),
         }),
+      ])
+    );
+    // Regression guard: sculpt-spells must NOT be at L3 (2014 holdover)
+    expect(level3?.grants).not.toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'feature', feature: expect.objectContaining({ id: 'evoker-sculpt-spells' }) }),
       ])
     );
   });
 
-  it('evoker level 6 grants 1 feature: potent-cantrip', () => {
+  it('evoker level 6 grants 1 feature: sculpt-spells (2024 PHB — NOT potent-cantrip)', () => {
     const source = getSubclassSource('evoker');
     const level6 = source?.features.find((f) => f.classLevel === 6);
     expect(level6).toBeDefined();
     expect(level6?.grants).toHaveLength(1);
     expect(level6?.grants[0]).toMatchObject({
+      type: 'feature',
+      feature: { id: 'evoker-sculpt-spells' },
+    });
+    // Regression guard: potent-cantrip must NOT be at L6 (2014 holdover)
+    expect(level6?.grants[0]).not.toMatchObject({
       type: 'feature',
       feature: { id: 'evoker-potent-cantrip' },
     });
@@ -3027,21 +3056,101 @@ describe('getSubclassSource — Illusionist', () => {
     });
   });
 
-  it('illusionist level 10 grants 1 feature: illusory-self', () => {
+  it('illusionist level 10 grants 2 grants: illusory-self feature and illusory-self resource pool', () => {
     const source = getSubclassSource('illusionist');
     const level10 = source?.features.find((f) => f.classLevel === 10);
     expect(level10).toBeDefined();
-    expect(level10?.grants).toHaveLength(1);
-    expect(level10?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'illusionist-illusory-self' },
-    });
+    expect(level10?.grants).toHaveLength(2);
+    expect(level10?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'illusionist-illusory-self' }),
+        }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'illusory-self',
+          max: { mode: 'fixed', value: 1 },
+          regen: 'short-rest',
+        }),
+      ])
+    );
   });
 });
 
 describe('getSubclassSource — unknown', () => {
   it('returns undefined for unknown subclass', () => {
     expect(getSubclassSource('unknown-subclass' as SubclassId)).toBeUndefined();
+  });
+});
+
+// ── Resolver integration: Wizard school correctness ──────────────────────────
+
+describe('Diviner Portent resource pool resolver integration', () => {
+  const subclassKey = createChoiceKey('subclass', 'class', 'wizard', 0);
+
+  it('Diviner L3: resourcePools includes portent with max=2 and long-rest regen', () => {
+    const build: CharacterBuild = {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'acolyte' as BackgroundId,
+      baseAbilities: { str: 10, dex: 10, con: 10, int: 16, wis: 10, cha: 10 },
+      abilityMethod: 'standard-array',
+      levels: [
+        { classId: 'wizard' as ClassId, classLevel: 1, hpRoll: null },
+        { classId: 'wizard' as ClassId, classLevel: 2, hpRoll: 4 },
+        { classId: 'wizard' as ClassId, classLevel: 3, hpRoll: 4 },
+      ],
+      choices: {
+        [subclassKey]: { type: 'subclass' as const, subclassId: 'diviner' as SubclassId },
+      },
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles, expandedFeats } = collectBundles(build);
+    const resolved = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 3,
+      bundles,
+      choices: build.choices,
+      expandedFeats,
+    });
+    const pool = resolved.resourcePools.find((p) => p.poolId === 'portent');
+    expect(pool).toBeDefined();
+    expect(pool?.max).toBe(2);
+    expect(pool?.regen).toBe('long-rest');
+  });
+});
+
+describe('Abjurer Spellbreaker resolver integration', () => {
+  const subclassKey = createChoiceKey('subclass', 'class', 'wizard', 0);
+
+  it('Abjurer L10: alwaysPreparedSpells includes counterspell and dispel-magic', () => {
+    const build: CharacterBuild = {
+      speciesId: 'human' as SpeciesId,
+      backgroundId: 'acolyte' as BackgroundId,
+      baseAbilities: { str: 10, dex: 10, con: 10, int: 16, wis: 10, cha: 10 },
+      abilityMethod: 'standard-array',
+      levels: Array.from({ length: 10 }, (_, i) => ({
+        classId: 'wizard' as ClassId,
+        classLevel: i + 1,
+        hpRoll: i === 0 ? null : 4,
+      })),
+      choices: {
+        [subclassKey]: { type: 'subclass' as const, subclassId: 'abjurer' as SubclassId },
+      },
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles, expandedFeats } = collectBundles(build);
+    const resolved = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: 10,
+      bundles,
+      choices: build.choices,
+      expandedFeats,
+    });
+    expect(resolved.spellcasting?.alwaysPreparedSpells).toContain('counterspell');
+    expect(resolved.spellcasting?.alwaysPreparedSpells).toContain('dispel-magic');
   });
 });
 

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -1619,8 +1619,11 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 10,
         grants: [
-          // Improved Abjuration: when you cast Counterspell or Dispel Magic, add your PB to the ability check
-          { type: 'feature', feature: { id: 'abjurer-improved-abjuration' } },
+          // Spellbreaker: Counterspell and Dispel Magic are always prepared; Dispel Magic can be cast as a
+          // Bonus Action; add PB to the check; a failed Counterspell or Dispel Magic cast doesn't expend the slot
+          { type: 'feature', feature: { id: 'abjurer-spellbreaker' } },
+          { type: 'spell', spellId: 'counterspell', alwaysPrepared: true },
+          { type: 'spell', spellId: 'dispel-magic', alwaysPrepared: true },
         ],
       },
     ] satisfies readonly SubclassFeature[],
@@ -1635,6 +1638,8 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
           // Portent: after each long rest, roll 2 d20s; replace any attack roll, ability check, or saving throw
           // you can see with one of these rolls; each pre-rolled die can be used once
           { type: 'feature', feature: { id: 'diviner-portent' } },
+          // Portent resource pool: tracks the 2 Portent dice (regain on Long Rest)
+          { type: 'resource-pool', poolId: 'portent', max: { mode: 'fixed', value: 2 }, regen: 'long-rest' },
         ],
       },
       {
@@ -1662,17 +1667,18 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
         grants: [
           // Evocation Savant: copy/inscribe Evocation spells into spellbook at half the usual cost
           { type: 'feature', feature: { id: 'evoker-evocation-savant' } },
-          // Sculpt Spells: when you cast an Evocation spell that affects other creatures you can see,
-          // choose up to 1 + spell level allies; chosen creatures automatically succeed their saves and take no damage
-          { type: 'feature', feature: { id: 'evoker-sculpt-spells' } },
+          // Potent Cantrip: when a creature succeeds on a saving throw against a cantrip you cast,
+          // it takes half damage (2024 PHB: moved from L6 to L3)
+          { type: 'feature', feature: { id: 'evoker-potent-cantrip' } },
         ],
       },
       {
         classLevel: 6,
         grants: [
-          // Potent Cantrip: when a creature succeeds on a saving throw against a cantrip you cast,
-          // it takes half damage and any non-damage effects only partially apply
-          { type: 'feature', feature: { id: 'evoker-potent-cantrip' } },
+          // Sculpt Spells: when you cast an Evocation spell that affects other creatures you can see,
+          // choose up to 1 + spell level allies; chosen creatures automatically succeed their saves and take no damage
+          // (2024 PHB: moved from L3 to L6)
+          { type: 'feature', feature: { id: 'evoker-sculpt-spells' } },
         ],
       },
       {
@@ -1699,8 +1705,8 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 6,
         grants: [
-          // Phantasmal Creatures: Phantasmal Force and Phantasmal Killer are always prepared and can be cast
-          // at their minimum slot levels without expending a spell slot; uses = PB per long rest
+          // Phantasmal Creatures: 2024 PHB grants Summon Beast + Summon Fey with free casts (PB uses per long rest)
+          // TODO(#159-followup): wire summon-beast/summon-fey always-prepared once catalogued
           { type: 'feature', feature: { id: 'illusionist-phantasmal-creatures' } },
         ],
       },
@@ -1710,6 +1716,8 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
           // Illusory Self: Reaction — when a creature makes an attack roll against you, interpose an illusion
           // that causes the attack to automatically miss; 1 use per short rest
           { type: 'feature', feature: { id: 'illusionist-illusory-self' } },
+          // Illusory Self resource pool: 1 use, recharges on Short or Long Rest
+          { type: 'resource-pool', poolId: 'illusory-self', max: { mode: 'fixed', value: 1 }, regen: 'short-rest' },
         ],
       },
     ] satisfies readonly SubclassFeature[],

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1723,9 +1723,9 @@
       "name": "Projected Ward",
       "description": "When a creature that you can see within 30 feet of you takes damage, you can use your Reaction to cause your Arcane Ward to absorb that damage. If this damage reduces the ward to 0 Hit Points, the warded creature takes any remaining damage."
     },
-    "abjurer-improved-abjuration": {
-      "name": "Improved Abjuration",
-      "description": "When you cast Counterspell or Dispel Magic, you can add your Proficiency Bonus to the ability check made as part of casting those spells."
+    "abjurer-spellbreaker": {
+      "name": "Spellbreaker",
+      "description": "Counterspell and Dispel Magic are always prepared for you and don't count against the number of spells you can prepare each day. You can cast Dispel Magic as a Bonus Action. You add your Proficiency Bonus to the ability check of Counterspell or Dispel Magic. If you fail the ability check for either spell, the spell doesn't expend the spell slot."
     },
     "diviner-divination-savant": {
       "name": "Divination Savant",
@@ -1769,7 +1769,7 @@
     },
     "illusionist-phantasmal-creatures": {
       "name": "Phantasmal Creatures",
-      "description": "You can cast Phantasmal Force and Phantasmal Killer without expending a spell slot. When you cast these spells in this way, you cast them at their lowest possible levels. Once you cast either spell in this way, you can't do so again until you finish a Long Rest, unless you expend a spell slot to cast it. You can use each spell a number of times equal to your Proficiency Bonus before you must use a spell slot."
+      "description": "You can cast Summon Beast and Summon Fey without expending a spell slot. When you cast these spells in this way, you cast them at their lowest possible levels. Once you cast either spell in this way, you can't do so again until you finish a Long Rest, unless you expend a spell slot to cast it. You can use each spell a number of times equal to your Proficiency Bonus before you must use a spell slot."
     },
     "illusionist-illusory-self": {
       "name": "Illusory Self",
@@ -2418,6 +2418,14 @@
     "sorcery-points": {
       "name": "Sorcery Points",
       "description": "Fuel Metamagic and subclass features. Regain on a Long Rest; maximum equals your Sorcerer level."
+    },
+    "portent": {
+      "name": "Portent Dice",
+      "description": "After each Long Rest, roll 2 d20s; replace any d20 roll (attack, save, or check) with one. Each die is used once."
+    },
+    "illusory-self": {
+      "name": "Illusory Self",
+      "description": "As a Reaction when hit by an attack, interpose an illusory duplicate so the attack misses. Recharges on a Short or Long Rest."
     }
   },
   "spells": {
@@ -2732,6 +2740,10 @@
     "dispel-magic": {
       "name": "Dispel Magic",
       "description": "Choose any creature, object, or magical effect within range. Any spell of 3rd level or lower on the target ends. For each spell of 4th level or higher on the target, make an ability check using your spellcasting ability. The DC equals 10 plus that spell's level. On a successful check, the spell ends."
+    },
+    "counterspell": {
+      "name": "Counterspell",
+      "description": "You attempt to interrupt a creature in the process of casting a spell. If the creature is casting a spell of 3rd level or lower, its spell fails and has no effect. If it is casting a spell of 4th level or higher, make an ability check using your spellcasting ability. The DC equals 10 plus the spell's level. On a success, the creature's spell fails and has no effect."
     },
     "guardian-of-faith": {
       "name": "Guardian of Faith",

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -2743,7 +2743,7 @@
     },
     "counterspell": {
       "name": "Counterspell",
-      "description": "You attempt to interrupt a creature in the process of casting a spell. If the creature is casting a spell of 3rd level or lower, its spell fails and has no effect. If it is casting a spell of 4th level or higher, make an ability check using your spellcasting ability. The DC equals 10 plus the spell's level. On a success, the creature's spell fails and has no effect."
+      "description": "You attempt to interrupt a creature casting a spell. The creature makes a Constitution saving throw (DC 10 + the spell's level). On a failed save, the spell dissipates with no effect and the action, Bonus Action, or Reaction used to cast it is wasted; if it was cast with a spell slot, the slot isn't expended."
     },
     "guardian-of-faith": {
       "name": "Guardian of Faith",


### PR DESCRIPTION
Closes #159

## Summary
Verifies the four Wizard schools against the 2024 PHB and wires the achievable mechanical pieces. Wizards use a spellbook (no domain-style spell lists), so most gaps defer; the wins here are two 2014-holdover correctness fixes and two fixed-count resource pools.

## What Changed
- **Evoker L3/L6 swap (2014 holdover)** — Potent Cantrip → L3, Sculpt Spells → L6 (was reversed).
- **Abjurer L10 Spellbreaker (2014 holdover)** — replaced `improved-abjuration` with `Spellbreaker`; Counterspell + Dispel Magic are now always-prepared. Added `counterspell` to the catalog (it was missing). Runtime bits (Bonus Action cast, no-slot-on-failure) stay descriptive.
- **Diviner Portent** — `resource-pool` (fixed 2 / long-rest); renders on the sheet.
- **Illusionist Illusory Self** — `resource-pool` (fixed 1 / short-rest).
- **Illusionist L6 Phantasmal Creatures** — description corrected to the 2024 feature (Summon Beast/Fey, not Phantasmal Force/Killer); the summon-spell wiring is deferred (those spells aren't catalogued yet).

## Deferred (follow-ups will be filed)
Savant spellbook cost reduction (no spellbook model), Expert Divination slot regain (runtime), Phantasmal Creatures PB-uses (PB-max blocker), runtime conditional effects (Third Eye/Illusory Self reaction/Potent/Empowered cantrips), Illusionist L6 summon spells, and all four schools' L14 features.

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 1874 pass (Evoker swap guard, Abjurer Spellbreaker + spells, both resource pools, resolver integration)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)