### PR TITLE
feat(character): hit dice and spell slot tracking

### DIFF
--- a/features/characters/steps/finalize-character.steps.ts
+++ b/features/characters/steps/finalize-character.steps.ts
@@ -86,6 +86,8 @@ function draftCharacter(build: CharacterBuild): Character {
     heroic_inspiration: false,
     exhaustion_level: 0,
     conditions: [],
+    hit_dice_used: null,
+    spell_slots_used: null,
   };
 }
 

--- a/src/components/character-builder/BasicsStep.test.tsx
+++ b/src/components/character-builder/BasicsStep.test.tsx
@@ -148,6 +148,8 @@ function buildSeedCharacter(overrides?: Partial<Character>): Character {
     heroic_inspiration: false,
     exhaustion_level: 0 as const,
     conditions: [],
+    hit_dice_used: null,
+    spell_slots_used: null,
     ...overrides,
   };
 }

--- a/src/components/character-builder/OriginStep.test.tsx
+++ b/src/components/character-builder/OriginStep.test.tsx
@@ -98,6 +98,8 @@ function buildSeedCharacter(overrides?: Partial<Character>): Character {
     heroic_inspiration: false,
     exhaustion_level: 0 as const,
     conditions: [],
+    hit_dice_used: null,
+    spell_slots_used: null,
     ...overrides,
   };
 }

--- a/src/components/character-sheet/ConditionsPanel.test.tsx
+++ b/src/components/character-sheet/ConditionsPanel.test.tsx
@@ -62,6 +62,8 @@ function buildMinimalCharacter(overrides: Partial<Character> = {}): Character {
     heroic_inspiration: false,
     exhaustion_level: 0,
     conditions: [],
+    hit_dice_used: null,
+    spell_slots_used: null,
     ...overrides,
   };
 }

--- a/src/components/character-sheet/HitDicePanel.test.tsx
+++ b/src/components/character-sheet/HitDicePanel.test.tsx
@@ -1,0 +1,184 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { HitDicePanel } from '@/components/character-sheet/HitDicePanel';
+import type { Character } from '@/types/database';
+import type { ResolvedCharacter } from '@/types/resolved';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (_ns?: string) => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts?.defaultValue !== undefined) return opts.defaultValue as string;
+      const segments = key.split('.');
+      return segments[segments.length - 1];
+    },
+  }),
+}));
+
+function buildMinimalCharacter(overrides: Partial<Character> = {}): Character {
+  return {
+    id: 'char-1',
+    slug: 'test-char',
+    previous_slugs: [],
+    created_at: '',
+    updated_at: '',
+    campaign_id: 'camp-1',
+    name: 'Test Character',
+    player_name: null,
+    character_type: 'pc',
+    species: null,
+    class: null,
+    subclass: null,
+    level: 1,
+    background: null,
+    alignment: null,
+    gender: null,
+    size: null,
+    age: null,
+    height: null,
+    weight: null,
+    eye_color: null,
+    hair_color: null,
+    skin_color: null,
+    hit_points_max: null,
+    armor_class: null,
+    speed: null,
+    proficiency_bonus: null,
+    personality_traits: null,
+    ideals: null,
+    bonds: null,
+    flaws: null,
+    appearance: null,
+    backstory: null,
+    notes: null,
+    portrait_url: null,
+    is_active: true,
+    status: 'ready',
+    weapon_masteries: null,
+    heroic_inspiration: false,
+    exhaustion_level: 0,
+    conditions: [],
+    hit_dice_used: null,
+    spell_slots_used: null,
+    ...overrides,
+  };
+}
+
+function buildMinimalResolved(overrides: Partial<ResolvedCharacter> = {}): ResolvedCharacter {
+  return {
+    abilities: {} as ResolvedCharacter['abilities'],
+    hitDie: [],
+    hitPoints: { max: 0 },
+    speed: {},
+    initiative: 0,
+    proficiencyBonus: 2,
+    armorClass: { calculations: [], bonuses: [], effective: 10 },
+    savingThrows: {} as ResolvedCharacter['savingThrows'],
+    skills: {} as ResolvedCharacter['skills'],
+    armorProficiencies: [],
+    weaponProficiencies: [],
+    toolProficiencies: [],
+    languages: [],
+    features: [],
+    resistances: [],
+    immunities: [],
+    spellcasting: null,
+    equipment: [],
+    attacks: [],
+    toolExpertise: [],
+    bardicInspiration: null,
+    pendingChoices: [],
+    weaponMasteries: [],
+    resourcePools: [],
+    ...overrides,
+  };
+}
+
+describe('HitDicePanel', () => {
+  it('returns null when resolved.hitDie is empty', () => {
+    const { container } = render(
+      <HitDicePanel
+        resolved={buildMinimalResolved({ hitDie: [] })}
+        character={buildMinimalCharacter()}
+        onUpdate={vi.fn()}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders a section heading', () => {
+    const resolved = buildMinimalResolved({ hitDie: [{ die: 8, count: 3 }] });
+    render(<HitDicePanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={vi.fn()} />);
+    // tc('characterSheet.sections.hitDice') → last segment = "hitDice"
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('hitDice');
+  });
+
+  it('renders one row per distinct die type', () => {
+    const resolved = buildMinimalResolved({
+      hitDie: [
+        { die: 10, count: 2 },
+        { die: 6, count: 3 },
+      ],
+    });
+    render(<HitDicePanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={vi.fn()} />);
+    expect(screen.getByText(/d10/)).toBeInTheDocument();
+    expect(screen.getByText(/d6/)).toBeInTheDocument();
+  });
+
+  it('shows correct available count when no dice are used', () => {
+    const resolved = buildMinimalResolved({ hitDie: [{ die: 8, count: 4 }] });
+    render(
+      <HitDicePanel resolved={resolved} character={buildMinimalCharacter({ hit_dice_used: {} })} onUpdate={vi.fn()} />
+    );
+    expect(screen.getByText(/4 \/ 4 available/)).toBeInTheDocument();
+  });
+
+  it('shows decremented available count when some dice are used', () => {
+    const resolved = buildMinimalResolved({ hitDie: [{ die: 8, count: 4 }] });
+    render(
+      <HitDicePanel
+        resolved={resolved}
+        character={buildMinimalCharacter({ hit_dice_used: { '8': 2 } })}
+        onUpdate={vi.fn()}
+      />
+    );
+    expect(screen.getByText(/2 \/ 4 available/)).toBeInTheDocument();
+  });
+
+  it('clicking Spend calls onUpdate with incremented used count', async () => {
+    const onUpdate = vi.fn();
+    const resolved = buildMinimalResolved({ hitDie: [{ die: 8, count: 3 }] });
+    render(
+      <HitDicePanel resolved={resolved} character={buildMinimalCharacter({ hit_dice_used: {} })} onUpdate={onUpdate} />
+    );
+    await userEvent.click(screen.getByRole('button', { name: /spend/i }));
+    expect(onUpdate).toHaveBeenCalledWith({ hit_dice_used: { '8': 1 } });
+  });
+
+  it('Spend button is disabled when all dice of that type are used', () => {
+    const resolved = buildMinimalResolved({ hitDie: [{ die: 8, count: 2 }] });
+    render(
+      <HitDicePanel
+        resolved={resolved}
+        character={buildMinimalCharacter({ hit_dice_used: { '8': 2 } })}
+        onUpdate={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /spend/i })).toBeDisabled();
+  });
+
+  it('does not call onUpdate on initial render', () => {
+    const onUpdate = vi.fn();
+    const resolved = buildMinimalResolved({ hitDie: [{ die: 8, count: 3 }] });
+    render(<HitDicePanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={onUpdate} />);
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+
+  it('treats hit_dice_used null as empty (all available)', () => {
+    const resolved = buildMinimalResolved({ hitDie: [{ die: 8, count: 2 }] });
+    render(
+      <HitDicePanel resolved={resolved} character={buildMinimalCharacter({ hit_dice_used: null })} onUpdate={vi.fn()} />
+    );
+    expect(screen.getByText(/2 \/ 2 available/)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /spend/i })).not.toBeDisabled();
+  });
+});

--- a/src/components/character-sheet/HitDicePanel.test.tsx
+++ b/src/components/character-sheet/HitDicePanel.test.tsx
@@ -120,19 +120,21 @@ describe('HitDicePanel', () => {
       ],
     });
     render(<HitDicePanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={vi.fn()} />);
-    expect(screen.getByText(/d10/)).toBeInTheDocument();
-    expect(screen.getByText(/d6/)).toBeInTheDocument();
+    // tc('characterSheet.hitDice.dieLabel', {die, count}) → mock returns last segment "dieLabel"
+    // Two die rows → two "dieLabel" labels
+    expect(screen.getAllByText('dieLabel')).toHaveLength(2);
   });
 
-  it('shows correct available count when no dice are used', () => {
+  it('shows available count label for each die row', () => {
     const resolved = buildMinimalResolved({ hitDie: [{ die: 8, count: 4 }] });
     render(
       <HitDicePanel resolved={resolved} character={buildMinimalCharacter({ hit_dice_used: {} })} onUpdate={vi.fn()} />
     );
-    expect(screen.getByText(/4 \/ 4 available/)).toBeInTheDocument();
+    // tc('characterSheet.hitDice.available', {...}) → mock returns last segment "available"
+    expect(screen.getByText('available')).toBeInTheDocument();
   });
 
-  it('shows decremented available count when some dice are used', () => {
+  it('shows available count label when some dice are used', () => {
     const resolved = buildMinimalResolved({ hitDie: [{ die: 8, count: 4 }] });
     render(
       <HitDicePanel
@@ -141,7 +143,8 @@ describe('HitDicePanel', () => {
         onUpdate={vi.fn()}
       />
     );
-    expect(screen.getByText(/2 \/ 4 available/)).toBeInTheDocument();
+    // tc('characterSheet.hitDice.available', {...}) → mock returns last segment "available"
+    expect(screen.getByText('available')).toBeInTheDocument();
   });
 
   it('clicking Spend calls onUpdate with incremented used count', async () => {
@@ -150,7 +153,8 @@ describe('HitDicePanel', () => {
     render(
       <HitDicePanel resolved={resolved} character={buildMinimalCharacter({ hit_dice_used: {} })} onUpdate={onUpdate} />
     );
-    await userEvent.click(screen.getByRole('button', { name: /spend/i }));
+    // tc('characterSheet.hitDice.spend') → mock returns "spend"
+    await userEvent.click(screen.getByRole('button', { name: 'spend' }));
     expect(onUpdate).toHaveBeenCalledWith({ hit_dice_used: { '8': 1 } });
   });
 
@@ -163,7 +167,7 @@ describe('HitDicePanel', () => {
         onUpdate={vi.fn()}
       />
     );
-    expect(screen.getByRole('button', { name: /spend/i })).toBeDisabled();
+    expect(screen.getByRole('button', { name: 'spend' })).toBeDisabled();
   });
 
   it('does not call onUpdate on initial render', () => {
@@ -178,7 +182,7 @@ describe('HitDicePanel', () => {
     render(
       <HitDicePanel resolved={resolved} character={buildMinimalCharacter({ hit_dice_used: null })} onUpdate={vi.fn()} />
     );
-    expect(screen.getByText(/2 \/ 2 available/)).toBeInTheDocument();
-    expect(screen.getByRole('button', { name: /spend/i })).not.toBeDisabled();
+    expect(screen.getByText('available')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'spend' })).not.toBeDisabled();
   });
 });

--- a/src/components/character-sheet/HitDicePanel.test.tsx
+++ b/src/components/character-sheet/HitDicePanel.test.tsx
@@ -185,4 +185,20 @@ describe('HitDicePanel', () => {
     expect(screen.getByText('available')).toBeInTheDocument();
     expect(screen.getByRole('button', { name: 'spend' })).not.toBeDisabled();
   });
+
+  it('clamps available to 0 when used exceeds max (de-leveled stale data)', () => {
+    // used=5 > max=3 — available must never go negative; Spend must be disabled
+    const resolved = buildMinimalResolved({ hitDie: [{ die: 8, count: 3 }] });
+    render(
+      <HitDicePanel
+        resolved={resolved}
+        character={buildMinimalCharacter({ hit_dice_used: { '8': 5 } })}
+        onUpdate={vi.fn()}
+      />
+    );
+    // "available" text is still rendered (not negative label)
+    expect(screen.getByText('available')).toBeInTheDocument();
+    // Spend disabled because usedCount(5) >= max(3)
+    expect(screen.getByRole('button', { name: 'spend' })).toBeDisabled();
+  });
 });

--- a/src/components/character-sheet/HitDicePanel.tsx
+++ b/src/components/character-sheet/HitDicePanel.tsx
@@ -1,0 +1,55 @@
+import { Button } from '@/components/ui/button';
+import { getHitDiceMax, spendHitDie } from '@/lib/rest';
+import type { Character } from '@/types/database';
+import type { ResolvedCharacter } from '@/types/resolved';
+import { useTranslation } from 'react-i18next';
+
+interface HitDicePanelProps {
+  readonly resolved: ResolvedCharacter;
+  readonly character: Character;
+  readonly onUpdate: (u: Partial<Character>) => void;
+}
+
+export function HitDicePanel({ resolved, character, onUpdate }: HitDicePanelProps): React.JSX.Element | null {
+  const { t: tc } = useTranslation('common');
+
+  if (resolved.hitDie.length === 0) return null;
+
+  const maxByDie = getHitDiceMax(resolved);
+  const used = character.hit_dice_used ?? {};
+
+  function handleSpend(die: number): void {
+    const next = spendHitDie(used, die, maxByDie);
+    onUpdate({ hit_dice_used: next });
+  }
+
+  return (
+    <div className="bg-card border rounded-lg p-6">
+      <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.hitDice')}</h2>
+      <div className="space-y-3">
+        {resolved.hitDie.map(({ die, count }) => {
+          const key = String(die);
+          const usedCount = used[key] ?? 0;
+          const available = (maxByDie[key] ?? 0) - usedCount;
+          const isDisabled = usedCount >= (maxByDie[key] ?? 0);
+
+          return (
+            <div key={die} className="flex items-center justify-between bg-muted/50 p-3 rounded border">
+              <div className="flex items-center gap-3">
+                <span className="font-semibold text-foreground text-sm">
+                  d{die} × {count}
+                </span>
+                <span className="text-xs text-muted-foreground">
+                  {available} / {maxByDie[key] ?? 0} available
+                </span>
+              </div>
+              <Button type="button" variant="outline" size="sm" disabled={isDisabled} onClick={() => handleSpend(die)}>
+                Spend
+              </Button>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/character-sheet/HitDicePanel.tsx
+++ b/src/components/character-sheet/HitDicePanel.tsx
@@ -37,14 +37,14 @@ export function HitDicePanel({ resolved, character, onUpdate }: HitDicePanelProp
             <div key={die} className="flex items-center justify-between bg-muted/50 p-3 rounded border">
               <div className="flex items-center gap-3">
                 <span className="font-semibold text-foreground text-sm">
-                  d{die} × {count}
+                  {tc('characterSheet.hitDice.dieLabel', { die, count })}
                 </span>
                 <span className="text-xs text-muted-foreground">
-                  {available} / {maxByDie[key] ?? 0} available
+                  {tc('characterSheet.hitDice.available', { available, max: maxByDie[key] ?? 0 })}
                 </span>
               </div>
               <Button type="button" variant="outline" size="sm" disabled={isDisabled} onClick={() => handleSpend(die)}>
-                Spend
+                {tc('characterSheet.hitDice.spend')}
               </Button>
             </div>
           );

--- a/src/components/character-sheet/HitDicePanel.tsx
+++ b/src/components/character-sheet/HitDicePanel.tsx
@@ -30,7 +30,7 @@ export function HitDicePanel({ resolved, character, onUpdate }: HitDicePanelProp
         {resolved.hitDie.map(({ die, count }) => {
           const key = String(die);
           const usedCount = used[key] ?? 0;
-          const available = (maxByDie[key] ?? 0) - usedCount;
+          const available = Math.max(0, (maxByDie[key] ?? 0) - usedCount);
           const isDisabled = usedCount >= (maxByDie[key] ?? 0);
 
           return (

--- a/src/components/character-sheet/SpellSlotsPanel.test.tsx
+++ b/src/components/character-sheet/SpellSlotsPanel.test.tsx
@@ -1,0 +1,268 @@
+import { render, screen } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { SpellSlotsPanel } from '@/components/character-sheet/SpellSlotsPanel';
+import type { Character } from '@/types/database';
+import type { ResolvedCharacter, ResolvedSpellcasting } from '@/types/resolved';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (_ns?: string) => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts?.defaultValue !== undefined) return opts.defaultValue as string;
+      const segments = key.split('.');
+      return segments[segments.length - 1];
+    },
+  }),
+}));
+
+function buildMinimalCharacter(overrides: Partial<Character> = {}): Character {
+  return {
+    id: 'char-1',
+    slug: 'test-char',
+    previous_slugs: [],
+    created_at: '',
+    updated_at: '',
+    campaign_id: 'camp-1',
+    name: 'Test Character',
+    player_name: null,
+    character_type: 'pc',
+    species: null,
+    class: null,
+    subclass: null,
+    level: 1,
+    background: null,
+    alignment: null,
+    gender: null,
+    size: null,
+    age: null,
+    height: null,
+    weight: null,
+    eye_color: null,
+    hair_color: null,
+    skin_color: null,
+    hit_points_max: null,
+    armor_class: null,
+    speed: null,
+    proficiency_bonus: null,
+    personality_traits: null,
+    ideals: null,
+    bonds: null,
+    flaws: null,
+    appearance: null,
+    backstory: null,
+    notes: null,
+    portrait_url: null,
+    is_active: true,
+    status: 'ready',
+    weapon_masteries: null,
+    heroic_inspiration: false,
+    exhaustion_level: 0,
+    conditions: [],
+    hit_dice_used: null,
+    spell_slots_used: null,
+    ...overrides,
+  };
+}
+
+function buildMinimalResolved(overrides: Partial<ResolvedCharacter> = {}): ResolvedCharacter {
+  return {
+    abilities: {} as ResolvedCharacter['abilities'],
+    hitDie: [],
+    hitPoints: { max: 0 },
+    speed: {},
+    initiative: 0,
+    proficiencyBonus: 2,
+    armorClass: { calculations: [], bonuses: [], effective: 10 },
+    savingThrows: {} as ResolvedCharacter['savingThrows'],
+    skills: {} as ResolvedCharacter['skills'],
+    armorProficiencies: [],
+    weaponProficiencies: [],
+    toolProficiencies: [],
+    languages: [],
+    features: [],
+    resistances: [],
+    immunities: [],
+    spellcasting: null,
+    equipment: [],
+    attacks: [],
+    toolExpertise: [],
+    bardicInspiration: null,
+    pendingChoices: [],
+    weaponMasteries: [],
+    resourcePools: [],
+    ...overrides,
+  };
+}
+
+function makeSpellcasting(overrides: Partial<ResolvedSpellcasting> = {}): ResolvedSpellcasting {
+  return {
+    ability: 'wis',
+    spellSaveDC: 14,
+    spellAttackBonus: 6,
+    cantrips: [],
+    knownSpells: [],
+    alwaysPreparedSpells: [],
+    slots: [],
+    preparedCount: 0,
+    pactMagic: null,
+    ...overrides,
+  };
+}
+
+describe('SpellSlotsPanel', () => {
+  it('returns null when spellcasting is null', () => {
+    const { container } = render(
+      <SpellSlotsPanel
+        resolved={buildMinimalResolved({ spellcasting: null })}
+        character={buildMinimalCharacter()}
+        onUpdate={vi.fn()}
+      />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('returns null when all slot counts are 0 and no pact magic', () => {
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({ slots: [0, 0, 0, 0, 0, 0, 0, 0, 0], pactMagic: null }),
+    });
+    const { container } = render(
+      <SpellSlotsPanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={vi.fn()} />
+    );
+    expect(container.firstChild).toBeNull();
+  });
+
+  it('renders section heading when there are slots', () => {
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({ slots: [2, 0, 0, 0, 0, 0, 0, 0, 0] }),
+    });
+    render(<SpellSlotsPanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={vi.fn()} />);
+    // tc('characterSheet.sections.spellSlots') → last segment = "spellSlots"
+    expect(screen.getByRole('heading', { level: 2 })).toHaveTextContent('spellSlots');
+  });
+
+  it('renders correct number of slot toggles for level 1 with 4 slots', () => {
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({ slots: [4, 0, 0, 0, 0, 0, 0, 0, 0] }),
+    });
+    render(<SpellSlotsPanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={vi.fn()} />);
+    // 4 slot buttons for level 1
+    const slotButtons = screen.getAllByRole('button', { name: /use level 1 slot|recover level 1 slot/i });
+    expect(slotButtons).toHaveLength(4);
+  });
+
+  it('all slots are unfilled (aria-pressed=false) when none used', () => {
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({ slots: [2, 0, 0, 0, 0, 0, 0, 0, 0] }),
+    });
+    render(
+      <SpellSlotsPanel
+        resolved={resolved}
+        character={buildMinimalCharacter({ spell_slots_used: {} })}
+        onUpdate={vi.fn()}
+      />
+    );
+    const buttons = screen.getAllByRole('button');
+    for (const btn of buttons) {
+      expect(btn).toHaveAttribute('aria-pressed', 'false');
+    }
+  });
+
+  it('clicking an unfilled slot calls onUpdate with incremented used count', async () => {
+    const onUpdate = vi.fn();
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({ slots: [2, 0, 0, 0, 0, 0, 0, 0, 0] }),
+    });
+    render(
+      <SpellSlotsPanel
+        resolved={resolved}
+        character={buildMinimalCharacter({ spell_slots_used: {} })}
+        onUpdate={onUpdate}
+      />
+    );
+    await userEvent.click(screen.getAllByRole('button', { name: /use level 1 slot/i })[0]);
+    expect(onUpdate).toHaveBeenCalledWith({ spell_slots_used: { '1': 1 } });
+  });
+
+  it('clicking a filled slot calls onUpdate with decremented used count (recover)', async () => {
+    const onUpdate = vi.fn();
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({ slots: [2, 0, 0, 0, 0, 0, 0, 0, 0] }),
+    });
+    render(
+      <SpellSlotsPanel
+        resolved={resolved}
+        character={buildMinimalCharacter({ spell_slots_used: { '1': 2 } })}
+        onUpdate={onUpdate}
+      />
+    );
+    // Both slots are filled — clicking either recovers one
+    await userEvent.click(screen.getAllByRole('button', { name: /recover level 1 slot/i })[0]);
+    expect(onUpdate).toHaveBeenCalledWith({ spell_slots_used: { '1': 1 } });
+  });
+
+  it('renders pact magic row with correct number of toggles for warlock', () => {
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({
+        slots: [],
+        pactMagic: { count: 2, slotLevel: 3 },
+      }),
+    });
+    render(<SpellSlotsPanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={vi.fn()} />);
+    const pactButtons = screen.getAllByRole('button', { name: /pact slot/i });
+    expect(pactButtons).toHaveLength(2);
+  });
+
+  it('renders panel for warlock with pact magic (no normal slots)', () => {
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({
+        slots: [],
+        pactMagic: { count: 1, slotLevel: 5 },
+      }),
+    });
+    const { container } = render(
+      <SpellSlotsPanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={vi.fn()} />
+    );
+    expect(container.firstChild).not.toBeNull();
+  });
+
+  it('clicking a pact slot calls onUpdate with pact key', async () => {
+    const onUpdate = vi.fn();
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({
+        slots: [],
+        pactMagic: { count: 2, slotLevel: 3 },
+      }),
+    });
+    render(
+      <SpellSlotsPanel
+        resolved={resolved}
+        character={buildMinimalCharacter({ spell_slots_used: {} })}
+        onUpdate={onUpdate}
+      />
+    );
+    await userEvent.click(screen.getAllByRole('button', { name: /use pact slot/i })[0]);
+    expect(onUpdate).toHaveBeenCalledWith({ spell_slots_used: { pact: 1 } });
+  });
+
+  it('treats spell_slots_used null as empty (all unfilled)', () => {
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({ slots: [1, 0, 0, 0, 0, 0, 0, 0, 0] }),
+    });
+    render(
+      <SpellSlotsPanel
+        resolved={resolved}
+        character={buildMinimalCharacter({ spell_slots_used: null })}
+        onUpdate={vi.fn()}
+      />
+    );
+    expect(screen.getByRole('button', { name: /use level 1 slot/i })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('does not call onUpdate on initial render', () => {
+    const onUpdate = vi.fn();
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({ slots: [2, 0, 0, 0, 0, 0, 0, 0, 0] }),
+    });
+    render(<SpellSlotsPanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={onUpdate} />);
+    expect(onUpdate).not.toHaveBeenCalled();
+  });
+});

--- a/src/components/character-sheet/SpellSlotsPanel.test.tsx
+++ b/src/components/character-sheet/SpellSlotsPanel.test.tsx
@@ -144,8 +144,8 @@ describe('SpellSlotsPanel', () => {
       spellcasting: makeSpellcasting({ slots: [4, 0, 0, 0, 0, 0, 0, 0, 0] }),
     });
     render(<SpellSlotsPanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={vi.fn()} />);
-    // 4 slot buttons for level 1
-    const slotButtons = screen.getAllByRole('button', { name: /use level 1 slot|recover level 1 slot/i });
+    // 4 slot buttons for level 1 — mock returns last segment of key: "useSlot" or "recoverSlot"
+    const slotButtons = screen.getAllByRole('button', { name: /useSlot|recoverSlot/i });
     expect(slotButtons).toHaveLength(4);
   });
 
@@ -178,7 +178,8 @@ describe('SpellSlotsPanel', () => {
         onUpdate={onUpdate}
       />
     );
-    await userEvent.click(screen.getAllByRole('button', { name: /use level 1 slot/i })[0]);
+    // mock returns last segment of key: "useSlot"
+    await userEvent.click(screen.getAllByRole('button', { name: /useSlot/i })[0]);
     expect(onUpdate).toHaveBeenCalledWith({ spell_slots_used: { '1': 1 } });
   });
 
@@ -194,8 +195,29 @@ describe('SpellSlotsPanel', () => {
         onUpdate={onUpdate}
       />
     );
-    // Both slots are filled — clicking either recovers one
-    await userEvent.click(screen.getAllByRole('button', { name: /recover level 1 slot/i })[0]);
+    // Both slots are filled — clicking pip i=0 (filled) sets used = 0
+    await userEvent.click(screen.getAllByRole('button', { name: /recoverSlot/i })[0]);
+    expect(onUpdate).toHaveBeenCalledWith({ spell_slots_used: { '1': 0 } });
+  });
+
+  it('clicking a partially-filled pip recovers slots above the clicked position', async () => {
+    // max=4, used=3 → pips 0,1,2 are filled, pip 3 is empty
+    // clicking pip i=1 (filled) sets used = 1 (recovers slots 2 and above)
+    const onUpdate = vi.fn();
+    const resolved = buildMinimalResolved({
+      spellcasting: makeSpellcasting({ slots: [4, 0, 0, 0, 0, 0, 0, 0, 0] }),
+    });
+    render(
+      <SpellSlotsPanel
+        resolved={resolved}
+        character={buildMinimalCharacter({ spell_slots_used: { '1': 3 } })}
+        onUpdate={onUpdate}
+      />
+    );
+    // All 4 pips rendered; pips 0,1,2 have aria-label "recoverSlot", pip 3 has "useSlot"
+    const filledPips = screen.getAllByRole('button', { name: /recoverSlot/i });
+    // filledPips[1] is pip i=1
+    await userEvent.click(filledPips[1]);
     expect(onUpdate).toHaveBeenCalledWith({ spell_slots_used: { '1': 1 } });
   });
 
@@ -207,7 +229,8 @@ describe('SpellSlotsPanel', () => {
       }),
     });
     render(<SpellSlotsPanel resolved={resolved} character={buildMinimalCharacter()} onUpdate={vi.fn()} />);
-    const pactButtons = screen.getAllByRole('button', { name: /pact slot/i });
+    // mock returns last key segment: "usePact" or "recoverPact"
+    const pactButtons = screen.getAllByRole('button', { name: /usePact|recoverPact/i });
     expect(pactButtons).toHaveLength(2);
   });
 
@@ -239,7 +262,8 @@ describe('SpellSlotsPanel', () => {
         onUpdate={onUpdate}
       />
     );
-    await userEvent.click(screen.getAllByRole('button', { name: /use pact slot/i })[0]);
+    // mock returns last key segment: "usePact"
+    await userEvent.click(screen.getAllByRole('button', { name: /usePact/i })[0]);
     expect(onUpdate).toHaveBeenCalledWith({ spell_slots_used: { pact: 1 } });
   });
 
@@ -254,7 +278,8 @@ describe('SpellSlotsPanel', () => {
         onUpdate={vi.fn()}
       />
     );
-    expect(screen.getByRole('button', { name: /use level 1 slot/i })).toHaveAttribute('aria-pressed', 'false');
+    // mock returns last key segment: "useSlot"
+    expect(screen.getByRole('button', { name: /useSlot/i })).toHaveAttribute('aria-pressed', 'false');
   });
 
   it('does not call onUpdate on initial render', () => {

--- a/src/components/character-sheet/SpellSlotsPanel.tsx
+++ b/src/components/character-sheet/SpellSlotsPanel.tsx
@@ -1,4 +1,4 @@
-import { getSpellSlotMax, markSpellSlot, recoverSpellSlot } from '@/lib/rest';
+import { getSpellSlotMax } from '@/lib/rest';
 import type { Character } from '@/types/database';
 import type { ResolvedCharacter } from '@/types/resolved';
 import { useTranslation } from 'react-i18next';
@@ -22,12 +22,10 @@ export function SpellSlotsPanel({ resolved, character, onUpdate }: SpellSlotsPan
   const max = getSpellSlotMax(resolved);
   const used = character.spell_slots_used ?? {};
 
-  function handleToggle(level: number | 'pact'): void {
-    const key = String(level);
-    const usedCount = used[key] ?? 0;
+  function handlePipClick(key: string, i: number, isFilled: boolean): void {
     const maxCount = max[key] ?? 0;
-    const next = usedCount < maxCount ? markSpellSlot(used, level, max) : recoverSpellSlot(used, level);
-    onUpdate({ spell_slots_used: next });
+    const newUsed = isFilled ? Math.max(0, i) : Math.min(i + 1, maxCount);
+    onUpdate({ spell_slots_used: { ...used, [key]: newUsed } });
   }
 
   return (
@@ -53,9 +51,13 @@ export function SpellSlotsPanel({ resolved, character, onUpdate }: SpellSlotsPan
                     <button
                       key={i}
                       type="button"
-                      aria-label={isFilled ? `recover level ${level} slot` : `use level ${level} slot`}
+                      aria-label={
+                        isFilled
+                          ? tc('characterSheet.spellSlots.recoverSlot', { level })
+                          : tc('characterSheet.spellSlots.useSlot', { level })
+                      }
                       aria-pressed={isFilled}
-                      onClick={() => handleToggle(level)}
+                      onClick={() => handlePipClick(key, i, isFilled)}
                       className={`size-6 rounded-full border-2 transition-colors cursor-pointer ${
                         isFilled
                           ? 'bg-primary border-primary'
@@ -83,9 +85,11 @@ export function SpellSlotsPanel({ resolved, character, onUpdate }: SpellSlotsPan
                   <button
                     key={i}
                     type="button"
-                    aria-label={isFilled ? 'recover pact slot' : 'use pact slot'}
+                    aria-label={
+                      isFilled ? tc('characterSheet.spellSlots.recoverPact') : tc('characterSheet.spellSlots.usePact')
+                    }
                     aria-pressed={isFilled}
-                    onClick={() => handleToggle('pact')}
+                    onClick={() => handlePipClick('pact', i, isFilled)}
                     className={`size-6 rounded-full border-2 transition-colors cursor-pointer ${
                       isFilled
                         ? 'bg-purple-600 border-purple-600'

--- a/src/components/character-sheet/SpellSlotsPanel.tsx
+++ b/src/components/character-sheet/SpellSlotsPanel.tsx
@@ -1,0 +1,101 @@
+import { getSpellSlotMax, markSpellSlot, recoverSpellSlot } from '@/lib/rest';
+import type { Character } from '@/types/database';
+import type { ResolvedCharacter } from '@/types/resolved';
+import { useTranslation } from 'react-i18next';
+
+interface SpellSlotsPanelProps {
+  readonly resolved: ResolvedCharacter;
+  readonly character: Character;
+  readonly onUpdate: (u: Partial<Character>) => void;
+}
+
+export function SpellSlotsPanel({ resolved, character, onUpdate }: SpellSlotsPanelProps): React.JSX.Element | null {
+  const { t: tc } = useTranslation('common');
+
+  const spellcasting = resolved.spellcasting;
+  if (!spellcasting) return null;
+
+  const hasNormalSlots = spellcasting.slots.some((n) => n > 0);
+  const hasPactMagic = spellcasting.pactMagic !== null;
+  if (!hasNormalSlots && !hasPactMagic) return null;
+
+  const max = getSpellSlotMax(resolved);
+  const used = character.spell_slots_used ?? {};
+
+  function handleToggle(level: number | 'pact'): void {
+    const key = String(level);
+    const usedCount = used[key] ?? 0;
+    const maxCount = max[key] ?? 0;
+    const next = usedCount < maxCount ? markSpellSlot(used, level, max) : recoverSpellSlot(used, level);
+    onUpdate({ spell_slots_used: next });
+  }
+
+  return (
+    <div className="bg-card border rounded-lg p-6">
+      <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.spellSlots')}</h2>
+      <div className="space-y-3">
+        {/* Normal spell slots: levels 1–9 */}
+        {spellcasting.slots.map((slotMax, index) => {
+          if (slotMax === 0) return null;
+          const level = index + 1;
+          const key = String(level);
+          const usedCount = used[key] ?? 0;
+
+          return (
+            <div key={level} className="flex items-center justify-between gap-3">
+              <span className="text-sm font-semibold text-foreground w-16 shrink-0">Level {level}</span>
+              <div className="flex gap-1 flex-wrap">
+                {Array.from({ length: slotMax }, (_, i) => {
+                  const isFilled = i < usedCount;
+                  return (
+                    <button
+                      key={i}
+                      type="button"
+                      aria-label={isFilled ? `recover level ${level} slot` : `use level ${level} slot`}
+                      aria-pressed={isFilled}
+                      onClick={() => handleToggle(level)}
+                      className={`size-6 rounded-full border-2 transition-colors cursor-pointer ${
+                        isFilled
+                          ? 'bg-primary border-primary'
+                          : 'bg-transparent border-muted-foreground hover:border-primary'
+                      }`}
+                    />
+                  );
+                })}
+              </div>
+            </div>
+          );
+        })}
+
+        {/* Pact magic row */}
+        {hasPactMagic && spellcasting.pactMagic !== null && (
+          <div className="flex items-center justify-between gap-3">
+            <span className="text-sm font-semibold text-foreground w-16 shrink-0">
+              Pact (L{spellcasting.pactMagic.slotLevel})
+            </span>
+            <div className="flex gap-1 flex-wrap">
+              {Array.from({ length: spellcasting.pactMagic.count }, (_, i) => {
+                const usedCount = used['pact'] ?? 0;
+                const isFilled = i < usedCount;
+                return (
+                  <button
+                    key={i}
+                    type="button"
+                    aria-label={isFilled ? 'recover pact slot' : 'use pact slot'}
+                    aria-pressed={isFilled}
+                    onClick={() => handleToggle('pact')}
+                    className={`size-6 rounded-full border-2 transition-colors cursor-pointer ${
+                      isFilled
+                        ? 'bg-purple-600 border-purple-600'
+                        : 'bg-transparent border-muted-foreground hover:border-purple-600'
+                    }`}
+                  />
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/character-sheet/SpellSlotsPanel.tsx
+++ b/src/components/character-sheet/SpellSlotsPanel.tsx
@@ -43,7 +43,9 @@ export function SpellSlotsPanel({ resolved, character, onUpdate }: SpellSlotsPan
 
           return (
             <div key={level} className="flex items-center justify-between gap-3">
-              <span className="text-sm font-semibold text-foreground w-16 shrink-0">Level {level}</span>
+              <span className="text-sm font-semibold text-foreground w-16 shrink-0">
+                {tc('characterSheet.spellSlots.levelLabel', { level })}
+              </span>
               <div className="flex gap-1 flex-wrap">
                 {Array.from({ length: slotMax }, (_, i) => {
                   const isFilled = i < usedCount;
@@ -71,7 +73,7 @@ export function SpellSlotsPanel({ resolved, character, onUpdate }: SpellSlotsPan
         {hasPactMagic && spellcasting.pactMagic !== null && (
           <div className="flex items-center justify-between gap-3">
             <span className="text-sm font-semibold text-foreground w-16 shrink-0">
-              Pact (L{spellcasting.pactMagic.slotLevel})
+              {tc('characterSheet.spellSlots.pactLabel', { slotLevel: spellcasting.pactMagic.slotLevel })}
             </span>
             <div className="flex gap-1 flex-wrap">
               {Array.from({ length: spellcasting.pactMagic.count }, (_, i) => {

--- a/src/hooks/useBuilderAutosave.test.ts
+++ b/src/hooks/useBuilderAutosave.test.ts
@@ -57,6 +57,8 @@ const basePayload: AutosavePayload = {
     heroic_inspiration: false,
     exhaustion_level: 0 as const,
     conditions: [],
+    hit_dice_used: null,
+    spell_slots_used: null,
   },
   rows: [],
   resolved: null,

--- a/src/hooks/useCharacterContext.test.tsx
+++ b/src/hooks/useCharacterContext.test.tsx
@@ -176,6 +176,8 @@ function buildSeedCharacter(overrides: Partial<Character> = {}): Character {
     heroic_inspiration: false,
     exhaustion_level: 0 as const,
     conditions: [],
+    hit_dice_used: null,
+    spell_slots_used: null,
     ...overrides,
   };
 }

--- a/src/hooks/useCharacters.test.ts
+++ b/src/hooks/useCharacters.test.ts
@@ -56,6 +56,8 @@ const baseCharacter: Character = {
   heroic_inspiration: false,
   exhaustion_level: 0 as const,
   conditions: [],
+  hit_dice_used: null,
+  spell_slots_used: null,
 };
 
 setupMockReset();

--- a/src/lib/export-sql.test.ts
+++ b/src/lib/export-sql.test.ts
@@ -280,6 +280,24 @@ describe('generateSeedSql', () => {
     expect(sql).toContain("ARRAY['blinded', 'charmed']::text[]");
   });
 
+  it('character INSERT includes hit_dice_used and spell_slots_used as jsonb', () => {
+    const data: ExportData = {
+      ...emptyData,
+      characters: [
+        {
+          id: 'ch1',
+          campaign_id: 'c1',
+          name: 'Hero',
+          hit_dice_used: { '8': 2 },
+          spell_slots_used: { '1': 1 },
+        },
+      ],
+    };
+    const sql = generateSeedSql(data);
+    expect(sql).toContain('\'{"8":2}\'::jsonb');
+    expect(sql).toContain('\'{"1":1}\'::jsonb');
+  });
+
   it('character INSERT uses species column not race', () => {
     const data: ExportData = {
       ...emptyData,

--- a/src/lib/export-sql.ts
+++ b/src/lib/export-sql.ts
@@ -62,6 +62,8 @@ const TABLE_COLUMNS = {
     { name: 'heroic_inspiration', type: 'boolean' },
     { name: 'exhaustion_level', type: 'integer' },
     { name: 'conditions', type: 'text[]' },
+    { name: 'hit_dice_used', type: 'jsonb' },
+    { name: 'spell_slots_used', type: 'jsonb' },
     { name: 'gender', type: 'text' },
     { name: 'size', type: 'text' },
     { name: 'age', type: 'text' },

--- a/src/lib/query-columns.test.ts
+++ b/src/lib/query-columns.test.ts
@@ -22,4 +22,12 @@ describe('CHARACTER_DETAIL_COLS', () => {
   it('contains conditions so the sheet loads persisted conditions (word boundary match)', () => {
     expect(CHARACTER_DETAIL_COLS).toMatch(/\bconditions\b/);
   });
+
+  it('contains hit_dice_used so the sheet loads hit dice tracking (word boundary match)', () => {
+    expect(CHARACTER_DETAIL_COLS).toMatch(/\bhit_dice_used\b/);
+  });
+
+  it('contains spell_slots_used so the sheet loads spell slot tracking (word boundary match)', () => {
+    expect(CHARACTER_DETAIL_COLS).toMatch(/\bspell_slots_used\b/);
+  });
 });

--- a/src/lib/query-columns.ts
+++ b/src/lib/query-columns.ts
@@ -6,7 +6,7 @@ export const CAMPAIGN_DETAIL_COLS =
 export const CHARACTER_SUMMARY_COLS =
   'id, slug, previous_slugs, campaign_id, name, player_name, character_type, species, class, subclass, level, hit_points_max, armor_class, updated_at' as const;
 export const CHARACTER_DETAIL_COLS =
-  'id, slug, previous_slugs, campaign_id, name, player_name, character_type, species, class, subclass, background, alignment, gender, size, age, height, weight, eye_color, hair_color, skin_color, level, hit_points_max, armor_class, speed, proficiency_bonus, heroic_inspiration, exhaustion_level, conditions, personality_traits, ideals, bonds, flaws, appearance, backstory, notes, portrait_url, is_active, status, created_at, updated_at' as const;
+  'id, slug, previous_slugs, campaign_id, name, player_name, character_type, species, class, subclass, background, alignment, gender, size, age, height, weight, eye_color, hair_color, skin_color, level, hit_points_max, armor_class, speed, proficiency_bonus, heroic_inspiration, exhaustion_level, conditions, hit_dice_used, spell_slots_used, personality_traits, ideals, bonds, flaws, appearance, backstory, notes, portrait_url, is_active, status, created_at, updated_at' as const;
 
 export const SESSION_SUMMARY_COLS =
   'id, slug, previous_slugs, campaign_id, session_number, name, date, summary, experience_awarded, created_at, updated_at' as const;

--- a/src/lib/rest.test.ts
+++ b/src/lib/rest.test.ts
@@ -7,6 +7,7 @@ import {
   recoverSpellSlot,
   applyShortRest,
   applyLongRest,
+  buildRestUpdate,
   type HitDiceUsed,
   type SpellSlotsUsed,
   type RestUsed,
@@ -344,16 +345,17 @@ describe('applyLongRest', () => {
   });
 
   it('recovery budget is based on total character level, not stored used count', () => {
-    // 3 hit dice total, 0 used → budget = floor(3/2) = 1 but nothing to recover
-    // This verifies budget comes from hitDie.count, not from what's stored in hitDiceUsed
+    // totalLevel = 2 (count=2) → budget = max(1, floor(2/2)) = 1
+    // used = 4 → a used-count-derived budget would be 4; level-derived budget is 1
+    // so only 1 die is recovered: 4 - 1 = 3
     const used: RestUsed = {
-      hitDiceUsed: { '8': 0 },
+      hitDiceUsed: { '8': 4 },
       spellSlotsUsed: {},
     };
-    const resolved = makeResolved({ hitDie: [{ die: 8, count: 3 }] });
+    const resolved = makeResolved({ hitDie: [{ die: 8, count: 2 }] });
     const result = applyLongRest(used, resolved);
-    // budget = floor(3/2) = 1; but 0 used, so nothing changes
-    expect(result.hitDiceUsed['8']).toBe(0);
+    // budget comes from level (1), not from used (4) — proves level-derived formula
+    expect(result.hitDiceUsed['8']).toBe(3);
   });
 
   it('does not recover more than what is used (cannot go below 0)', () => {
@@ -412,5 +414,79 @@ describe('applyLongRest', () => {
     applyLongRest(used, resolved);
     expect(hitDiceUsed).toEqual({ '8': 3 });
     expect(spellSlotsUsed).toEqual({ '1': 2 });
+  });
+});
+
+// ─── buildRestUpdate ──────────────────────────────────────────────────────────
+
+describe('buildRestUpdate', () => {
+  it('long rest resets all spell slots and recovers hit dice, returning both columns', () => {
+    // level 4 → budget = floor(4/2) = 2; used 3 of 4 → recovers 2 → used becomes 1
+    const character = {
+      hit_dice_used: { '8': 3 } as HitDiceUsed,
+      spell_slots_used: { '1': 4, '2': 3, pact: 2 } as SpellSlotsUsed,
+    };
+    const resolved = makeResolved({
+      hitDie: [{ die: 8, count: 4 }],
+      spellcasting: makeSpellcasting({ slots: [4, 3, 0, 0, 0, 0, 0, 0, 0] }),
+    });
+    const result = buildRestUpdate('long', character, resolved);
+    // Both columns must be present
+    expect(result).toHaveProperty('hit_dice_used');
+    expect(result).toHaveProperty('spell_slots_used');
+    // All spell slots reset to 0
+    expect(result.spell_slots_used).toEqual({ '1': 0, '2': 0, pact: 0 });
+    // Hit dice recovered by budget (2): 3 - 2 = 1
+    expect(result.hit_dice_used['8']).toBe(1);
+  });
+
+  it('short rest leaves hit_dice_used untouched and resets only pact slots', () => {
+    const character = {
+      hit_dice_used: { '8': 2 } as HitDiceUsed,
+      spell_slots_used: { '1': 3, pact: 2 } as SpellSlotsUsed,
+    };
+    const resolved = makeResolved({
+      hitDie: [{ die: 8, count: 4 }],
+      spellcasting: makeSpellcasting({
+        slots: [4, 0, 0, 0, 0, 0, 0, 0, 0],
+        pactMagic: { count: 2, slotLevel: 3 },
+      }),
+    });
+    const result = buildRestUpdate('short', character, resolved);
+    // Both columns returned
+    expect(result).toHaveProperty('hit_dice_used');
+    expect(result).toHaveProperty('spell_slots_used');
+    // Hit dice unchanged
+    expect(result.hit_dice_used).toEqual({ '8': 2 });
+    // Normal spell slots unchanged; pact reset to 0
+    expect(result.spell_slots_used['1']).toBe(3);
+    expect(result.spell_slots_used['pact']).toBe(0);
+  });
+
+  it('short rest with no pact magic returns hit_dice_used unchanged', () => {
+    const character = {
+      hit_dice_used: { '10': 1 } as HitDiceUsed,
+      spell_slots_used: { '1': 2 } as SpellSlotsUsed,
+    };
+    const resolved = makeResolved({
+      hitDie: [{ die: 10, count: 3 }],
+      spellcasting: makeSpellcasting({ slots: [4, 0, 0, 0, 0, 0, 0, 0, 0], pactMagic: null }),
+    });
+    const result = buildRestUpdate('short', character, resolved);
+    expect(result.hit_dice_used).toEqual({ '10': 1 });
+    expect(result.spell_slots_used).toEqual({ '1': 2 });
+  });
+
+  it('handles null hit_dice_used and spell_slots_used (treats both as empty)', () => {
+    const character = {
+      hit_dice_used: null as unknown as HitDiceUsed,
+      spell_slots_used: null as unknown as SpellSlotsUsed,
+    };
+    const resolved = makeResolved({
+      hitDie: [{ die: 8, count: 2 }],
+    });
+    const result = buildRestUpdate('long', character, resolved);
+    expect(result.hit_dice_used).toEqual({});
+    expect(result.spell_slots_used).toEqual({});
   });
 });

--- a/src/lib/rest.test.ts
+++ b/src/lib/rest.test.ts
@@ -1,0 +1,416 @@
+import { describe, it, expect } from 'vitest';
+import {
+  getHitDiceMax,
+  getSpellSlotMax,
+  spendHitDie,
+  markSpellSlot,
+  recoverSpellSlot,
+  applyShortRest,
+  applyLongRest,
+  type HitDiceUsed,
+  type SpellSlotsUsed,
+  type RestUsed,
+} from '@/lib/rest';
+import type { ResolvedCharacter } from '@/types/resolved';
+
+// Minimal resolved character factory
+function makeResolved(overrides: Partial<ResolvedCharacter> = {}): ResolvedCharacter {
+  return {
+    abilities: {} as ResolvedCharacter['abilities'],
+    hitDie: [],
+    hitPoints: { max: 0 },
+    speed: {},
+    initiative: 0,
+    proficiencyBonus: 2,
+    armorClass: { calculations: [], bonuses: [], effective: 10 },
+    savingThrows: {} as ResolvedCharacter['savingThrows'],
+    skills: {} as ResolvedCharacter['skills'],
+    armorProficiencies: [],
+    weaponProficiencies: [],
+    toolProficiencies: [],
+    languages: [],
+    features: [],
+    resistances: [],
+    immunities: [],
+    spellcasting: null,
+    equipment: [],
+    attacks: [],
+    toolExpertise: [],
+    bardicInspiration: null,
+    pendingChoices: [],
+    weaponMasteries: [],
+    resourcePools: [],
+    ...overrides,
+  };
+}
+
+function makeSpellcasting(
+  overrides: Partial<ResolvedCharacter['spellcasting']> = {}
+): NonNullable<ResolvedCharacter['spellcasting']> {
+  return {
+    ability: 'wis',
+    spellSaveDC: 14,
+    spellAttackBonus: 6,
+    cantrips: [],
+    knownSpells: [],
+    alwaysPreparedSpells: [],
+    slots: [],
+    preparedCount: 0,
+    pactMagic: null,
+    ...overrides,
+  };
+}
+
+// ─── getHitDiceMax ────────────────────────────────────────────────────────────
+
+describe('getHitDiceMax', () => {
+  it('returns empty object when hitDie is empty', () => {
+    const resolved = makeResolved({ hitDie: [] });
+    expect(getHitDiceMax(resolved)).toEqual({});
+  });
+
+  it('returns single die entry for a single-class character', () => {
+    const resolved = makeResolved({ hitDie: [{ die: 8, count: 3 }] });
+    expect(getHitDiceMax(resolved)).toEqual({ '8': 3 });
+  });
+
+  it('combines counts for duplicate die sizes (multiclass same die)', () => {
+    const resolved = makeResolved({
+      hitDie: [
+        { die: 8, count: 2 },
+        { die: 8, count: 1 },
+      ],
+    });
+    expect(getHitDiceMax(resolved)).toEqual({ '8': 3 });
+  });
+
+  it('returns separate entries for different die sizes (multiclass)', () => {
+    const resolved = makeResolved({
+      hitDie: [
+        { die: 12, count: 2 },
+        { die: 8, count: 3 },
+      ],
+    });
+    expect(getHitDiceMax(resolved)).toEqual({ '12': 2, '8': 3 });
+  });
+});
+
+// ─── getSpellSlotMax ──────────────────────────────────────────────────────────
+
+describe('getSpellSlotMax', () => {
+  it('returns empty object when spellcasting is null', () => {
+    const resolved = makeResolved({ spellcasting: null });
+    expect(getSpellSlotMax(resolved)).toEqual({});
+  });
+
+  it('skips levels with 0 slots', () => {
+    const resolved = makeResolved({
+      spellcasting: makeSpellcasting({ slots: [2, 0, 0, 0, 0, 0, 0, 0, 0] }),
+    });
+    expect(getSpellSlotMax(resolved)).toEqual({ '1': 2 });
+  });
+
+  it('keys are 1-based spell level strings', () => {
+    // slots[0] = level 1, slots[1] = level 2, etc.
+    const resolved = makeResolved({
+      spellcasting: makeSpellcasting({ slots: [4, 3, 2, 1, 0, 0, 0, 0, 0] }),
+    });
+    expect(getSpellSlotMax(resolved)).toEqual({ '1': 4, '2': 3, '3': 2, '4': 1 });
+  });
+
+  it('includes pact magic as "pact" key when present', () => {
+    const resolved = makeResolved({
+      spellcasting: makeSpellcasting({
+        slots: [],
+        pactMagic: { count: 2, slotLevel: 3 },
+      }),
+    });
+    expect(getSpellSlotMax(resolved)).toEqual({ pact: 2 });
+  });
+
+  it('includes both normal slots and pact when both present (edge case)', () => {
+    const resolved = makeResolved({
+      spellcasting: makeSpellcasting({
+        slots: [2, 0, 0, 0, 0, 0, 0, 0, 0],
+        pactMagic: { count: 1, slotLevel: 1 },
+      }),
+    });
+    expect(getSpellSlotMax(resolved)).toEqual({ '1': 2, pact: 1 });
+  });
+});
+
+// ─── spendHitDie ─────────────────────────────────────────────────────────────
+
+describe('spendHitDie', () => {
+  it('increments used count for the given die', () => {
+    const used: HitDiceUsed = {};
+    const maxByDie: HitDiceUsed = { '8': 3 };
+    expect(spendHitDie(used, 8, maxByDie)).toEqual({ '8': 1 });
+  });
+
+  it('does not mutate the input object', () => {
+    const used: HitDiceUsed = { '8': 1 };
+    const maxByDie: HitDiceUsed = { '8': 3 };
+    const result = spendHitDie(used, 8, maxByDie);
+    expect(used).toEqual({ '8': 1 });
+    expect(result).toEqual({ '8': 2 });
+  });
+
+  it('is clamped at max and returns original object when already at max', () => {
+    const used: HitDiceUsed = { '8': 3 };
+    const maxByDie: HitDiceUsed = { '8': 3 };
+    const result = spendHitDie(used, 8, maxByDie);
+    expect(result).toBe(used); // same reference — no change
+  });
+
+  it('returns unchanged object when die size is not in max', () => {
+    const used: HitDiceUsed = {};
+    const maxByDie: HitDiceUsed = {};
+    const result = spendHitDie(used, 12, maxByDie);
+    expect(result).toBe(used);
+  });
+});
+
+// ─── markSpellSlot ────────────────────────────────────────────────────────────
+
+describe('markSpellSlot', () => {
+  it('increments used count for the given level', () => {
+    const used: SpellSlotsUsed = {};
+    const max: SpellSlotsUsed = { '1': 4 };
+    expect(markSpellSlot(used, 1, max)).toEqual({ '1': 1 });
+  });
+
+  it('does not mutate the input object', () => {
+    const used: SpellSlotsUsed = { '1': 1 };
+    const max: SpellSlotsUsed = { '1': 4 };
+    const result = markSpellSlot(used, 1, max);
+    expect(used).toEqual({ '1': 1 });
+    expect(result).toEqual({ '1': 2 });
+  });
+
+  it('is clamped at max and returns original object when all slots used', () => {
+    const used: SpellSlotsUsed = { '1': 4 };
+    const max: SpellSlotsUsed = { '1': 4 };
+    const result = markSpellSlot(used, 1, max);
+    expect(result).toBe(used);
+  });
+
+  it('accepts "pact" as level string for warlock pact magic', () => {
+    const used: SpellSlotsUsed = {};
+    const max: SpellSlotsUsed = { pact: 2 };
+    expect(markSpellSlot(used, 'pact', max)).toEqual({ pact: 1 });
+  });
+});
+
+// ─── recoverSpellSlot ─────────────────────────────────────────────────────────
+
+describe('recoverSpellSlot', () => {
+  it('decrements used count for the given level', () => {
+    const used: SpellSlotsUsed = { '1': 2 };
+    expect(recoverSpellSlot(used, 1)).toEqual({ '1': 1 });
+  });
+
+  it('does not mutate the input object', () => {
+    const used: SpellSlotsUsed = { '1': 2 };
+    const result = recoverSpellSlot(used, 1);
+    expect(used).toEqual({ '1': 2 });
+    expect(result).toEqual({ '1': 1 });
+  });
+
+  it('is clamped at 0 and returns original object when already 0', () => {
+    const used: SpellSlotsUsed = { '1': 0 };
+    const result = recoverSpellSlot(used, 1);
+    expect(result).toBe(used);
+  });
+
+  it('is clamped at 0 for missing keys (treat as 0)', () => {
+    const used: SpellSlotsUsed = {};
+    const result = recoverSpellSlot(used, 1);
+    expect(result).toBe(used);
+  });
+
+  it('accepts "pact" as level string', () => {
+    const used: SpellSlotsUsed = { pact: 1 };
+    expect(recoverSpellSlot(used, 'pact')).toEqual({ pact: 0 });
+  });
+});
+
+// ─── applyShortRest ───────────────────────────────────────────────────────────
+
+describe('applyShortRest', () => {
+  it('resets pact slots to 0 when pact magic is present', () => {
+    const used: RestUsed = {
+      hitDiceUsed: { '8': 2 },
+      spellSlotsUsed: { pact: 2 },
+    };
+    const resolved = makeResolved({
+      spellcasting: makeSpellcasting({ pactMagic: { count: 2, slotLevel: 3 } }),
+    });
+    const result = applyShortRest(used, resolved);
+    expect(result.spellSlotsUsed).toEqual({ pact: 0 });
+  });
+
+  it('does not change hit dice on short rest', () => {
+    const used: RestUsed = {
+      hitDiceUsed: { '8': 2 },
+      spellSlotsUsed: { pact: 2 },
+    };
+    const resolved = makeResolved({
+      spellcasting: makeSpellcasting({ pactMagic: { count: 2, slotLevel: 3 } }),
+    });
+    const result = applyShortRest(used, resolved);
+    expect(result.hitDiceUsed).toEqual({ '8': 2 });
+  });
+
+  it('does not change normal spell slots on short rest', () => {
+    const used: RestUsed = {
+      hitDiceUsed: {},
+      spellSlotsUsed: { '1': 3, pact: 1 },
+    };
+    const resolved = makeResolved({
+      spellcasting: makeSpellcasting({ pactMagic: { count: 2, slotLevel: 3 } }),
+    });
+    const result = applyShortRest(used, resolved);
+    expect(result.spellSlotsUsed['1']).toBe(3);
+    expect(result.spellSlotsUsed['pact']).toBe(0);
+  });
+
+  it('returns original used object unchanged when spellcasting is null', () => {
+    const used: RestUsed = {
+      hitDiceUsed: { '8': 1 },
+      spellSlotsUsed: { '1': 2 },
+    };
+    const resolved = makeResolved({ spellcasting: null });
+    const result = applyShortRest(used, resolved);
+    expect(result).toBe(used);
+  });
+
+  it('returns original used object unchanged when no pact magic', () => {
+    const used: RestUsed = {
+      hitDiceUsed: { '8': 1 },
+      spellSlotsUsed: { '1': 2 },
+    };
+    const resolved = makeResolved({
+      spellcasting: makeSpellcasting({ pactMagic: null }),
+    });
+    const result = applyShortRest(used, resolved);
+    expect(result).toBe(used);
+  });
+});
+
+// ─── applyLongRest ────────────────────────────────────────────────────────────
+
+describe('applyLongRest', () => {
+  it('resets all normal spell slots to 0', () => {
+    const used: RestUsed = {
+      hitDiceUsed: {},
+      spellSlotsUsed: { '1': 4, '2': 3, '3': 2 },
+    };
+    const resolved = makeResolved({ hitDie: [{ die: 8, count: 1 }] });
+    const result = applyLongRest(used, resolved);
+    expect(result.spellSlotsUsed).toEqual({ '1': 0, '2': 0, '3': 0 });
+  });
+
+  it('resets pact spell slots to 0', () => {
+    const used: RestUsed = {
+      hitDiceUsed: {},
+      spellSlotsUsed: { pact: 2 },
+    };
+    const resolved = makeResolved({ hitDie: [{ die: 8, count: 1 }] });
+    const result = applyLongRest(used, resolved);
+    expect(result.spellSlotsUsed).toEqual({ pact: 0 });
+  });
+
+  it('recovers floor(level/2) hit dice for single class at level 4', () => {
+    // level 4: budget = floor(4/2) = 2; used 3 of 4; recover 2 → used becomes 1
+    const used: RestUsed = {
+      hitDiceUsed: { '8': 3 },
+      spellSlotsUsed: {},
+    };
+    const resolved = makeResolved({ hitDie: [{ die: 8, count: 4 }] });
+    const result = applyLongRest(used, resolved);
+    expect(result.hitDiceUsed['8']).toBe(1);
+  });
+
+  it('enforces minimum recovery of 1 at level 1', () => {
+    // level 1: budget = max(1, floor(1/2)) = max(1, 0) = 1
+    const used: RestUsed = {
+      hitDiceUsed: { '8': 1 },
+      spellSlotsUsed: {},
+    };
+    const resolved = makeResolved({ hitDie: [{ die: 8, count: 1 }] });
+    const result = applyLongRest(used, resolved);
+    expect(result.hitDiceUsed['8']).toBe(0);
+  });
+
+  it('recovery budget is based on total character level, not stored used count', () => {
+    // 3 hit dice total, 0 used → budget = floor(3/2) = 1 but nothing to recover
+    // This verifies budget comes from hitDie.count, not from what's stored in hitDiceUsed
+    const used: RestUsed = {
+      hitDiceUsed: { '8': 0 },
+      spellSlotsUsed: {},
+    };
+    const resolved = makeResolved({ hitDie: [{ die: 8, count: 3 }] });
+    const result = applyLongRest(used, resolved);
+    // budget = floor(3/2) = 1; but 0 used, so nothing changes
+    expect(result.hitDiceUsed['8']).toBe(0);
+  });
+
+  it('does not recover more than what is used (cannot go below 0)', () => {
+    // level 10 → budget = 5; but only 2 used
+    const used: RestUsed = {
+      hitDiceUsed: { '8': 2 },
+      spellSlotsUsed: {},
+    };
+    const resolved = makeResolved({ hitDie: [{ die: 8, count: 10 }] });
+    const result = applyLongRest(used, resolved);
+    expect(result.hitDiceUsed['8']).toBe(0);
+  });
+
+  it('allocates recovery largest-die-first for multiclass characters', () => {
+    // Fighter 3 (d10) + Wizard 3 (d6) = level 6, budget = 3
+    // Largest die first: recover from d10 first
+    // Used: d10=3, d6=2 → budget 3 → recover 3 from d10 → d10=0, d6=2 (budget exhausted)
+    const used: RestUsed = {
+      hitDiceUsed: { '10': 3, '6': 2 },
+      spellSlotsUsed: {},
+    };
+    const resolved = makeResolved({
+      hitDie: [
+        { die: 10, count: 3 },
+        { die: 6, count: 3 },
+      ],
+    });
+    const result = applyLongRest(used, resolved);
+    expect(result.hitDiceUsed['10']).toBe(0);
+    expect(result.hitDiceUsed['6']).toBe(2); // budget exhausted after d10
+  });
+
+  it('continues to smaller dice when larger dice are fully recovered', () => {
+    // Fighter 2 (d10) + Wizard 4 (d6) = level 6, budget = 3
+    // Used: d10=2, d6=2 → recover 2 from d10 (budget left = 1) → recover 1 from d6
+    const used: RestUsed = {
+      hitDiceUsed: { '10': 2, '6': 2 },
+      spellSlotsUsed: {},
+    };
+    const resolved = makeResolved({
+      hitDie: [
+        { die: 10, count: 2 },
+        { die: 6, count: 4 },
+      ],
+    });
+    const result = applyLongRest(used, resolved);
+    expect(result.hitDiceUsed['10']).toBe(0);
+    expect(result.hitDiceUsed['6']).toBe(1); // 1 recovered from d6
+  });
+
+  it('does not mutate the input used object', () => {
+    const hitDiceUsed: HitDiceUsed = { '8': 3 };
+    const spellSlotsUsed: SpellSlotsUsed = { '1': 2 };
+    const used: RestUsed = { hitDiceUsed, spellSlotsUsed };
+    const resolved = makeResolved({ hitDie: [{ die: 8, count: 4 }] });
+    applyLongRest(used, resolved);
+    expect(hitDiceUsed).toEqual({ '8': 3 });
+    expect(spellSlotsUsed).toEqual({ '1': 2 });
+  });
+});

--- a/src/lib/rest.ts
+++ b/src/lib/rest.ts
@@ -1,3 +1,4 @@
+import type { Character } from '@/types/database';
 import type { ResolvedCharacter } from '@/types/resolved';
 
 // Local aliases for clarity
@@ -85,6 +86,23 @@ export function recoverSpellSlot(used: SpellSlotsUsed, level: number | 'pact'): 
   const currentUsed = used[key] ?? 0;
   if (currentUsed <= 0) return used;
   return { ...used, [key]: currentUsed - 1 };
+}
+
+/**
+ * Builds the Partial<Character> update payload for a short or long rest.
+ * Pure function — safe to test without any component or mutation machinery.
+ */
+export function buildRestUpdate(
+  kind: 'short' | 'long',
+  character: Pick<Character, 'hit_dice_used' | 'spell_slots_used'>,
+  resolved: ResolvedCharacter
+): { hit_dice_used: HitDiceUsed; spell_slots_used: SpellSlotsUsed } {
+  const restUsed: RestUsed = {
+    hitDiceUsed: character.hit_dice_used ?? {},
+    spellSlotsUsed: character.spell_slots_used ?? {},
+  };
+  const next = kind === 'short' ? applyShortRest(restUsed, resolved) : applyLongRest(restUsed, resolved);
+  return { hit_dice_used: next.hitDiceUsed, spell_slots_used: next.spellSlotsUsed };
 }
 
 /**

--- a/src/lib/rest.ts
+++ b/src/lib/rest.ts
@@ -1,0 +1,141 @@
+import type { ResolvedCharacter } from '@/types/resolved';
+
+// Local aliases for clarity
+export type HitDiceUsed = Record<string, number>;
+export type SpellSlotsUsed = Record<string, number>;
+
+export interface RestUsed {
+  readonly hitDiceUsed: HitDiceUsed;
+  readonly spellSlotsUsed: SpellSlotsUsed;
+}
+
+/**
+ * Returns the maximum hit dice available, keyed by die size string.
+ * E.g. { "8": 3 } for a level-3 cleric.
+ */
+export function getHitDiceMax(resolved: ResolvedCharacter): HitDiceUsed {
+  const max: Record<string, number> = {};
+  for (const { die, count } of resolved.hitDie) {
+    const key = String(die);
+    max[key] = (max[key] ?? 0) + count;
+  }
+  return max;
+}
+
+/**
+ * Returns the maximum spell slots available, keyed by spell-level string "1".."9".
+ * Pact magic is keyed as "pact" with value pactMagic.count.
+ * Levels with 0 slots are omitted.
+ */
+export function getSpellSlotMax(resolved: ResolvedCharacter): SpellSlotsUsed {
+  if (!resolved.spellcasting) return {};
+
+  const max: Record<string, number> = {};
+
+  // Normal spell slots: slots[i] = slots for spell level i+1
+  resolved.spellcasting.slots.forEach((count, index) => {
+    if (count > 0) {
+      max[String(index + 1)] = count;
+    }
+  });
+
+  // Pact magic
+  if (resolved.spellcasting.pactMagic !== null) {
+    max['pact'] = resolved.spellcasting.pactMagic.count;
+  }
+
+  return max;
+}
+
+/**
+ * Spends one hit die of the given size.
+ * Increments used[String(dieSize)] clamped to the max for that die.
+ * Returns a new object (no mutation).
+ */
+export function spendHitDie(used: HitDiceUsed, dieSize: number, maxByDie: HitDiceUsed): HitDiceUsed {
+  const key = String(dieSize);
+  const currentUsed = used[key] ?? 0;
+  const max = maxByDie[key] ?? 0;
+  if (currentUsed >= max) return used;
+  return { ...used, [key]: currentUsed + 1 };
+}
+
+/**
+ * Marks one spell slot of the given level as used.
+ * Increments used[String(level)] clamped to max[String(level)].
+ * level may be a number (1-9) or 'pact'.
+ * Returns a new object (no mutation).
+ */
+export function markSpellSlot(used: SpellSlotsUsed, level: number | 'pact', max: SpellSlotsUsed): SpellSlotsUsed {
+  const key = String(level);
+  const currentUsed = used[key] ?? 0;
+  const maxForLevel = max[key] ?? 0;
+  if (currentUsed >= maxForLevel) return used;
+  return { ...used, [key]: currentUsed + 1 };
+}
+
+/**
+ * Recovers one spell slot of the given level (decrements used).
+ * Clamped at 0 — cannot go negative.
+ * level may be a number (1-9) or 'pact'.
+ * Returns a new object (no mutation).
+ */
+export function recoverSpellSlot(used: SpellSlotsUsed, level: number | 'pact'): SpellSlotsUsed {
+  const key = String(level);
+  const currentUsed = used[key] ?? 0;
+  if (currentUsed <= 0) return used;
+  return { ...used, [key]: currentUsed - 1 };
+}
+
+/**
+ * Applies a short rest.
+ * - Resets pact magic slots to 0 if the character has pact magic.
+ * - Hit dice and normal spell slots are unchanged.
+ * Returns new objects (no mutation).
+ */
+export function applyShortRest(used: RestUsed, resolved: ResolvedCharacter): RestUsed {
+  if (resolved.spellcasting?.pactMagic !== null && resolved.spellcasting?.pactMagic !== undefined) {
+    return {
+      hitDiceUsed: used.hitDiceUsed,
+      spellSlotsUsed: { ...used.spellSlotsUsed, pact: 0 },
+    };
+  }
+  return used;
+}
+
+/**
+ * Applies a long rest.
+ * - Resets ALL spell slots (including pact) to 0.
+ * - Recovers hit dice: budget = max(1, floor(totalLevel / 2)), allocated
+ *   largest-die-first (documented simplification — RAW lets the player choose).
+ * Returns new objects (no mutation).
+ */
+export function applyLongRest(used: RestUsed, resolved: ResolvedCharacter): RestUsed {
+  // Reset all spell slots
+  const spellSlotsUsed: SpellSlotsUsed = {};
+  for (const key of Object.keys(used.spellSlotsUsed)) {
+    spellSlotsUsed[key] = 0;
+  }
+
+  // Recover hit dice: budget = max(1, floor(totalLevel / 2))
+  const totalLevel = resolved.hitDie.reduce((sum, { count }) => sum + count, 0);
+  let budget = Math.max(1, Math.floor(totalLevel / 2));
+
+  const hitDiceUsed = { ...used.hitDiceUsed };
+
+  // Sort hit die entries by die size descending (largest first)
+  const sortedDice = [...resolved.hitDie].sort((a, b) => b.die - a.die);
+
+  for (const { die } of sortedDice) {
+    if (budget <= 0) break;
+    const key = String(die);
+    const currentUsed = hitDiceUsed[key] ?? 0;
+    if (currentUsed <= 0) continue;
+    // Recover as many dice of this size as the budget allows
+    const recover = Math.min(budget, currentUsed);
+    hitDiceUsed[key] = currentUsed - recover;
+    budget -= recover;
+  }
+
+  return { hitDiceUsed, spellSlotsUsed };
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -383,6 +383,15 @@
       "hitDice": "Hit Dice",
       "spellSlots": "Spell Slots"
     },
+    "hitDice": {
+      "dieLabel": "d{{die}} × {{count}}",
+      "available": "{{available}} / {{max}} available",
+      "spend": "Spend"
+    },
+    "spellSlots": {
+      "levelLabel": "Level {{level}}",
+      "pactLabel": "Pact (L{{slotLevel}})"
+    },
     "fields": {
       "class": "Class",
       "level": "Level",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -379,7 +379,9 @@
       "attacks": "Attacks",
       "resourcePools": "Resource Pools",
       "conditions": "Conditions",
-      "saveDC": "Save DC"
+      "saveDC": "Save DC",
+      "hitDice": "Hit Dice",
+      "spellSlots": "Spell Slots"
     },
     "fields": {
       "class": "Class",
@@ -539,6 +541,8 @@
       "cloneFailed": "Failed to clone character. Please try again."
     },
     "actions": {
+      "shortRest": "Short Rest",
+      "longRest": "Long Rest",
       "archiveTitle": "Archive Character",
       "archiveConfirm": "Are you sure you want to archive {{name}}? The character will be hidden from the active list but can be restored later.",
       "deleteTitle": "Delete Character",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -390,7 +390,11 @@
     },
     "spellSlots": {
       "levelLabel": "Level {{level}}",
-      "pactLabel": "Pact (L{{slotLevel}})"
+      "pactLabel": "Pact (L{{slotLevel}})",
+      "useSlot": "Use level {{level}} spell slot",
+      "recoverSlot": "Recover level {{level}} spell slot",
+      "usePact": "Use Pact Magic slot",
+      "recoverPact": "Recover Pact Magic slot"
     },
     "fields": {
       "class": "Class",

--- a/src/pages/CharacterBuilder.tsx
+++ b/src/pages/CharacterBuilder.tsx
@@ -105,6 +105,8 @@ function buildSeedCharacter(campaignId: string): Character {
     heroic_inspiration: false,
     exhaustion_level: 0 as const,
     conditions: [],
+    hit_dice_used: null,
+    spell_slots_used: null,
   };
 }
 

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -10,11 +10,14 @@ import { Textarea } from '@/components/ui/textarea';
 import { AttacksPanel } from '@/components/character-sheet/AttacksPanel';
 import { BonusBreakdown } from '@/components/character-sheet/BonusBreakdown';
 import { ConditionsPanel } from '@/components/character-sheet/ConditionsPanel';
+import { HitDicePanel } from '@/components/character-sheet/HitDicePanel';
+import { SpellSlotsPanel } from '@/components/character-sheet/SpellSlotsPanel';
 import { LevelControls } from '@/components/character-sheet/LevelControls';
 import { PendingChoicesPanel } from '@/components/character-sheet/PendingChoicesPanel';
 import { ProficienciesPanel } from '@/components/character-sheet/ProficienciesPanel';
 import { ResourcePoolsPanel } from '@/components/character-sheet/ResourcePoolsPanel';
 import { SkillsPanel } from '@/components/character-sheet/SkillsPanel';
+import { applyLongRest, applyShortRest } from '@/lib/rest';
 import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
 import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
 import { getGrantIcon, getSourceDisplayName } from '@/lib/class-icons';
@@ -156,6 +159,26 @@ function CharacterSheetInner({
         onError: () => toast.error(tc('characterSheet.errors.updateFailed')),
       }
     );
+  };
+
+  const handleShortRest = () => {
+    if (!resolved) return;
+    const restUsed = {
+      hitDiceUsed: character.hit_dice_used ?? {},
+      spellSlotsUsed: character.spell_slots_used ?? {},
+    };
+    const next = applyShortRest(restUsed, resolved);
+    handleUpdate({ hit_dice_used: next.hitDiceUsed, spell_slots_used: next.spellSlotsUsed });
+  };
+
+  const handleLongRest = () => {
+    if (!resolved) return;
+    const restUsed = {
+      hitDiceUsed: character.hit_dice_used ?? {},
+      spellSlotsUsed: character.spell_slots_used ?? {},
+    };
+    const next = applyLongRest(restUsed, resolved);
+    handleUpdate({ hit_dice_used: next.hitDiceUsed, spell_slots_used: next.spellSlotsUsed });
   };
 
   const handleArchive = () => {
@@ -531,6 +554,22 @@ function CharacterSheetInner({
 
             {/* Conditions */}
             <ConditionsPanel character={character} onUpdate={handleUpdate} />
+
+            {/* Rest buttons + Hit Dice + Spell Slots */}
+            {resolved && (
+              <>
+                <div className="flex gap-2">
+                  <Button variant="outline" size="sm" className="flex-1" onClick={handleShortRest}>
+                    {tc('characterSheet.actions.shortRest')}
+                  </Button>
+                  <Button variant="outline" size="sm" className="flex-1" onClick={handleLongRest}>
+                    {tc('characterSheet.actions.longRest')}
+                  </Button>
+                </div>
+                <HitDicePanel resolved={resolved} character={character} onUpdate={handleUpdate} />
+                <SpellSlotsPanel resolved={resolved} character={character} onUpdate={handleUpdate} />
+              </>
+            )}
 
             {/* Attacks */}
             {resolved && <AttacksPanel attacks={resolved.attacks} weaponMasteries={resolved.weaponMasteries} />}

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -17,7 +17,7 @@ import { PendingChoicesPanel } from '@/components/character-sheet/PendingChoices
 import { ProficienciesPanel } from '@/components/character-sheet/ProficienciesPanel';
 import { ResourcePoolsPanel } from '@/components/character-sheet/ResourcePoolsPanel';
 import { SkillsPanel } from '@/components/character-sheet/SkillsPanel';
-import { applyLongRest, applyShortRest } from '@/lib/rest';
+import { buildRestUpdate } from '@/lib/rest';
 import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
 import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
 import { getGrantIcon, getSourceDisplayName } from '@/lib/class-icons';
@@ -163,22 +163,12 @@ function CharacterSheetInner({
 
   const handleShortRest = () => {
     if (!resolved) return;
-    const restUsed = {
-      hitDiceUsed: character.hit_dice_used ?? {},
-      spellSlotsUsed: character.spell_slots_used ?? {},
-    };
-    const next = applyShortRest(restUsed, resolved);
-    handleUpdate({ hit_dice_used: next.hitDiceUsed, spell_slots_used: next.spellSlotsUsed });
+    handleUpdate(buildRestUpdate('short', character, resolved));
   };
 
   const handleLongRest = () => {
     if (!resolved) return;
-    const restUsed = {
-      hitDiceUsed: character.hit_dice_used ?? {},
-      spellSlotsUsed: character.spell_slots_used ?? {},
-    };
-    const next = applyLongRest(restUsed, resolved);
-    handleUpdate({ hit_dice_used: next.hitDiceUsed, spell_slots_used: next.spellSlotsUsed });
+    handleUpdate(buildRestUpdate('long', character, resolved));
   };
 
   const handleArchive = () => {

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -84,6 +84,8 @@ export interface Character {
   heroic_inspiration: boolean;
   exhaustion_level: ExhaustionLevel;
   conditions: ConditionId[];
+  hit_dice_used: Record<string, number> | null;
+  spell_slots_used: Record<string, number> | null;
 }
 
 // Combat participant

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -198,6 +198,8 @@ export type Database = {
           character_type: string
           class: string | null
           conditions: string[]
+          hit_dice_used: Json
+          spell_slots_used: Json
           created_at: string
           exhaustion_level: number
           eye_color: string | null
@@ -241,6 +243,8 @@ export type Database = {
           character_type: string
           class?: string | null
           conditions?: string[]
+          hit_dice_used?: Json
+          spell_slots_used?: Json
           created_at?: string
           exhaustion_level?: number
           eye_color?: string | null
@@ -284,6 +288,8 @@ export type Database = {
           character_type?: string
           class?: string | null
           conditions?: string[]
+          hit_dice_used?: Json
+          spell_slots_used?: Json
           created_at?: string
           exhaustion_level?: number
           eye_color?: string | null

--- a/supabase/migrations/20260604000000_add_hit_dice_spell_slots_used.sql
+++ b/supabase/migrations/20260604000000_add_hit_dice_spell_slots_used.sql
@@ -1,0 +1,2 @@
+ALTER TABLE characters ADD COLUMN hit_dice_used jsonb NOT NULL DEFAULT '{}';
+ALTER TABLE characters ADD COLUMN spell_slots_used jsonb NOT NULL DEFAULT '{}';


### PR DESCRIPTION
Closes #49

## Summary
Runtime tracking of hit dice and spell slots on the character sheet: spend hit dice, mark spell slots used, and Short/Long Rest buttons that reset the appropriate resources. Maxes come from the resolved character (`resolved.hitDie`, `resolved.spellcasting.slots`/`pactMagic`); expenditure is persisted in two new jsonb columns.

## What Changed
- **Persistence** — migration adding `hit_dice_used jsonb` + `spell_slots_used jsonb` to characters; full schema sync (`supabase.ts` hand-edited, `database.ts`, `query-columns`, `export-sql` per the schema-sync rule, + query-column tests).
- **`src/lib/rest.ts`** (new, pure + fully tested) — `getHitDiceMax`/`getSpellSlotMax`, `spendHitDie`, `markSpellSlot`/`recoverSpellSlot`, `applyShortRest` (resets Pact Magic only), `applyLongRest` (resets all slots + recovers `max(1, floor(level/2))` hit dice, largest-die-first). Largest-die-first allocation is a documented simplification (2024 RAW lets the player choose).
- **`HitDicePanel`** + **`SpellSlotsPanel`** (new) — spend/mark UI gated on resolved data (non-casters render nothing); Warlock Pact Magic handled via a `"pact"` key.
- **`CharacterSheet.tsx`** — renders the panels + Short/Long Rest buttons.
- i18n labels.

## Notes
- `supabase.ts` hand-edited (no live DB to regenerate) — run `npm run supabase:types` before deploy. Migration is additive with defaults.
- The panel homes (CombatPanel/SpellcastingPanel from the #45 redesign) don't exist yet, so these are standalone panels that drop into the current sheet and can be re-sliced when #45 lands.
- Tracks counts only — no automatic HP changes from spending hit dice.

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 1954 pass (rest-rule unit tests incl. multiclass recovery + clamping; both panels; schema-sync)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)