### PR TITLE
feat(character): character cloning

### DIFF
--- a/src/hooks/useCharacters.test.ts
+++ b/src/hooks/useCharacters.test.ts
@@ -169,4 +169,69 @@ describe('useCharacterMutations', () => {
     await waitFor(() => expect(result.current.remove.isSuccess).toBe(true));
     expect(supabase.eq).toHaveBeenCalledWith('id', 'char-1');
   });
+
+  describe('clone', () => {
+    it('inserts a new character with the new name, blank slug, and reset previous_slugs', async () => {
+      // Object data => the child fetches return an object whose .length is undefined,
+      // so child inserts are skipped and only the character is inserted.
+      mockQueryResult.data = baseCharacter;
+
+      const { result } = renderHook(() => useCharacterMutations(), { wrapper: createWrapper() });
+      result.current.clone.mutate({
+        sourceCharacterId: 'char-1',
+        newName: 'Copy of Aria Silverwind',
+        campaignId: 'camp-1',
+      });
+
+      await waitFor(() => expect(result.current.clone.isSuccess).toBe(true));
+
+      const payload = vi.mocked(supabase.insert).mock.calls[0][0] as Record<string, unknown>;
+      expect(payload.name).toBe('Copy of Aria Silverwind');
+      expect(payload.slug).toBe('');
+      expect(payload.previous_slugs).toEqual([]);
+      // DB-managed columns are dropped so the database regenerates them.
+      expect(payload).not.toHaveProperty('id');
+      expect(payload).not.toHaveProperty('created_at');
+      expect(payload).not.toHaveProperty('updated_at');
+      // Duplicate semantics: type/status/campaign carried over verbatim.
+      expect(payload.character_type).toBe('pc');
+      expect(payload.status).toBe('ready');
+      expect(payload.campaign_id).toBe('camp-1');
+    });
+
+    it('skips child inserts when the source has no build levels or items', async () => {
+      mockQueryResult.data = baseCharacter;
+
+      const { result } = renderHook(() => useCharacterMutations(), { wrapper: createWrapper() });
+      result.current.clone.mutate({ sourceCharacterId: 'char-1', newName: 'Copy', campaignId: 'camp-1' });
+
+      await waitFor(() => expect(result.current.clone.isSuccess).toBe(true));
+      // Only the character row is inserted (no child-table inserts).
+      expect(supabase.insert).toHaveBeenCalledTimes(1);
+    });
+
+    it('inserts child build levels and items when the source has them', async () => {
+      // Array data => the child fetches report length > 0, exercising both child-insert branches.
+      mockQueryResult.data = [{ id: 'row-1', character_id: 'char-1', sequence: 0, choices: {} }];
+
+      const { result } = renderHook(() => useCharacterMutations(), { wrapper: createWrapper() });
+      result.current.clone.mutate({ sourceCharacterId: 'char-1', newName: 'Copy', campaignId: 'camp-1' });
+
+      await waitFor(() => expect(result.current.clone.isSuccess).toBe(true));
+      // character + character_build_levels + character_items.
+      expect(supabase.insert).toHaveBeenCalledTimes(3);
+      expect(supabase.from).toHaveBeenCalledWith('character_build_levels');
+      expect(supabase.from).toHaveBeenCalledWith('character_items');
+    });
+
+    it('sets error state when the character insert fails', async () => {
+      mockQueryResult.data = baseCharacter;
+      mockQueryResult.error = { message: 'Clone failed' };
+
+      const { result } = renderHook(() => useCharacterMutations(), { wrapper: createWrapper() });
+      result.current.clone.mutate({ sourceCharacterId: 'char-1', newName: 'Copy', campaignId: 'camp-1' });
+
+      await waitFor(() => expect(result.current.clone.isError).toBe(true));
+    });
+  });
 });

--- a/src/hooks/useCharacters.test.ts
+++ b/src/hooks/useCharacters.test.ts
@@ -180,7 +180,6 @@ describe('useCharacterMutations', () => {
       result.current.clone.mutate({
         sourceCharacterId: 'char-1',
         newName: 'Copy of Aria Silverwind',
-        campaignId: 'camp-1',
       });
 
       await waitFor(() => expect(result.current.clone.isSuccess).toBe(true));
@@ -193,45 +192,53 @@ describe('useCharacterMutations', () => {
       expect(payload).not.toHaveProperty('id');
       expect(payload).not.toHaveProperty('created_at');
       expect(payload).not.toHaveProperty('updated_at');
-      // Duplicate semantics: type/status/campaign carried over verbatim.
+      // Duplicate semantics: type/status/campaign carried over verbatim from the source.
       expect(payload.character_type).toBe('pc');
       expect(payload.status).toBe('ready');
       expect(payload.campaign_id).toBe('camp-1');
+      // Build levels are fetched excluding soft-deleted rows.
+      expect(supabase.is).toHaveBeenCalledWith('deleted_at', null);
     });
 
     it('skips child inserts when the source has no build levels or items', async () => {
       mockQueryResult.data = baseCharacter;
 
       const { result } = renderHook(() => useCharacterMutations(), { wrapper: createWrapper() });
-      result.current.clone.mutate({ sourceCharacterId: 'char-1', newName: 'Copy', campaignId: 'camp-1' });
+      result.current.clone.mutate({ sourceCharacterId: 'char-1', newName: 'Copy' });
 
       await waitFor(() => expect(result.current.clone.isSuccess).toBe(true));
       // Only the character row is inserted (no child-table inserts).
       expect(supabase.insert).toHaveBeenCalledTimes(1);
     });
 
-    it('inserts child build levels and items when the source has them', async () => {
+    it('inserts child build levels and items (with DB columns dropped) when the source has them', async () => {
       // Array data => the child fetches report length > 0, exercising both child-insert branches.
       mockQueryResult.data = [{ id: 'row-1', character_id: 'char-1', sequence: 0, choices: {} }];
 
       const { result } = renderHook(() => useCharacterMutations(), { wrapper: createWrapper() });
-      result.current.clone.mutate({ sourceCharacterId: 'char-1', newName: 'Copy', campaignId: 'camp-1' });
+      result.current.clone.mutate({ sourceCharacterId: 'char-1', newName: 'Copy' });
 
       await waitFor(() => expect(result.current.clone.isSuccess).toBe(true));
       // character + character_build_levels + character_items.
       expect(supabase.insert).toHaveBeenCalledTimes(3);
       expect(supabase.from).toHaveBeenCalledWith('character_build_levels');
       expect(supabase.from).toHaveBeenCalledWith('character_items');
+      // Child rows drop their own id/created_at before re-insert.
+      const levelRows = vi.mocked(supabase.insert).mock.calls[1][0] as Record<string, unknown>[];
+      expect(levelRows[0]).not.toHaveProperty('id');
+      expect(levelRows[0]).not.toHaveProperty('created_at');
     });
 
-    it('sets error state when the character insert fails', async () => {
+    it('propagates the error when the source fetch fails (insert never attempted)', async () => {
       mockQueryResult.data = baseCharacter;
-      mockQueryResult.error = { message: 'Clone failed' };
+      mockQueryResult.error = { message: 'Source fetch failed' };
 
       const { result } = renderHook(() => useCharacterMutations(), { wrapper: createWrapper() });
-      result.current.clone.mutate({ sourceCharacterId: 'char-1', newName: 'Copy', campaignId: 'camp-1' });
+      result.current.clone.mutate({ sourceCharacterId: 'char-1', newName: 'Copy' });
 
       await waitFor(() => expect(result.current.clone.isError).toBe(true));
+      // The first awaited query (source select) throws, so no insert is attempted.
+      expect(supabase.insert).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/hooks/useCharacters.ts
+++ b/src/hooks/useCharacters.ts
@@ -105,5 +105,100 @@ export function useCharacterMutations() {
     },
   });
 
-  return { create, update, remove };
+  // Duplicate a character (row + its character_build_levels and character_items child rows)
+  // into a fresh record. The DB regenerates id/slug (slug via trigger from name+id) and
+  // timestamps. Supabase JS has no client-side transaction, so on any child-insert failure
+  // we compensate by deleting the new character (ON DELETE CASCADE removes partial children).
+  const clone = useMutation({
+    mutationFn: async ({
+      sourceCharacterId,
+      newName,
+    }: {
+      sourceCharacterId: string;
+      newName: string;
+      campaignId: string;
+    }) => {
+      const { data: source, error: sourceError } = await supabase
+        .from('characters')
+        .select('*')
+        .eq('id', sourceCharacterId)
+        .single();
+      if (sourceError) throw sourceError;
+      if (!source) throw new Error('Source character not found');
+
+      const { data: levels, error: levelsError } = await supabase
+        .from('character_build_levels')
+        .select('*')
+        .eq('character_id', sourceCharacterId)
+        .is('deleted_at', null);
+      if (levelsError) throw levelsError;
+
+      const { data: items, error: itemsError } = await supabase
+        .from('character_items')
+        .select('*')
+        .eq('character_id', sourceCharacterId);
+      if (itemsError) throw itemsError;
+
+      // Copy every column, then drop DB-managed ones and override identity fields.
+      const characterPayload: Record<string, unknown> = { ...source };
+      delete characterPayload.id;
+      delete characterPayload.created_at;
+      delete characterPayload.updated_at;
+      characterPayload.name = newName;
+      characterPayload.slug = '';
+      characterPayload.previous_slugs = [];
+
+      const { data: newChar, error: insertError } = await supabase
+        .from('characters')
+        .insert(characterPayload as unknown as TablesInsert<'characters'>)
+        .select()
+        .single();
+      if (insertError) throw insertError;
+      const newCharacter = newChar as unknown as Character;
+
+      try {
+        if (levels && levels.length > 0) {
+          const levelRows = (levels as Record<string, unknown>[]).map((row) => {
+            const copy: Record<string, unknown> = { ...row };
+            delete copy.id;
+            delete copy.created_at;
+            copy.character_id = newCharacter.id;
+            return copy;
+          });
+          const { error } = await supabase
+            .from('character_build_levels')
+            .insert(levelRows as unknown as TablesInsert<'character_build_levels'>[]);
+          if (error) throw error;
+        }
+
+        if (items && items.length > 0) {
+          const itemRows = (items as Record<string, unknown>[]).map((row) => {
+            const copy: Record<string, unknown> = { ...row };
+            delete copy.id;
+            delete copy.created_at;
+            delete copy.updated_at;
+            copy.character_id = newCharacter.id;
+            return copy;
+          });
+          const { error } = await supabase
+            .from('character_items')
+            .insert(itemRows as unknown as TablesInsert<'character_items'>[]);
+          if (error) throw error;
+        }
+      } catch (childError) {
+        // Roll back the orphaned new character (cascade clears any partial children).
+        await supabase.from('characters').delete().eq('id', newCharacter.id);
+        throw childError;
+      }
+
+      return newCharacter;
+    },
+    onSuccess: (data) => {
+      queryClient.invalidateQueries({ queryKey: ['characters', data.campaign_id] });
+      queryClient.invalidateQueries({ queryKey: ['character-build-levels', data.id] });
+      queryClient.invalidateQueries({ queryKey: ['character-items', data.id] });
+    },
+  });
+
+  return { create, update, remove, clone };
 }

--- a/src/hooks/useCharacters.ts
+++ b/src/hooks/useCharacters.ts
@@ -110,14 +110,7 @@ export function useCharacterMutations() {
   // timestamps. Supabase JS has no client-side transaction, so on any child-insert failure
   // we compensate by deleting the new character (ON DELETE CASCADE removes partial children).
   const clone = useMutation({
-    mutationFn: async ({
-      sourceCharacterId,
-      newName,
-    }: {
-      sourceCharacterId: string;
-      newName: string;
-      campaignId: string;
-    }) => {
+    mutationFn: async ({ sourceCharacterId, newName }: { sourceCharacterId: string; newName: string }) => {
       const { data: source, error: sourceError } = await supabase
         .from('characters')
         .select('*')
@@ -187,7 +180,16 @@ export function useCharacterMutations() {
         }
       } catch (childError) {
         // Roll back the orphaned new character (cascade clears any partial children).
-        await supabase.from('characters').delete().eq('id', newCharacter.id);
+        // supabase-js resolves (doesn't reject) on a failed delete, so surface a rollback
+        // failure explicitly — otherwise a partially-cloned character persists silently.
+        const { error: rollbackError } = await supabase.from('characters').delete().eq('id', newCharacter.id);
+        if (rollbackError) {
+          const original = childError instanceof Error ? childError.message : String(childError);
+          throw new Error(
+            `Character clone failed and rollback also failed; an orphaned character (${newCharacter.id}) ` +
+              `may remain. Original error: ${original}; rollback error: ${rollbackError.message}`
+          );
+        }
         throw childError;
       }
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -8,6 +8,7 @@
     "creating": "Creating...",
     "edit": "Edit",
     "delete": "Delete",
+    "clone": "Clone",
     "add": "Add",
     "remove": "Remove",
     "next": "Next",
@@ -533,7 +534,8 @@
       "buildFailed": "Failed to compute character build: {{message}}",
       "updateFailed": "Failed to save changes. Please try again.",
       "archiveFailed": "Failed to archive character. Please try again.",
-      "deleteFailed": "Failed to delete character. Please try again."
+      "deleteFailed": "Failed to delete character. Please try again.",
+      "cloneFailed": "Failed to clone character. Please try again."
     },
     "actions": {
       "archiveTitle": "Archive Character",
@@ -541,7 +543,11 @@
       "deleteTitle": "Delete Character",
       "deleteConfirm": "Are you sure you want to permanently delete {{name}}? This action cannot be undone.",
       "archiveSuccess": "{{name}} has been archived.",
-      "deleteSuccess": "{{name}} has been deleted."
+      "deleteSuccess": "{{name}} has been deleted.",
+      "cloneTitle": "Clone Character",
+      "cloneNameLabel": "New character name",
+      "copyOfName": "Copy of {{name}}",
+      "cloneSuccess": "Character cloned: {{name}}"
     },
     "status": {
       "heroicInspiration": "Heroic Inspiration",

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -188,7 +188,7 @@ function CharacterSheetInner({
   const handleClone = () => {
     const name = cloneName.trim() || tc('characterSheet.actions.copyOfName', { name: character.name });
     cloneMutation.mutate(
-      { sourceCharacterId: characterId, newName: name, campaignId: character.campaign_id },
+      { sourceCharacterId: characterId, newName: name },
       {
         onSuccess: (cloned) => {
           setConfirmAction(null);

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -28,7 +28,7 @@ import type { PersistedItem } from '@/lib/resolver/index';
 import type { SourceTag } from '@/types/sources';
 import { DND_CLASSES, getProficiencyBonus, isBackgroundId, type ClassId, type DndGender } from '@/lib/dnd-helpers';
 import type { Character } from '@/types/database';
-import { Archive, Check, Edit2, Save, Trash2 } from 'lucide-react';
+import { Archive, Check, Copy, Edit2, Save, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -87,11 +87,12 @@ function CharacterSheetInner({
 
   const navigate = useNavigate();
   const { campaignSlug } = useParams<{ campaignSlug: string }>();
-  const [confirmAction, setConfirmAction] = useState<'archive' | 'delete' | null>(null);
+  const [confirmAction, setConfirmAction] = useState<'archive' | 'delete' | 'clone' | null>(null);
+  const [cloneName, setCloneName] = useState('');
 
   usePageTitle(character.name);
 
-  const { update: updateMutation, remove: removeMutation } = useCharacterMutations();
+  const { update: updateMutation, remove: removeMutation, clone: cloneMutation } = useCharacterMutations();
   const {
     character: ctxCharacter,
     rows,
@@ -184,6 +185,21 @@ function CharacterSheetInner({
     );
   };
 
+  const handleClone = () => {
+    const name = cloneName.trim() || tc('characterSheet.actions.copyOfName', { name: character.name });
+    cloneMutation.mutate(
+      { sourceCharacterId: characterId, newName: name, campaignId: character.campaign_id },
+      {
+        onSuccess: (cloned) => {
+          setConfirmAction(null);
+          toast.success(tc('characterSheet.actions.cloneSuccess', { name: cloned.name }));
+          navigate(`/campaign/${campaignSlug}/character/${cloned.slug}`);
+        },
+        onError: () => toast.error(tc('characterSheet.errors.cloneFailed')),
+      }
+    );
+  };
+
   const buildErrorBanner = buildError ? (
     <div className="mb-6 p-4 bg-destructive/10 border border-destructive/50 rounded-lg text-destructive text-sm">
       {tc('characterSheet.errors.buildFailed', { message: buildError })}
@@ -263,6 +279,17 @@ function CharacterSheetInner({
                 title={tc('characterSheet.dialogs.editCharacterInfo')}
               >
                 <Edit2 size={16} />
+              </Button>
+              <Button
+                variant="ghost"
+                size="icon-sm"
+                onClick={() => {
+                  setCloneName(tc('characterSheet.actions.copyOfName', { name: character.name }));
+                  setConfirmAction('clone');
+                }}
+                title={tc('buttons.clone')}
+              >
+                <Copy size={16} />
               </Button>
               <Button
                 variant="ghost"
@@ -798,24 +825,49 @@ function CharacterSheetInner({
               <DialogTitle>
                 {confirmAction === 'archive'
                   ? tc('characterSheet.actions.archiveTitle')
-                  : tc('characterSheet.actions.deleteTitle')}
+                  : confirmAction === 'clone'
+                    ? tc('characterSheet.actions.cloneTitle')
+                    : tc('characterSheet.actions.deleteTitle')}
               </DialogTitle>
             </DialogHeader>
-            <p className="text-sm text-muted-foreground">
-              {confirmAction === 'archive'
-                ? tc('characterSheet.actions.archiveConfirm', { name: character.name })
-                : tc('characterSheet.actions.deleteConfirm', { name: character.name })}
-            </p>
+            {confirmAction === 'clone' ? (
+              <div className="space-y-2">
+                <label htmlFor="clone-name" className="text-sm text-muted-foreground">
+                  {tc('characterSheet.actions.cloneNameLabel')}
+                </label>
+                <Input
+                  id="clone-name"
+                  value={cloneName}
+                  onChange={(e) => setCloneName(e.target.value)}
+                  onKeyDown={(e) => {
+                    if (e.key === 'Enter' && cloneName.trim()) handleClone();
+                  }}
+                />
+              </div>
+            ) : (
+              <p className="text-sm text-muted-foreground">
+                {confirmAction === 'archive'
+                  ? tc('characterSheet.actions.archiveConfirm', { name: character.name })
+                  : tc('characterSheet.actions.deleteConfirm', { name: character.name })}
+              </p>
+            )}
             <DialogFooter>
               <Button variant="outline" onClick={() => setConfirmAction(null)}>
                 {tc('buttons.cancel')}
               </Button>
               <Button
                 variant={confirmAction === 'delete' ? 'destructive' : 'default'}
-                onClick={confirmAction === 'archive' ? handleArchive : handleDelete}
-                pending={updateMutation.isPending || removeMutation.isPending}
+                onClick={
+                  confirmAction === 'archive' ? handleArchive : confirmAction === 'clone' ? handleClone : handleDelete
+                }
+                disabled={confirmAction === 'clone' && !cloneName.trim()}
+                pending={updateMutation.isPending || removeMutation.isPending || cloneMutation.isPending}
               >
-                {confirmAction === 'archive' ? tc('buttons.archive') : tc('buttons.delete')}
+                {confirmAction === 'archive'
+                  ? tc('buttons.archive')
+                  : confirmAction === 'clone'
+                    ? tc('buttons.clone')
+                    : tc('buttons.delete')}
               </Button>
             </DialogFooter>
           </DialogContent>


### PR DESCRIPTION
Closes #50

## Summary
Adds a "Clone Character" action that duplicates a character (its `characters` row plus all `character_build_levels` and `character_items` child rows) into a fresh record in the same campaign — useful for NPC variants and backups.

## What Changed
- **`src/hooks/useCharacters.ts`** — new `clone` mutation on `useCharacterMutations`. It fetches the source character + its build-levels (non-soft-deleted) + items, inserts a new character (copying all columns via `select('*')` spread; dropping `id`/`created_at`/`updated_at`; setting `slug:''` so the DB trigger regenerates it, `previous_slugs:[]`, and the new name), then inserts the child rows pointed at the new id. Supabase JS has no client-side transaction, so on any child-insert failure it compensates by deleting the new character (ON DELETE CASCADE clears partial children). Invalidates the characters / build-levels / items query keys.
- **`src/pages/CharacterSheet.tsx`** — a `Copy` icon action in the header opens a confirm dialog with an editable name field defaulting to "Copy of {name}"; on success it toasts and navigates to the new character's sheet.
- **`src/locales/en/common.json`** — clone i18n keys.

## Design notes
- Only `character_build_levels` and `character_items` reference a character (FK); sessions/encounters/notes are campaign-scoped — verified against `supabase/migrations/`.
- `character_type`, `status`, `is_active` are copied verbatim (a clone is a duplicate). Same campaign only.
- Clone action is on the sheet only (list-level action deferred per the issue's note).

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 1883 pass (4 new: insert payload name/slug/previous_slugs + dropped id + preserved type/status; skips child inserts when none; inserts children when present; error state)
- [x] `npm run lint` clean

Note: the clone mutation does DB writes; the hook test uses the repo's shared Supabase mock (call introspection), so end-to-end behavior against a live DB wasn't exercised in this autonomous run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)