### PR TITLE
feat(sourcebooks): source book data model and tagging

### DIFF
--- a/features/campaigns/steps/campaigns.steps.ts
+++ b/features/campaigns/steps/campaigns.steps.ts
@@ -62,6 +62,7 @@ function makeCampaignRow(overrides: Partial<Campaign> & { name: string }): Campa
     created_at: NOW,
     updated_at: NOW,
     archived_at: null,
+    allowed_source_books: ['phb-2024'],
     ...overrides,
   };
 }

--- a/features/characters/steps/archive-character.steps.ts
+++ b/features/characters/steps/archive-character.steps.ts
@@ -30,6 +30,7 @@ function seedCampaignWithCharacter(world: DndWorld, name: string, isActive: bool
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
     archived_at: null,
+    allowed_source_books: ['phb-2024'],
   };
   world.db.seed('campaigns', [campaign as unknown as Row]);
   world.db.seed('characters', [

--- a/features/characters/steps/builder-autosave.steps.ts
+++ b/features/characters/steps/builder-autosave.steps.ts
@@ -28,6 +28,7 @@ function seedDraft(world: DndWorld, name: string): { campaign: Campaign; slug: s
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
     archived_at: null,
+    allowed_source_books: ['phb-2024'],
   };
   world.db.seed('campaigns', [campaign as unknown as Row]);
 

--- a/features/characters/steps/character-sheet.steps.ts
+++ b/features/characters/steps/character-sheet.steps.ts
@@ -63,6 +63,7 @@ function seedCampaign(world: DndWorld): Campaign {
     created_at: '2024-01-01T00:00:00Z',
     updated_at: '2024-01-01T00:00:00Z',
     archived_at: null,
+    allowed_source_books: ['phb-2024'],
   };
   world.db.seed('campaigns', [campaign as unknown as Row]);
   world.createdCampaign = campaign;

--- a/features/steps/support/fixtures.ts
+++ b/features/steps/support/fixtures.ts
@@ -18,6 +18,7 @@ export function buildCampaign(overrides: Partial<Campaign> = {}): Campaign {
     dm_notes: null,
     theme: null,
     archived_at: null,
+    allowed_source_books: ['phb-2024'],
     ...overrides,
   };
 }

--- a/src/hooks/useCampaigns.test.ts
+++ b/src/hooks/useCampaigns.test.ts
@@ -28,6 +28,7 @@ const baseCampaign: Campaign = {
   dm_notes: null,
   theme: null,
   archived_at: null,
+  allowed_source_books: ['phb-2024'],
 };
 
 setupMockReset();

--- a/src/lib/export-sql.test.ts
+++ b/src/lib/export-sql.test.ts
@@ -280,6 +280,15 @@ describe('generateSeedSql', () => {
     expect(sql).toContain("ARRAY['blinded', 'charmed']::text[]");
   });
 
+  it('campaign INSERT includes allowed_source_books as a text[] array', () => {
+    const data: ExportData = {
+      ...emptyData,
+      campaigns: [{ id: 'camp-1', name: 'Test Campaign', allowed_source_books: ['phb-2024'] }],
+    };
+    const sql = generateSeedSql(data);
+    expect(sql).toContain("ARRAY['phb-2024']::text[]");
+  });
+
   it('character INSERT includes hit_dice_used and spell_slots_used as jsonb', () => {
     const data: ExportData = {
       ...emptyData,

--- a/src/lib/export-sql.ts
+++ b/src/lib/export-sql.ts
@@ -27,6 +27,7 @@ const TABLE_COLUMNS = {
     { name: 'status', type: 'text' },
     { name: 'image_url', type: 'text' },
     { name: 'dm_notes', type: 'text' },
+    { name: 'allowed_source_books', type: 'text[]' },
     { name: 'created_at', type: 'timestamptz' },
     { name: 'updated_at', type: 'timestamptz' },
   ],

--- a/src/lib/query-columns.test.ts
+++ b/src/lib/query-columns.test.ts
@@ -1,4 +1,10 @@
-import { CHARACTER_DETAIL_COLS, CHARACTER_SUMMARY_COLS } from '@/lib/query-columns';
+import { CAMPAIGN_DETAIL_COLS, CHARACTER_DETAIL_COLS, CHARACTER_SUMMARY_COLS } from '@/lib/query-columns';
+
+describe('CAMPAIGN_DETAIL_COLS', () => {
+  it('contains allowed_source_books so the campaign detail loads source book settings (word boundary match)', () => {
+    expect(CAMPAIGN_DETAIL_COLS).toMatch(/\ballowed_source_books\b/);
+  });
+});
 
 describe('CHARACTER_SUMMARY_COLS', () => {
   it('contains species (word boundary match)', () => {

--- a/src/lib/query-columns.ts
+++ b/src/lib/query-columns.ts
@@ -1,7 +1,7 @@
 export const CAMPAIGN_SUMMARY_COLS =
   'id, slug, previous_slugs, name, description, setting, status, theme, created_at, updated_at, archived_at' as const;
 export const CAMPAIGN_DETAIL_COLS =
-  'id, slug, previous_slugs, name, description, setting, status, image_url, dm_notes, theme, created_at, updated_at, archived_at' as const;
+  'id, slug, previous_slugs, name, description, setting, status, image_url, dm_notes, theme, created_at, updated_at, archived_at, allowed_source_books' as const;
 
 export const CHARACTER_SUMMARY_COLS =
   'id, slug, previous_slugs, campaign_id, name, player_name, character_type, species, class, subclass, level, hit_points_max, armor_class, updated_at' as const;

--- a/src/lib/source-books.test.ts
+++ b/src/lib/source-books.test.ts
@@ -1,0 +1,48 @@
+import { filterBySourceBooks, SOURCE_BOOKS, SOURCE_BOOK_IDS, type SourceBookId } from '@/lib/source-books';
+
+// ---------------------------------------------------------------------------
+// SOURCE_BOOKS integrity
+// ---------------------------------------------------------------------------
+describe('SOURCE_BOOKS integrity', () => {
+  it('every SOURCE_BOOKS entry id is in SOURCE_BOOK_IDS', () => {
+    for (const book of SOURCE_BOOKS) {
+      expect(SOURCE_BOOK_IDS).toContain(book.id);
+    }
+  });
+
+  it('SOURCE_BOOK_IDS.length equals SOURCE_BOOKS.length', () => {
+    expect(SOURCE_BOOK_IDS.length).toBe(SOURCE_BOOKS.length);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterBySourceBooks
+// ---------------------------------------------------------------------------
+describe('filterBySourceBooks', () => {
+  it('includes an item whose sourceBook is in the allowed list', () => {
+    const items = [{ id: 'a', sourceBook: 'phb-2024' as SourceBookId }];
+    expect(filterBySourceBooks(items, ['phb-2024'])).toHaveLength(1);
+  });
+
+  it('excludes an item whose sourceBook is not in the allowed list', () => {
+    // Cast to SourceBookId to satisfy the generic constraint for testing future values
+    const items = [{ id: 'a', sourceBook: 'dmg-2024' as SourceBookId }];
+    expect(filterBySourceBooks(items, ['phb-2024'])).toHaveLength(0);
+  });
+
+  it('includes an untagged item (no sourceBook field) by defaulting to phb-2024', () => {
+    const items: Array<{ sourceBook?: SourceBookId }> = [{}];
+    expect(filterBySourceBooks(items, ['phb-2024'])).toHaveLength(1);
+  });
+
+  it('returns empty array when allowed list is empty', () => {
+    const items: Array<{ sourceBook?: SourceBookId }> = [{ sourceBook: 'phb-2024' }, {}];
+    expect(filterBySourceBooks(items, [])).toHaveLength(0);
+  });
+
+  it('does not crash when allowed contains an unknown id', () => {
+    const items = [{ id: 'a', sourceBook: 'phb-2024' as SourceBookId }];
+    // unknown id in allowed → the phb-2024 item won't match 'dmg-2024'
+    expect(filterBySourceBooks(items, ['dmg-2024' as SourceBookId])).toHaveLength(0);
+  });
+});

--- a/src/lib/source-books.test.ts
+++ b/src/lib/source-books.test.ts
@@ -40,6 +40,14 @@ describe('filterBySourceBooks', () => {
     expect(filterBySourceBooks(items, [])).toHaveLength(0);
   });
 
+  it('returns only the allowed items from a mixed list, preserving order', () => {
+    const a = { id: 'a', sourceBook: 'phb-2024' as SourceBookId };
+    const b = { id: 'b', sourceBook: 'dmg-2024' as SourceBookId };
+    const c = { id: 'c' }; // untagged -> defaults to phb-2024
+    // Identity (not just length): the right subset survives, in original order.
+    expect(filterBySourceBooks([a, b, c], ['phb-2024'])).toEqual([a, c]);
+  });
+
   it('does not crash when allowed contains an unknown id', () => {
     const items = [{ id: 'a', sourceBook: 'phb-2024' as SourceBookId }];
     // unknown id in allowed → the phb-2024 item won't match 'dmg-2024'

--- a/src/lib/source-books.test.ts
+++ b/src/lib/source-books.test.ts
@@ -43,7 +43,7 @@ describe('filterBySourceBooks', () => {
   it('returns only the allowed items from a mixed list, preserving order', () => {
     const a = { id: 'a', sourceBook: 'phb-2024' as SourceBookId };
     const b = { id: 'b', sourceBook: 'dmg-2024' as SourceBookId };
-    const c = { id: 'c' }; // untagged -> defaults to phb-2024
+    const c: { id: string; sourceBook?: SourceBookId } = { id: 'c' }; // untagged -> defaults to phb-2024
     // Identity (not just length): the right subset survives, in original order.
     expect(filterBySourceBooks([a, b, c], ['phb-2024'])).toEqual([a, c]);
   });

--- a/src/lib/source-books.ts
+++ b/src/lib/source-books.ts
@@ -1,0 +1,16 @@
+export const SOURCE_BOOK_IDS = ['phb-2024'] as const;
+export type SourceBookId = (typeof SOURCE_BOOK_IDS)[number];
+
+export interface SourceBookDef {
+  readonly id: SourceBookId;
+  readonly abbreviation: string;
+}
+
+export const SOURCE_BOOKS: readonly SourceBookDef[] = [{ id: 'phb-2024', abbreviation: 'PHB 2024' }] as const;
+
+export function filterBySourceBooks<T extends { readonly sourceBook?: SourceBookId }>(
+  items: readonly T[],
+  allowed: readonly SourceBookId[]
+): readonly T[] {
+  return items.filter((item) => allowed.includes(item.sourceBook ?? 'phb-2024'));
+}

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -2957,5 +2957,8 @@
       "name": "Summon Celestial",
       "description": "You call forth a celestial spirit. It manifests in an angelic form in an unoccupied space within range. The creature is friendly to you and obeys your commands for the duration."
     }
+  },
+  "sourceBooks": {
+    "phb-2024": "Player's Handbook 2024"
   }
 }

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -10,6 +10,7 @@ import type {
 import type { ThemeId } from '@/lib/theme';
 import type { ConditionId } from '@/lib/sources/conditions';
 import type { WeaponMasteryId } from '@/types/items';
+import type { SourceBookId } from '@/lib/source-books';
 
 export type { Proficiencies };
 
@@ -40,6 +41,7 @@ export interface Campaign {
   /** null = inherit global preference; a ThemeId = explicit override for this campaign */
   theme: ThemeId | null;
   archived_at?: string | null;
+  allowed_source_books: SourceBookId[];
 }
 
 export interface Character {

--- a/src/types/sources.ts
+++ b/src/types/sources.ts
@@ -1,6 +1,7 @@
 import type { SpeciesId, ClassId, BackgroundId, SizeId, AbilityKey, FeatId } from '@/lib/dnd-helpers';
 import type { Grant } from '@/types/grants';
 import type { SubclassId } from '@/lib/sources/subclasses';
+import type { SourceBookId } from '@/lib/source-books';
 
 export type { SubclassId } from '@/lib/sources/subclasses';
 export { isSubclassId } from '@/lib/sources/subclasses';
@@ -26,6 +27,7 @@ export interface SpeciesSource {
   readonly defaultSize: SizeId;
   readonly defaultSpeed: number;
   readonly grants: readonly Grant[];
+  readonly sourceBook?: SourceBookId;
 }
 
 export interface LevelUp {
@@ -70,6 +72,7 @@ export interface ClassSource {
   readonly primaryAbility: AbilityKey;
   readonly levels: readonly LevelUp[];
   readonly quickBuild?: ClassQuickBuild;
+  readonly sourceBook?: SourceBookId;
 }
 
 export interface SubclassFeature {
@@ -79,11 +82,13 @@ export interface SubclassFeature {
 
 export interface SubclassSource {
   readonly features: readonly SubclassFeature[];
+  readonly sourceBook?: SourceBookId;
 }
 
 export interface BackgroundSource {
   readonly id: BackgroundId;
   readonly grants: readonly Grant[];
+  readonly sourceBook?: SourceBookId;
 }
 
 export const FEAT_CATEGORIES = ['origin', 'general', 'fightingStyle', 'epicBoon'] as const;
@@ -108,10 +113,12 @@ export interface FeatSource {
    * per-instance indexing. Tracked in #178.
    */
   readonly repeatable?: boolean;
+  readonly sourceBook?: SourceBookId;
 }
 
 export interface ItemSource {
   readonly id: string;
   readonly grants: readonly Grant[];
   readonly requiresAttunement: boolean;
+  readonly sourceBook?: SourceBookId;
 }

--- a/src/types/spells.ts
+++ b/src/types/spells.ts
@@ -1,5 +1,6 @@
 import type { ClassId } from '@/lib/dnd-helpers';
 import type { SpellId } from '@/lib/sources/spells';
+import type { SourceBookId } from '@/lib/source-books';
 
 export type { SpellId };
 
@@ -30,4 +31,5 @@ export interface SpellDef {
   readonly components: SpellComponents;
   readonly duration: string;
   readonly nativeClasses: readonly [ClassId, ...ClassId[]];
+  readonly sourceBook?: SourceBookId;
 }

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -36,6 +36,7 @@ export type Database = {
     Tables: {
       campaigns: {
         Row: {
+          allowed_source_books: string[]
           archived_at: string | null
           created_at: string
           description: string | null
@@ -51,6 +52,7 @@ export type Database = {
           updated_at: string
         }
         Insert: {
+          allowed_source_books?: string[]
           archived_at?: string | null
           created_at?: string
           description?: string | null
@@ -66,6 +68,7 @@ export type Database = {
           updated_at?: string
         }
         Update: {
+          allowed_source_books?: string[]
           archived_at?: string | null
           created_at?: string
           description?: string | null

--- a/supabase/migrations/20260605000000_add_campaign_allowed_source_books.sql
+++ b/supabase/migrations/20260605000000_add_campaign_allowed_source_books.sql
@@ -1,0 +1,1 @@
+ALTER TABLE campaigns ADD COLUMN allowed_source_books text[] NOT NULL DEFAULT '{phb-2024}';


### PR DESCRIPTION
Closes #39

## Summary
Foundation for filtering reference data by allowed source books per campaign (the basis for #40). Re-scoped to the project's actual target: the app ships 2024 PHB only, so `phb-2024` is the sole book today and filtering is currently a no-op — but the type, column, constant, and helper are in place for future 2024-line books.

## Design (low-churn, structural)
Rather than tagging every reference entry, the source TYPE interfaces gain an **optional** `sourceBook?: SourceBookId` that defaults to `'phb-2024'` at filter time. This avoids hundreds of identical edits and makes the default structural (no per-contributor discipline). When a second book lands, promoting `sourceBook?` → `sourceBook` (drop the `?`) turns the default into a compile-time requirement at exactly the right moment.

## What Changed
- **`src/lib/source-books.ts`** (new) — `SourceBookId`, `SOURCE_BOOKS` (id + abbreviation), `filterBySourceBooks<T>(items, allowed)`.
- **Tagging** — optional `sourceBook?: SourceBookId` on the 6 `*Source` interfaces + `SpellDef`.
- **`campaigns.allowed_source_books`** — migration (`text[] NOT NULL DEFAULT '{phb-2024}'`) + full schema sync (supabase.ts hand-edited, `database.ts` Campaign, `query-columns` DETAIL, `export-sql` TABLE_COLUMNS) + 6 Campaign fixtures.
- i18n display name (`sourceBooks.phb-2024`).

## Scope
Foundation only — no #40 campaign-settings UI and no selector-filtering wiring (those are #40). `supabase.ts` hand-edited (no live DB) — run `npm run supabase:types` before deploy.

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 1997 pass (filterBySourceBooks: in/not-allowed, untagged-default, empty-allowed, unknown-id; SOURCE_BOOKS integrity; campaign export + query-column sync)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)