### PR TITLE
feat(sourcebooks): campaign settings UI and selector filtering

### DIFF
--- a/src/components/character-builder/BasicsStep.test.tsx
+++ b/src/components/character-builder/BasicsStep.test.tsx
@@ -36,6 +36,38 @@ vi.mock('@/hooks/useCharacters', () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// Mock react-router-dom (useParams)
+// ---------------------------------------------------------------------------
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ campaignSlug: 'test-campaign' }),
+}));
+
+// ---------------------------------------------------------------------------
+// Mock useGameData — returns full lists (phb-2024 allowed) by default
+// ---------------------------------------------------------------------------
+
+import { SPECIES_SOURCES as _SS } from '@/lib/sources/species';
+import { CLASS_SOURCES as _CS } from '@/lib/sources/classes';
+import { BACKGROUND_SOURCES as _BS } from '@/lib/sources/backgrounds';
+import { FEAT_SOURCES as _FS } from '@/lib/sources/feats';
+import { SUBCLASS_SOURCES as _SCS } from '@/lib/sources/subclasses';
+import type { GameData } from '@/hooks/useGameData';
+
+const mockGameData: GameData = {
+  species: _SS,
+  classes: _CS,
+  backgrounds: _BS,
+  feats: _FS,
+  subclasses: _SCS,
+  allowedSourceBooks: ['phb-2024'],
+};
+
+vi.mock('@/hooks/useGameData', () => ({
+  useGameData: () => mockGameData,
+}));
+
+// ---------------------------------------------------------------------------
 // Mock sonner toast
 // ---------------------------------------------------------------------------
 

--- a/src/components/character-builder/BasicsStep.test.tsx
+++ b/src/components/character-builder/BasicsStep.test.tsx
@@ -54,7 +54,21 @@ import { FEAT_SOURCES as _FS } from '@/lib/sources/feats';
 import { SUBCLASS_SOURCES as _SCS } from '@/lib/sources/subclasses';
 import type { GameData } from '@/hooks/useGameData';
 
-const mockGameData: GameData = {
+// Mutable container — the mock reads `.current` so tests can swap game data
+// without reassigning a const. `let` would be simpler but ESLint/Prettier
+// prefer-const promotes it back to const on format.
+const gameDataRef = {
+  current: {
+    species: _SS,
+    classes: _CS,
+    backgrounds: _BS,
+    feats: _FS,
+    subclasses: _SCS,
+    allowedSourceBooks: ['phb-2024'],
+  } as GameData,
+};
+
+const DEFAULT_GAME_DATA: GameData = {
   species: _SS,
   classes: _CS,
   backgrounds: _BS,
@@ -64,7 +78,7 @@ const mockGameData: GameData = {
 };
 
 vi.mock('@/hooks/useGameData', () => ({
-  useGameData: () => mockGameData,
+  useGameData: () => gameDataRef.current,
 }));
 
 // ---------------------------------------------------------------------------
@@ -226,6 +240,7 @@ function resetContext() {
 describe('BasicsStep', () => {
   beforeEach(() => {
     resetContext();
+    gameDataRef.current = DEFAULT_GAME_DATA;
     vi.clearAllMocks();
   });
 
@@ -632,5 +647,41 @@ describe('BasicsStep', () => {
     render(<BasicsStep />);
 
     expect(screen.getByText('chooseBackground')).toBeTruthy();
+  });
+
+  // ---------------------------------------------------------------------------
+  // No-data-loss: current value stays visible when its source book is disabled
+  // ---------------------------------------------------------------------------
+
+  describe('no-data-loss when source book is disabled', () => {
+    it('keeps the currently selected species in the picker even when its source book is disabled', () => {
+      // Character already has 'elf' selected
+      contextCharacter = buildSeedCharacter({ species: 'elf' });
+      // Simulate a campaign that only allows a hypothetical future book (no PHB species)
+      gameDataRef.current = { ...DEFAULT_GAME_DATA, species: [], allowedSourceBooks: [] };
+
+      render(<BasicsStep />);
+
+      // The species picker's current value label should still render 'elf'
+      // (the i18n mock returns the last key segment, so species.elf → 'elf')
+      expect(screen.getByText('elf')).toBeTruthy();
+    });
+
+    it('shows the disabled-source-book badge when the current species is not in allowed source books', () => {
+      contextCharacter = buildSeedCharacter({ species: 'elf' });
+      gameDataRef.current = { ...DEFAULT_GAME_DATA, species: [], allowedSourceBooks: [] };
+
+      render(<BasicsStep />);
+
+      expect(screen.getByText('disabledSourceBook')).toBeTruthy();
+    });
+
+    it('does not show the disabled-source-book badge when the species is allowed', () => {
+      contextCharacter = buildSeedCharacter({ species: 'elf' });
+      // Default mockGameData has all species (phb-2024 allowed)
+      render(<BasicsStep />);
+
+      expect(screen.queryByText('disabledSourceBook')).toBeNull();
+    });
   });
 });

--- a/src/components/character-builder/BasicsStep.tsx
+++ b/src/components/character-builder/BasicsStep.tsx
@@ -38,6 +38,8 @@ import {
 import { useEffect, useLayoutEffect, useRef, useState } from 'react';
 import { toast } from 'sonner';
 import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
+import { useGameData } from '@/hooks/useGameData';
 
 const logger = getLogger('basics-step');
 
@@ -67,6 +69,8 @@ interface BasicsStepProps {
 export function BasicsStep({ onRequestAdvance }: BasicsStepProps) {
   const { t } = useTranslation('gamedata');
   const { t: tc } = useTranslation('common');
+  const { campaignSlug } = useParams<{ campaignSlug: string }>();
+  const gameData = useGameData(campaignSlug);
   const { data: playerNames = [], isError: playerNamesError } = usePlayerNames();
   const context = useCharacterContext();
 
@@ -84,6 +88,18 @@ export function BasicsStep({ onRequestAdvance }: BasicsStepProps) {
   const levelRows = rows.filter((r) => r.sequence !== 0);
   const characterClass = (levelRows[0]?.class_id ?? '') as ClassId | '';
   const level = levelRows.length;
+
+  // Compute allowed ID sets from gameData, then union with current values for
+  // no-data-loss: a selection made when a book was enabled stays visible in the
+  // picker even after the book is disabled, but shows a "disabled source book"
+  // warning badge so the DM knows to update it.
+  const allowedSpeciesIds = new Set(gameData.species.map((s) => s.id));
+  const allowedClassIds = new Set(gameData.classes.map((c) => c.id));
+  const allowedBackgroundIds = new Set(gameData.backgrounds.map((b) => b.id));
+
+  const filteredSpecies = DND_SPECIES.filter((s) => allowedSpeciesIds.has(s.id) || s.id === race);
+  const filteredClasses = DND_CLASSES.filter((c) => allowedClassIds.has(c.id) || c.id === characterClass);
+  const filteredBackgrounds = DND_BACKGROUNDS.filter((b) => allowedBackgroundIds.has(b.id) || b.id === background);
 
   // Ref-flag + useEffect for post-commit step advance. Refs dodge stale closures
   // and keep onRequestAdvance out of the effect deps (it is a new fn per render).
@@ -400,17 +416,23 @@ export function BasicsStep({ onRequestAdvance }: BasicsStepProps) {
                 </Badge>
                 <p className="text-xs text-muted-foreground">{race}</p>
               </div>
+            ) : race && !allowedSpeciesIds.has(race) ? (
+              <div className="space-y-1">
+                <Badge variant="destructive" className="text-xs">
+                  {tc('characterBuilder.hints.disabledSourceBook')}
+                </Badge>
+              </div>
             ) : null}
             <Select
               value={race || null}
               onValueChange={(value) => value && handleSpeciesChange(value as SpeciesId)}
-              items={DND_SPECIES.map((s) => ({ value: s.id, label: t(`species.${s.id}`) }))}
+              items={filteredSpecies.map((s) => ({ value: s.id, label: t(`species.${s.id}`) }))}
             >
               <SelectTrigger className="w-full">
                 <SelectValue placeholder={tc('characterBuilder.placeholders.chooseSpecies')} />
               </SelectTrigger>
               <SelectContent>
-                {DND_SPECIES.map((s) => (
+                {filteredSpecies.map((s) => (
                   <SelectItem key={s.id} value={s.id}>
                     {t(`species.${s.id}`)}
                     {speciesHasLaterChoices(s.id) && (
@@ -427,16 +449,23 @@ export function BasicsStep({ onRequestAdvance }: BasicsStepProps) {
               {tc('characterBuilder.fields.class')}
               <span className="text-destructive">*</span>
             </Label>
+            {characterClass && !allowedClassIds.has(characterClass) && (
+              <div className="space-y-1">
+                <Badge variant="destructive" className="text-xs">
+                  {tc('characterBuilder.hints.disabledSourceBook')}
+                </Badge>
+              </div>
+            )}
             <Select
               value={characterClass || null}
               onValueChange={(value) => value && handleClassChange(value as ClassId)}
-              items={DND_CLASSES.map((c) => ({ value: c.id, label: t(`classes.${c.id}`) }))}
+              items={filteredClasses.map((c) => ({ value: c.id, label: t(`classes.${c.id}`) }))}
             >
               <SelectTrigger className="w-full">
                 <SelectValue placeholder={tc('characterBuilder.placeholders.chooseClass')} />
               </SelectTrigger>
               <SelectContent>
-                {DND_CLASSES.map((cls) => (
+                {filteredClasses.map((cls) => (
                   <SelectItem key={cls.id} value={cls.id}>
                     {t(`classes.${cls.id}`)}
                     {classHasLaterChoices(cls.id) && (
@@ -450,16 +479,23 @@ export function BasicsStep({ onRequestAdvance }: BasicsStepProps) {
 
           <div className="space-y-2">
             <Label>{tc('characterBuilder.fields.background')}</Label>
+            {background && !allowedBackgroundIds.has(background as BackgroundId) && (
+              <div className="space-y-1">
+                <Badge variant="destructive" className="text-xs">
+                  {tc('characterBuilder.hints.disabledSourceBook')}
+                </Badge>
+              </div>
+            )}
             <Select
               value={background || null}
               onValueChange={(value) => value && context.updateCharacter({ background: value })}
-              items={DND_BACKGROUNDS.map((b) => ({ value: b.id, label: t(`backgrounds.${b.id}`) }))}
+              items={filteredBackgrounds.map((b) => ({ value: b.id, label: t(`backgrounds.${b.id}`) }))}
             >
               <SelectTrigger className="w-full">
                 <SelectValue placeholder={tc('characterBuilder.placeholders.chooseBackground')} />
               </SelectTrigger>
               <SelectContent>
-                {DND_BACKGROUNDS.map((b) => (
+                {filteredBackgrounds.map((b) => (
                   <SelectItem key={b.id} value={b.id}>
                     {t(`backgrounds.${b.id}`)}
                     {backgroundHasLaterChoices(b.id as BackgroundId) && (

--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -577,3 +577,99 @@ describe('ChoicePicker spell-choice', () => {
     expect(screen.getByText('1 / 2')).toBeTruthy();
   });
 });
+
+// ---------------------------------------------------------------------------
+// ChoicePicker — feat-choice with allowedFeats (disabled-book no-data-loss)
+// ---------------------------------------------------------------------------
+
+import { FEAT_SOURCES } from '@/lib/sources';
+import type { FeatSource } from '@/lib/sources';
+
+// Fixture: no `from` so allowedFeats controls the pool via category filtering.
+const ORIGIN_FEAT_CHOICE: PendingChoice & { type: 'feat-choice' } = {
+  type: 'feat-choice',
+  choiceKey: 'feat-choice:species:human:1' as ChoiceKey,
+  source: { origin: 'species' as const, id: 'human' as const },
+  from: null,
+  category: 'origin',
+};
+
+// allowedFeats includes 'lucky' and 'skilled' but NOT 'alert'
+const ALLOWED_FEATS_WITHOUT_ALERT: readonly FeatSource[] = FEAT_SOURCES.filter(
+  (f) => f.id === 'lucky' || f.id === 'skilled'
+);
+
+describe('ChoicePicker feat-choice — allowedFeats (disabled-book no-data-loss)', () => {
+  it('renders only allowed feats when no current selection', () => {
+    render(
+      <ChoicePicker
+        choice={ORIGIN_FEAT_CHOICE}
+        currentDecision={undefined}
+        onDecide={vi.fn()}
+        onClear={vi.fn()}
+        allowedFeats={ALLOWED_FEATS_WITHOUT_ALERT}
+      />
+    );
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    // Only lucky and skilled are in allowedFeats; alert is absent
+    expect(radios).toHaveLength(2);
+  });
+
+  it('unions in the current feat even when its book is disabled (feat absent from allowedFeats)', () => {
+    // alert is NOT in ALLOWED_FEATS_WITHOUT_ALERT but is the current selection
+    const currentDecision: ChoiceDecision = {
+      type: 'feat-choice',
+      featId: 'alert' as import('@/lib/dnd-helpers').FeatId,
+    };
+    render(
+      <ChoicePicker
+        choice={ORIGIN_FEAT_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        onClear={vi.fn()}
+        allowedFeats={ALLOWED_FEATS_WITHOUT_ALERT}
+      />
+    );
+    // All three radios: lucky, skilled, alert (unioned in)
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios).toHaveLength(3);
+    // alert radio is checked
+    const alertRadio = radios.find((r) => r.id.includes('alert'));
+    expect(alertRadio?.checked).toBe(true);
+  });
+
+  it('shows disabled-book badge for the unioned-in feat', () => {
+    const currentDecision: ChoiceDecision = {
+      type: 'feat-choice',
+      featId: 'alert' as import('@/lib/dnd-helpers').FeatId,
+    };
+    render(
+      <ChoicePicker
+        choice={ORIGIN_FEAT_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        onClear={vi.fn()}
+        allowedFeats={ALLOWED_FEATS_WITHOUT_ALERT}
+      />
+    );
+    // The mock returns the last key segment: 'disabledSourceBook'
+    expect(screen.getByText('disabledSourceBook')).toBeTruthy();
+  });
+
+  it('does NOT show disabled-book badge when the current feat is in allowedFeats', () => {
+    const currentDecision: ChoiceDecision = {
+      type: 'feat-choice',
+      featId: 'lucky' as import('@/lib/dnd-helpers').FeatId,
+    };
+    render(
+      <ChoicePicker
+        choice={ORIGIN_FEAT_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        onClear={vi.fn()}
+        allowedFeats={ALLOWED_FEATS_WITHOUT_ALERT}
+      />
+    );
+    expect(screen.queryByText('disabledSourceBook')).toBeNull();
+  });
+});

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -10,6 +10,7 @@ import type { FeatId } from '@/lib/dnd-helpers';
 import { getItemDef, getItemNameKey, WEAPON_CATALOG } from '@/lib/sources/items';
 import { getBundleDef, getBundleNameKey, getItemsForSlot, resolveBundleRef } from '@/lib/sources/bundles';
 import { FEAT_SOURCES } from '@/lib/sources';
+import type { FeatSource } from '@/lib/sources';
 import { getSpellsForList } from '@/lib/sources/spells';
 import type { SpellId } from '@/types/spells';
 import type { ChoiceDecision, ChoiceKey } from '@/types/choices';
@@ -29,6 +30,12 @@ interface ChoicePickerProps {
   readonly currentDecision: ChoiceDecision | undefined;
   readonly onDecide: (key: ChoiceKey, decision: ChoiceDecision) => void;
   readonly onClear: (key: ChoiceKey) => void;
+  /**
+   * Optional filtered feat list from useGameData. When provided, only feats in
+   * this list are shown for feat-choice prompts, PLUS the currently chosen feat
+   * (no-data-loss union). Falls back to the full FEAT_SOURCES when undefined.
+   */
+  readonly allowedFeats?: readonly FeatSource[];
 }
 
 const ALL_SKILL_IDS: readonly SkillId[] = DND_SKILLS.map((s) => s.id);
@@ -42,7 +49,7 @@ function isLanguageId(id: string): id is LanguageId {
   return (ALL_LANGUAGE_IDS as readonly string[]).includes(id);
 }
 
-export function ChoicePicker({ choice, currentDecision, onDecide, onClear }: ChoicePickerProps) {
+export function ChoicePicker({ choice, currentDecision, onDecide, onClear, allowedFeats }: ChoicePickerProps) {
   const { t } = useTranslation('gamedata');
   const { t: tc } = useTranslation('common');
 
@@ -237,8 +244,15 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear }: Cho
 
   if (choice.type === 'feat-choice') {
     const { from, category } = choice;
-    const pool: readonly FeatId[] = from ?? FEAT_SOURCES.filter((f) => f.category === category).map((f) => f.id);
     const currentFeatId = currentDecision?.type === 'feat-choice' ? currentDecision.featId : undefined;
+    // Base feat source list: use allowedFeats when provided, else full FEAT_SOURCES.
+    const featSource = allowedFeats ?? FEAT_SOURCES;
+    // Compute the pool: explicit `from` list takes priority; otherwise filter by category.
+    // Union with currentFeatId for no-data-loss (keep current selection visible even if its
+    // book is now disabled).
+    const basePool: readonly FeatId[] = from ?? featSource.filter((f) => f.category === category).map((f) => f.id);
+    const pool: readonly FeatId[] =
+      currentFeatId && !basePool.includes(currentFeatId) ? [...basePool, currentFeatId] : basePool;
 
     return (
       <div className="space-y-2">

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -264,6 +264,7 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear, allow
             const descKey = `feats.${featId}.description` as `feats.${string}.description`;
             const label = t(nameKey, { defaultValue: featId });
             const description = t(descKey, { defaultValue: '' });
+            const isDisabledBook = featId === currentFeatId && !basePool.includes(featId);
             return (
               <div
                 key={featId}
@@ -279,6 +280,11 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear, allow
                 />
                 <Label htmlFor={radioId} className="flex-1 cursor-pointer">
                   <span className="font-medium">{label}</span>
+                  {isDisabledBook && (
+                    <Badge variant="destructive" className="text-xs ml-2">
+                      {tc('characterBuilder.hints.disabledSourceBook')}
+                    </Badge>
+                  )}
                   {description ? (
                     <span className="block text-xs text-muted-foreground mt-0.5">{description}</span>
                   ) : null}

--- a/src/components/character-builder/ClassStep.test.tsx
+++ b/src/components/character-builder/ClassStep.test.tsx
@@ -27,6 +27,35 @@ vi.mock('react-i18next', () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// react-router-dom mock
+// ---------------------------------------------------------------------------
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ campaignSlug: 'test-campaign' }),
+}));
+
+// ---------------------------------------------------------------------------
+// useGameData mock — returns full SUBCLASS_SOURCES by default
+// ---------------------------------------------------------------------------
+
+import { SUBCLASS_SOURCES } from '@/lib/sources/subclasses';
+import { CLASS_SOURCES } from '@/lib/sources/classes';
+import { SPECIES_SOURCES } from '@/lib/sources/species';
+import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
+import { FEAT_SOURCES } from '@/lib/sources/feats';
+
+vi.mock('@/hooks/useGameData', () => ({
+  useGameData: () => ({
+    species: SPECIES_SOURCES,
+    classes: CLASS_SOURCES,
+    backgrounds: BACKGROUND_SOURCES,
+    feats: FEAT_SOURCES,
+    subclasses: SUBCLASS_SOURCES,
+    allowedSourceBooks: ['phb-2024'],
+  }),
+}));
+
+// ---------------------------------------------------------------------------
 // Context mock
 // ---------------------------------------------------------------------------
 

--- a/src/components/character-builder/ClassStep.tsx
+++ b/src/components/character-builder/ClassStep.tsx
@@ -3,6 +3,7 @@ import { Label } from '@/components/ui/label';
 import { SubclassPicker } from '@/components/character-sheet/SubclassPicker';
 import { ChoicePicker } from '@/components/character-builder/ChoicePicker';
 import { useCharacterContext } from '@/hooks/useCharacterContext';
+import { useGameData } from '@/hooks/useGameData';
 import { type ChoiceKey } from '@/types/choices';
 import { type FightingStyleId } from '@/lib/dnd-helpers';
 import { getChoiceSourceName } from '@/lib/character-builder/choice-source-name';
@@ -11,6 +12,7 @@ import type { PendingChoice } from '@/types/resolved';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 import { isSpellId } from '@/lib/sources/spells';
+import { useParams } from 'react-router-dom';
 
 interface FightingStyleChoiceInfo {
   readonly choiceKey: ChoiceKey;
@@ -21,6 +23,8 @@ interface FightingStyleChoiceInfo {
 export function ClassStep() {
   const { t } = useTranslation('gamedata');
   const { t: tc } = useTranslation('common');
+  const { campaignSlug } = useParams<{ campaignSlug: string }>();
+  const gameData = useGameData(campaignSlug);
   const context = useCharacterContext();
   const { resolved, build, bundles } = context;
 
@@ -211,6 +215,7 @@ export function ClassStep() {
               onDecide={(choiceKey, subclassId) => context.makeChoice(choiceKey, { type: 'subclass', subclassId })}
               onClear={(choiceKey) => context.clearChoice(choiceKey)}
               autoCommit
+              allowedSubclasses={gameData.subclasses}
             />
           ))}
         </div>

--- a/src/components/character-builder/OriginStep.test.tsx
+++ b/src/components/character-builder/OriginStep.test.tsx
@@ -27,6 +27,35 @@ vi.mock('react-i18next', () => ({
 }));
 
 // ---------------------------------------------------------------------------
+// react-router-dom mock
+// ---------------------------------------------------------------------------
+
+vi.mock('react-router-dom', () => ({
+  useParams: () => ({ campaignSlug: 'test-campaign' }),
+}));
+
+// ---------------------------------------------------------------------------
+// useGameData mock — returns full lists by default
+// ---------------------------------------------------------------------------
+
+import { SPECIES_SOURCES } from '@/lib/sources/species';
+import { CLASS_SOURCES } from '@/lib/sources/classes';
+import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
+import { FEAT_SOURCES } from '@/lib/sources/feats';
+import { SUBCLASS_SOURCES } from '@/lib/sources/subclasses';
+
+vi.mock('@/hooks/useGameData', () => ({
+  useGameData: () => ({
+    species: SPECIES_SOURCES,
+    classes: CLASS_SOURCES,
+    backgrounds: BACKGROUND_SOURCES,
+    feats: FEAT_SOURCES,
+    subclasses: SUBCLASS_SOURCES,
+    allowedSourceBooks: ['phb-2024'],
+  }),
+}));
+
+// ---------------------------------------------------------------------------
 // Mock useCharacterContext
 // ---------------------------------------------------------------------------
 

--- a/src/components/character-builder/OriginStep.tsx
+++ b/src/components/character-builder/OriginStep.tsx
@@ -1,6 +1,7 @@
 import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
 import { useCharacterContext } from '@/hooks/useCharacterContext';
+import { useGameData } from '@/hooks/useGameData';
 import { type SpeciesId, type ToolProficiencyId } from '@/lib/dnd-helpers';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
 import { getChoiceSourceName } from '@/lib/character-builder/choice-source-name';
@@ -9,6 +10,7 @@ import type { ChoiceDecision } from '@/types/choices';
 import type { PendingChoice } from '@/types/resolved';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
+import { useParams } from 'react-router-dom';
 import { ChoicePicker } from './ChoicePicker';
 import { LineagePicker } from './LineagePicker';
 import { SPECIES_SOURCES } from '@/lib/sources/species';
@@ -16,6 +18,8 @@ import { SPECIES_SOURCES } from '@/lib/sources/species';
 export function OriginStep() {
   const { t } = useTranslation('gamedata');
   const { t: tc } = useTranslation('common');
+  const { campaignSlug } = useParams<{ campaignSlug: string }>();
+  const gameData = useGameData(campaignSlug);
   const context = useCharacterContext();
   const { character, bundles, build, resolved } = context;
 
@@ -92,6 +96,7 @@ export function OriginStep() {
                 currentDecision={build?.choices[choice.choiceKey]}
                 onDecide={(choiceKey, decision) => context.makeChoice(choiceKey, decision)}
                 onClear={(choiceKey) => context.clearChoice(choiceKey)}
+                allowedFeats={gameData.feats}
               />
             </div>
           ))}

--- a/src/components/character-sheet/SubclassPicker.test.tsx
+++ b/src/components/character-sheet/SubclassPicker.test.tsx
@@ -1,0 +1,127 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { SubclassPicker } from '@/components/character-sheet/SubclassPicker';
+import { SUBCLASS_SOURCES } from '@/lib/sources/subclasses';
+import type { PendingChoice } from '@/types/resolved';
+import type { ChoiceKey, ChoiceDecision } from '@/types/choices';
+
+// Mirror the mock pattern used in the rest of the character-sheet test suite.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string }) => opts?.defaultValue ?? key,
+    i18n: { language: 'en' },
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Shared fixtures
+// ---------------------------------------------------------------------------
+
+const FIGHTER_SOURCE = { origin: 'class' as const, id: 'fighter' as const, level: 3 };
+
+const SUBCLASS_CHOICE: Extract<PendingChoice, { type: 'subclass' }> = {
+  type: 'subclass',
+  choiceKey: 'subclass:class:fighter:0' as ChoiceKey,
+  source: FIGHTER_SOURCE,
+  classId: 'fighter',
+};
+
+// ---------------------------------------------------------------------------
+// SubclassPicker — no-data-loss: kept subclass with disabled book
+// ---------------------------------------------------------------------------
+
+describe('SubclassPicker — disabled-book kept subclass (no-data-loss)', () => {
+  it('renders the current subclass even when its book is excluded from allowedSubclasses', () => {
+    // champion is current; allowedSubclasses only contains battlemaster (champion excluded)
+    const allowedSubclasses = { battlemaster: SUBCLASS_SOURCES.battlemaster };
+    const currentDecision: ChoiceDecision = { type: 'subclass', subclassId: 'champion' };
+
+    render(
+      <SubclassPicker
+        choice={SUBCLASS_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        allowedSubclasses={allowedSubclasses}
+      />
+    );
+
+    // champion should render — the t() mock returns the full key, so look for the key
+    expect(screen.getByText('subclasses.champion.name')).toBeTruthy();
+  });
+
+  it('does not crash when the kept subclass is selected (features.flatMap path executes)', () => {
+    // This is the exact crash path: existingSubclassId === 'champion', selected === 'champion',
+    // allowedSubclasses excludes champion → old code did sourceMap['champion'] = undefined →
+    // { id, ...undefined } = { id } → sc.features.flatMap throws.
+    const allowedSubclasses = { battlemaster: SUBCLASS_SOURCES.battlemaster };
+    const currentDecision: ChoiceDecision = { type: 'subclass', subclassId: 'champion' };
+
+    // Should NOT throw; champion's features must render (features list has content)
+    expect(() =>
+      render(
+        <SubclassPicker
+          choice={SUBCLASS_CHOICE}
+          currentDecision={currentDecision}
+          onDecide={vi.fn()}
+          allowedSubclasses={allowedSubclasses}
+        />
+      )
+    ).not.toThrow();
+
+    // The selected button expands features — verify at least one feature <li> renders
+    const featureItems = document.querySelectorAll('ul li');
+    expect(featureItems.length).toBeGreaterThan(0);
+  });
+
+  it('shows the disabled-book badge next to the kept-but-excluded subclass', () => {
+    const allowedSubclasses = { battlemaster: SUBCLASS_SOURCES.battlemaster };
+    const currentDecision: ChoiceDecision = { type: 'subclass', subclassId: 'champion' };
+
+    render(
+      <SubclassPicker
+        choice={SUBCLASS_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        allowedSubclasses={allowedSubclasses}
+      />
+    );
+
+    // The badge text is the last segment of characterBuilder.hints.disabledSourceBook
+    // which the mock returns as the full key
+    expect(screen.getByText('characterBuilder.hints.disabledSourceBook')).toBeTruthy();
+  });
+
+  it('does NOT show the disabled-book badge for allowed subclasses', () => {
+    const allowedSubclasses = { battlemaster: SUBCLASS_SOURCES.battlemaster };
+    const currentDecision: ChoiceDecision = { type: 'subclass', subclassId: 'battlemaster' };
+
+    render(
+      <SubclassPicker
+        choice={SUBCLASS_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        allowedSubclasses={allowedSubclasses}
+      />
+    );
+
+    expect(screen.queryByText('characterBuilder.hints.disabledSourceBook')).toBeNull();
+  });
+
+  it('does NOT render a subclass that is excluded AND not the current selection', () => {
+    // eldritchknight is excluded and not selected; it should be absent
+    const allowedSubclasses = { battlemaster: SUBCLASS_SOURCES.battlemaster };
+    const currentDecision: ChoiceDecision = { type: 'subclass', subclassId: 'champion' };
+
+    render(
+      <SubclassPicker
+        choice={SUBCLASS_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        allowedSubclasses={allowedSubclasses}
+      />
+    );
+
+    expect(screen.queryByText('subclasses.eldritchknight.name')).toBeNull();
+    expect(screen.queryByText('subclasses.psiwarrior.name')).toBeNull();
+  });
+});

--- a/src/components/character-sheet/SubclassPicker.tsx
+++ b/src/components/character-sheet/SubclassPicker.tsx
@@ -7,6 +7,7 @@ import type { ChoiceKey, ChoiceDecision } from '@/types/choices';
 import type { SubclassId } from '@/lib/sources/subclasses';
 import { isSubclassId } from '@/lib/sources/subclasses';
 import { useTranslation } from 'react-i18next';
+import type { SubclassSource } from '@/types/sources';
 
 interface SubclassPickerProps {
   readonly choice: Extract<PendingChoice, { type: 'subclass' }>;
@@ -15,9 +16,22 @@ interface SubclassPickerProps {
   readonly onClear?: (key: ChoiceKey) => void;
   /** When true, calls onDecide immediately on selection and hides the confirm button. */
   readonly autoCommit?: boolean;
+  /**
+   * Optional filtered subclass map from useGameData. Only subclasses present in
+   * this map are shown, PLUS the currently selected subclass (no-data-loss union).
+   * Falls back to the full SUBCLASS_SOURCES when undefined.
+   */
+  readonly allowedSubclasses?: Readonly<Record<SubclassId, SubclassSource>>;
 }
 
-export function SubclassPicker({ choice, currentDecision, onDecide, onClear, autoCommit }: SubclassPickerProps) {
+export function SubclassPicker({
+  choice,
+  currentDecision,
+  onDecide,
+  onClear,
+  autoCommit,
+  allowedSubclasses,
+}: SubclassPickerProps) {
   const { t } = useTranslation('gamedata');
   const { t: tc } = useTranslation('common');
 
@@ -28,8 +42,14 @@ export function SubclassPicker({ choice, currentDecision, onDecide, onClear, aut
   const [selected, setSelected] = useState<SubclassId | null>(existingSubclassId);
   const hasExistingDecision = existingSubclassId !== null;
 
+  // Use the provided allowed map or fall back to the full registry.
+  const sourceMap = allowedSubclasses ?? SUBCLASS_SOURCES;
+
+  // Filter to ids that are present in sourceMap OR are the currently selected id
+  // (no-data-loss: keep the selection visible even when its book is disabled).
   const subclasses = SUBCLASS_IDS_BY_CLASS[choice.classId]
-    .map((id) => ({ id, ...SUBCLASS_SOURCES[id] }))
+    .filter((id) => id in sourceMap || id === existingSubclassId)
+    .map((id) => ({ id, ...sourceMap[id] }))
     .sort((a, b) => t(`subclasses.${a.id}.name`).localeCompare(t(`subclasses.${b.id}.name`)));
   const className = t(`classes.${choice.classId}`, { defaultValue: choice.classId });
 

--- a/src/components/character-sheet/SubclassPicker.tsx
+++ b/src/components/character-sheet/SubclassPicker.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { SUBCLASS_SOURCES, SUBCLASS_IDS_BY_CLASS } from '@/lib/sources/subclasses';
@@ -21,7 +22,7 @@ interface SubclassPickerProps {
    * this map are shown, PLUS the currently selected subclass (no-data-loss union).
    * Falls back to the full SUBCLASS_SOURCES when undefined.
    */
-  readonly allowedSubclasses?: Readonly<Record<SubclassId, SubclassSource>>;
+  readonly allowedSubclasses?: Readonly<Partial<Record<SubclassId, SubclassSource>>>;
 }
 
 export function SubclassPicker({
@@ -45,11 +46,12 @@ export function SubclassPicker({
   // Use the provided allowed map or fall back to the full registry.
   const sourceMap = allowedSubclasses ?? SUBCLASS_SOURCES;
 
-  // Filter to ids that are present in sourceMap OR are the currently selected id
+  // Filter to ids that are present in sourceMap (visibility) OR are the currently selected id
   // (no-data-loss: keep the selection visible even when its book is disabled).
+  // Data always comes from the full SUBCLASS_SOURCES registry so features are never undefined.
   const subclasses = SUBCLASS_IDS_BY_CLASS[choice.classId]
     .filter((id) => id in sourceMap || id === existingSubclassId)
-    .map((id) => ({ id, ...sourceMap[id] }))
+    .map((id) => ({ id, ...SUBCLASS_SOURCES[id] }))
     .sort((a, b) => t(`subclasses.${a.id}.name`).localeCompare(t(`subclasses.${b.id}.name`)));
   const className = t(`classes.${choice.classId}`, { defaultValue: choice.classId });
 
@@ -84,6 +86,7 @@ export function SubclassPicker({
         )}
         {subclasses.map((sc) => {
           const isSelected = selected === sc.id;
+          const isDisabledBook = sc.id === existingSubclassId && !(sc.id in sourceMap);
 
           return (
             <button
@@ -94,8 +97,13 @@ export function SubclassPicker({
                 isSelected ? 'border-primary bg-primary/5' : 'border-border bg-muted/20'
               }`}
             >
-              <div className={`text-sm text-foreground ${isSelected ? 'font-semibold' : ''}`}>
+              <div className={`flex items-center gap-2 text-sm text-foreground ${isSelected ? 'font-semibold' : ''}`}>
                 {t(`subclasses.${sc.id}.name`)}
+                {isDisabledBook && (
+                  <Badge variant="destructive" className="text-xs">
+                    {tc('characterBuilder.hints.disabledSourceBook')}
+                  </Badge>
+                )}
               </div>
               <p className="text-xs text-muted-foreground mt-1">{t(`subclasses.${sc.id}.description`)}</p>
               {isSelected && (

--- a/src/hooks/useGameData.test.ts
+++ b/src/hooks/useGameData.test.ts
@@ -1,0 +1,153 @@
+import { setupMockReset, renderHook, waitFor, createWrapper, mockQueryResult } from '@/test/hook-test-helpers';
+
+vi.mock('@/lib/supabase', () => import('@/test/mocks/supabase'));
+
+import { useGameData } from '@/hooks/useGameData';
+import type { Campaign } from '@/types/database';
+import { SPECIES_SOURCES } from '@/lib/sources/species';
+import { CLASS_SOURCES } from '@/lib/sources/classes';
+import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
+import { FEAT_SOURCES } from '@/lib/sources/feats';
+import { SUBCLASS_SOURCES } from '@/lib/sources/subclasses';
+import type { SourceBookId } from '@/lib/source-books';
+
+const baseCampaign: Campaign = {
+  id: 'camp-1',
+  slug: 'test-campaign',
+  previous_slugs: [],
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  name: 'Test Campaign',
+  status: 'active',
+  description: null,
+  setting: null,
+  image_url: null,
+  dm_notes: null,
+  theme: null,
+  archived_at: null,
+  allowed_source_books: ['phb-2024'],
+};
+
+setupMockReset();
+
+describe('useGameData', () => {
+  describe('with allowed source books = [phb-2024]', () => {
+    it('returns full species list when phb-2024 is allowed', async () => {
+      mockQueryResult.data = baseCampaign;
+
+      const { result } = renderHook(() => useGameData('test-campaign'), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(result.current.species.length).toBeGreaterThan(0));
+      expect(result.current.species).toEqual(SPECIES_SOURCES);
+    });
+
+    it('returns full classes list when phb-2024 is allowed', async () => {
+      mockQueryResult.data = baseCampaign;
+
+      const { result } = renderHook(() => useGameData('test-campaign'), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(result.current.classes.length).toBeGreaterThan(0));
+      expect(result.current.classes).toEqual(CLASS_SOURCES);
+    });
+
+    it('returns full backgrounds list when phb-2024 is allowed', async () => {
+      mockQueryResult.data = baseCampaign;
+
+      const { result } = renderHook(() => useGameData('test-campaign'), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(result.current.backgrounds.length).toBeGreaterThan(0));
+      expect(result.current.backgrounds).toEqual(BACKGROUND_SOURCES);
+    });
+
+    it('returns full feats list when phb-2024 is allowed', async () => {
+      mockQueryResult.data = baseCampaign;
+
+      const { result } = renderHook(() => useGameData('test-campaign'), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(result.current.feats.length).toBeGreaterThan(0));
+      expect(result.current.feats).toEqual(FEAT_SOURCES);
+    });
+
+    it('returns full subclasses record when phb-2024 is allowed', async () => {
+      mockQueryResult.data = baseCampaign;
+
+      const { result } = renderHook(() => useGameData('test-campaign'), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(Object.keys(result.current.subclasses).length).toBeGreaterThan(0));
+      expect(result.current.subclasses).toEqual(SUBCLASS_SOURCES);
+    });
+
+    it('exposes allowedSourceBooks with the campaign value', async () => {
+      mockQueryResult.data = baseCampaign;
+
+      const { result } = renderHook(() => useGameData('test-campaign'), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(result.current.allowedSourceBooks).toEqual(['phb-2024']));
+    });
+  });
+
+  describe('with allowed source books = [some-future-book] (simulated disabled PHB)', () => {
+    const futureCampaign: Campaign = {
+      ...baseCampaign,
+      allowed_source_books: ['some-future-book' as SourceBookId],
+    };
+
+    it('returns empty species list when phb-2024 is not allowed', async () => {
+      mockQueryResult.data = futureCampaign;
+
+      const { result } = renderHook(() => useGameData('test-campaign'), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(result.current.allowedSourceBooks).toEqual(['some-future-book']));
+      expect(result.current.species).toHaveLength(0);
+    });
+
+    it('returns empty classes list when phb-2024 is not allowed', async () => {
+      mockQueryResult.data = futureCampaign;
+
+      const { result } = renderHook(() => useGameData('test-campaign'), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(result.current.allowedSourceBooks).toEqual(['some-future-book']));
+      expect(result.current.classes).toHaveLength(0);
+    });
+
+    it('returns empty backgrounds list when phb-2024 is not allowed', async () => {
+      mockQueryResult.data = futureCampaign;
+
+      const { result } = renderHook(() => useGameData('test-campaign'), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(result.current.allowedSourceBooks).toEqual(['some-future-book']));
+      expect(result.current.backgrounds).toHaveLength(0);
+    });
+
+    it('returns empty feats list when phb-2024 is not allowed', async () => {
+      mockQueryResult.data = futureCampaign;
+
+      const { result } = renderHook(() => useGameData('test-campaign'), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(result.current.allowedSourceBooks).toEqual(['some-future-book']));
+      expect(result.current.feats).toHaveLength(0);
+    });
+
+    it('returns empty subclasses record when phb-2024 is not allowed', async () => {
+      mockQueryResult.data = futureCampaign;
+
+      const { result } = renderHook(() => useGameData('test-campaign'), { wrapper: createWrapper() });
+
+      await waitFor(() => expect(result.current.allowedSourceBooks).toEqual(['some-future-book']));
+      expect(Object.keys(result.current.subclasses)).toHaveLength(0);
+    });
+  });
+
+  describe('with undefined slug (loading state)', () => {
+    it('defaults to phb-2024 and returns full lists when slug is undefined', () => {
+      const { result } = renderHook(() => useGameData(undefined), { wrapper: createWrapper() });
+
+      // No query is fired when slug is undefined, so we check synchronously
+      expect(result.current.allowedSourceBooks).toEqual(['phb-2024']);
+      expect(result.current.species).toEqual(SPECIES_SOURCES);
+      expect(result.current.classes).toEqual(CLASS_SOURCES);
+      expect(result.current.backgrounds).toEqual(BACKGROUND_SOURCES);
+      expect(result.current.feats).toEqual(FEAT_SOURCES);
+    });
+  });
+});

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -20,7 +20,7 @@ export interface GameData {
   readonly classes: readonly ClassSource[];
   readonly backgrounds: readonly BackgroundSource[];
   readonly feats: readonly FeatSource[];
-  readonly subclasses: Readonly<Record<SubclassId, SubclassSource>>;
+  readonly subclasses: Readonly<Partial<Record<SubclassId, SubclassSource>>>;
   readonly allowedSourceBooks: readonly SourceBookId[];
 }
 
@@ -45,10 +45,9 @@ export function useGameData(campaignSlug: string | undefined): GameData {
     const feats = filterBySourceBooks(FEAT_SOURCES, allowed);
     const subclasses = Object.fromEntries(
       Object.entries(SUBCLASS_SOURCES).filter(([, v]) => allowed.includes(v.sourceBook ?? 'phb-2024'))
-    ) as Record<SubclassId, SubclassSource>;
+    ) as Partial<Record<SubclassId, SubclassSource>>;
 
     return { species, classes, backgrounds, feats, subclasses, allowedSourceBooks: allowed };
     // allowedKey is a stable string representation of the source book list
-     
   }, [allowedKey]);
 }

--- a/src/hooks/useGameData.ts
+++ b/src/hooks/useGameData.ts
@@ -1,0 +1,54 @@
+import { useMemo } from 'react';
+import { useCampaign } from '@/hooks/useCampaigns';
+import { filterBySourceBooks, type SourceBookId } from '@/lib/source-books';
+import { SPECIES_SOURCES } from '@/lib/sources/species';
+import { CLASS_SOURCES } from '@/lib/sources/classes';
+import { SUBCLASS_SOURCES } from '@/lib/sources/subclasses';
+import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
+import { FEAT_SOURCES } from '@/lib/sources/feats';
+import type {
+  SpeciesSource,
+  ClassSource,
+  BackgroundSource,
+  FeatSource,
+  SubclassSource,
+  SubclassId,
+} from '@/lib/sources';
+
+export interface GameData {
+  readonly species: readonly SpeciesSource[];
+  readonly classes: readonly ClassSource[];
+  readonly backgrounds: readonly BackgroundSource[];
+  readonly feats: readonly FeatSource[];
+  readonly subclasses: Readonly<Record<SubclassId, SubclassSource>>;
+  readonly allowedSourceBooks: readonly SourceBookId[];
+}
+
+const DEFAULT_ALLOWED: readonly SourceBookId[] = ['phb-2024'];
+
+export function useGameData(campaignSlug: string | undefined): GameData {
+  const { data: campaign } = useCampaign(campaignSlug);
+  // Use the campaign's source book list, or fall back to the default.
+  // Spread into a stable reference so useMemo's dep comparison works correctly:
+  // campaign?.allowed_source_books is a new array ref on every query result, so we
+  // join it into a string key for memoization stability.
+  const allowedSourceBooks = campaign?.allowed_source_books ?? DEFAULT_ALLOWED;
+  const allowedKey = allowedSourceBooks.join(',');
+
+  return useMemo<GameData>((): GameData => {
+    // Re-derive `allowed` inside the memo so we have a typed readonly array.
+    const allowed: readonly SourceBookId[] = allowedKey ? (allowedKey.split(',') as SourceBookId[]) : DEFAULT_ALLOWED;
+
+    const species = filterBySourceBooks(SPECIES_SOURCES, allowed);
+    const classes = filterBySourceBooks(CLASS_SOURCES, allowed);
+    const backgrounds = filterBySourceBooks(BACKGROUND_SOURCES, allowed);
+    const feats = filterBySourceBooks(FEAT_SOURCES, allowed);
+    const subclasses = Object.fromEntries(
+      Object.entries(SUBCLASS_SOURCES).filter(([, v]) => allowed.includes(v.sourceBook ?? 'phb-2024'))
+    ) as Record<SubclassId, SubclassSource>;
+
+    return { species, classes, backgrounds, feats, subclasses, allowedSourceBooks: allowed };
+    // allowedKey is a stable string representation of the source book list
+     
+  }, [allowedKey]);
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -724,7 +724,12 @@
       "title": "Campaign Toolkit"
     },
     "theme": "Campaign Theme",
-    "themeDescription": "Customize the color theme for this campaign"
+    "themeDescription": "Customize the color theme for this campaign",
+    "sourceBooks": {
+      "title": "Source Books",
+      "description": "Choose which rulebooks are available for character creation in this campaign.",
+      "lastBookWarning": "At least one source book must be enabled."
+    }
   },
   "characterType": {
     "pc": "PC",

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -224,7 +224,8 @@
       "quickNpcCommitFailed": "Could not apply NPC — please try again",
       "quickNpcAdvanceTimeout": "NPC was created but the step did not advance — please navigate manually",
       "quickNpcOverwriteTitle": "Replace your current work?",
-      "quickNpcOverwriteConfirm": "This will overwrite the data you have already entered. Continue?"
+      "quickNpcOverwriteConfirm": "This will overwrite the data you have already entered. Continue?",
+      "disabledSourceBook": "This option is from a source book not enabled for this campaign."
     },
     "abilities": {
       "standardArray": "Standard Array",

--- a/src/pages/CampaignDashboard.sourcebooks.test.tsx
+++ b/src/pages/CampaignDashboard.sourcebooks.test.tsx
@@ -1,0 +1,129 @@
+/**
+ * Focused render tests for the source books toggle Card in CampaignDashboard.
+ * Mounts only the relevant portion of the dashboard by mocking every hook the
+ * page calls, then confirms the toggle card behaves correctly.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import { SOURCE_BOOKS } from '@/lib/source-books';
+import type { Campaign } from '@/types/database';
+import CampaignDashboard from '@/pages/CampaignDashboard';
+
+// ---------------------------------------------------------------------------
+// react-i18next mock
+// ---------------------------------------------------------------------------
+vi.mock('react-i18next', () => ({
+  useTranslation: (ns?: string) => ({
+    t: (key: string) => key.split('.').pop() ?? key,
+    i18n: { language: 'en' },
+    ns,
+  }),
+}));
+
+// ---------------------------------------------------------------------------
+// Hook mocks — populated per test via module-level variables
+// ---------------------------------------------------------------------------
+
+const mockUpdateMutate = vi.fn();
+let mockCampaign: Campaign | undefined;
+
+vi.mock('@/hooks/useCampaigns', () => ({
+  useCampaign: () => ({ data: mockCampaign, isLoading: false }),
+  useCampaignMutations: () => ({
+    update: {
+      mutate: mockUpdateMutate,
+      isPending: false,
+      isError: false,
+      variables: undefined,
+    },
+    create: { mutate: vi.fn() },
+    archive: { mutate: vi.fn() },
+  }),
+}));
+
+vi.mock('@/hooks/useCampaignContext', () => ({
+  useCampaignContext: () => ({ campaignId: 'camp-1' }),
+}));
+
+vi.mock('@/hooks/usePageTitle', () => ({
+  usePageTitle: () => undefined,
+}));
+
+vi.mock('@/hooks/useCharacters', () => ({
+  useCharacters: () => ({ data: [], error: null }),
+}));
+
+vi.mock('@/hooks/useSessions', () => ({
+  useSessions: () => ({ data: [], error: null }),
+}));
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+const makeCampaign = (overrides?: Partial<Campaign>): Campaign => ({
+  id: 'camp-1',
+  slug: 'test-campaign',
+  previous_slugs: [],
+  created_at: '2024-01-01T00:00:00Z',
+  updated_at: '2024-01-01T00:00:00Z',
+  name: 'Test Campaign',
+  status: 'active',
+  description: null,
+  setting: null,
+  image_url: null,
+  dm_notes: null,
+  theme: null,
+  archived_at: null,
+  allowed_source_books: ['phb-2024'],
+  ...overrides,
+});
+
+function renderDashboard() {
+  return render(
+    <MemoryRouter initialEntries={['/campaign/test-campaign']}>
+      <Routes>
+        <Route path="/campaign/:campaignSlug" element={<CampaignDashboard />} />
+      </Routes>
+    </MemoryRouter>
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+describe('CampaignDashboard — source books card', () => {
+  beforeEach(() => {
+    mockCampaign = makeCampaign();
+    mockUpdateMutate.mockClear();
+  });
+
+  it('renders one checkbox per SOURCE_BOOKS entry', () => {
+    renderDashboard();
+
+    // The card must have exactly as many checkboxes as there are SOURCE_BOOKS
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes.length).toBeGreaterThanOrEqual(SOURCE_BOOKS.length);
+  });
+
+  it('checkbox is checked when the book is in allowed_source_books', () => {
+    mockCampaign = makeCampaign({ allowed_source_books: ['phb-2024'] });
+    renderDashboard();
+
+    // There should be exactly one checkbox (one book today)
+    const checkbox = screen.getAllByRole('checkbox')[0];
+    expect(checkbox).toHaveAttribute('aria-checked', 'true');
+  });
+
+  it('disables the checkbox when it is the last checked book', () => {
+    // Only phb-2024 allowed — the checkbox for it must be disabled
+    mockCampaign = makeCampaign({ allowed_source_books: ['phb-2024'] });
+    renderDashboard();
+
+    const checkbox = screen.getAllByRole('checkbox')[0];
+    // Base UI Checkbox uses data-disabled attribute when disabled
+    expect(checkbox).toHaveAttribute('data-disabled');
+  });
+});

--- a/src/pages/CampaignDashboard.sourcebooks.test.tsx
+++ b/src/pages/CampaignDashboard.sourcebooks.test.tsx
@@ -4,9 +4,10 @@
  * page calls, then confirms the toggle card behaves correctly.
  */
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent } from '@testing-library/react';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
 import { SOURCE_BOOKS } from '@/lib/source-books';
+import type { SourceBookId } from '@/lib/source-books';
 import type { Campaign } from '@/types/database';
 import CampaignDashboard from '@/pages/CampaignDashboard';
 
@@ -125,5 +126,69 @@ describe('CampaignDashboard — source books card', () => {
     const checkbox = screen.getAllByRole('checkbox')[0];
     // Base UI Checkbox uses data-disabled attribute when disabled
     expect(checkbox).toHaveAttribute('data-disabled');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Toggle payload tests — require a second source book to be injectable.
+// We mock @/lib/source-books to add a fake second book so the toggle is
+// exercisable (with only one book the checkbox is always disabled).
+// ---------------------------------------------------------------------------
+
+// Inject a second source book so the toggle checkbox is exercisable.
+// vi.mock is hoisted — the factory must not reference outer module-scope consts,
+// so the id literal is inlined directly.
+vi.mock('@/lib/source-books', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/lib/source-books')>();
+  return {
+    ...actual,
+    SOURCE_BOOKS: [...actual.SOURCE_BOOKS, { id: 'xge-2024', abbreviation: 'XGE 2024' }],
+  };
+});
+
+// Alias used in test assertions — must match the inlined literal above.
+const FAKE_BOOK_ID = 'xge-2024' as SourceBookId;
+
+describe('CampaignDashboard — source books toggle payload', () => {
+  beforeEach(() => {
+    mockCampaign = makeCampaign({ allowed_source_books: ['phb-2024'] });
+    mockUpdateMutate.mockClear();
+  });
+
+  it('checking an unchecked book calls mutate with allowed_source_books including the added book', () => {
+    // phb-2024 is checked; xge-2024 is unchecked. Click xge-2024's checkbox.
+    renderDashboard();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    // The second checkbox corresponds to FAKE_BOOK_ID (xge-2024) which is unchecked
+    const xgeCheckbox = checkboxes[1];
+    expect(xgeCheckbox).not.toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(xgeCheckbox);
+
+    expect(mockUpdateMutate).toHaveBeenCalledOnce();
+    const callArgs = mockUpdateMutate.mock.calls[0][0] as { id: string; allowed_source_books: SourceBookId[] };
+    expect(callArgs.id).toBe('camp-1');
+    expect(callArgs.allowed_source_books).toContain('phb-2024');
+    expect(callArgs.allowed_source_books).toContain(FAKE_BOOK_ID);
+  });
+
+  it('unchecking a checked book (when >1 are checked) calls mutate with that book filtered out', () => {
+    // Both phb-2024 and xge-2024 are checked. Uncheck xge-2024.
+    mockCampaign = makeCampaign({ allowed_source_books: ['phb-2024', FAKE_BOOK_ID] });
+    renderDashboard();
+
+    const checkboxes = screen.getAllByRole('checkbox');
+    // xge-2024 is the second checkbox and is checked; phb-2024 is first
+    const xgeCheckbox = checkboxes[1];
+    expect(xgeCheckbox).toHaveAttribute('aria-checked', 'true');
+
+    fireEvent.click(xgeCheckbox);
+
+    expect(mockUpdateMutate).toHaveBeenCalledOnce();
+    const callArgs = mockUpdateMutate.mock.calls[0][0] as { id: string; allowed_source_books: SourceBookId[] };
+    expect(callArgs.id).toBe('camp-1');
+    expect(callArgs.allowed_source_books).toContain('phb-2024');
+    expect(callArgs.allowed_source_books).not.toContain(FAKE_BOOK_ID);
   });
 });

--- a/src/pages/CampaignDashboard.tsx
+++ b/src/pages/CampaignDashboard.tsx
@@ -1,9 +1,12 @@
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/ui/button';
 import { Card, CardContent } from '@/components/ui/card';
+import { Checkbox } from '@/components/ui/checkbox';
+import { Label } from '@/components/ui/label';
 import { ValidationError } from '@/components/ui/validation-error';
 import { ThemePicker } from '@/components/ThemePicker';
 import { useCampaign, useCampaignMutations } from '@/hooks/useCampaigns';
+import { SOURCE_BOOKS, type SourceBookId } from '@/lib/source-books';
 import { useCampaignContext } from '@/hooks/useCampaignContext';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { useCharacters } from '@/hooks/useCharacters';
@@ -561,6 +564,52 @@ export default function CampaignDashboard() {
                 {updateMutation.isError && updateMutation.variables && 'theme' in updateMutation.variables && (
                   <p className="text-sm text-destructive mt-1">{t('errors.saveFailed')}</p>
                 )}
+              </CardContent>
+            </Card>
+          </div>
+
+          <div className="mt-4">
+            <Card className="hover-lift">
+              <CardContent className="p-4">
+                <div className="flex items-center gap-2 mb-3">
+                  <BookOpen className="size-5 text-muted-foreground" />
+                  <h3 className="font-semibold">{t('campaign.sourceBooks.title')}</h3>
+                </div>
+                <p className="text-sm text-muted-foreground mb-3">{t('campaign.sourceBooks.description')}</p>
+                <div className="space-y-2">
+                  {SOURCE_BOOKS.map((book) => {
+                    const allowed = campaign.allowed_source_books;
+                    const isChecked = allowed.includes(book.id);
+                    const isLastChecked = isChecked && allowed.length === 1;
+                    const bookId = `source-book-${book.id}`;
+                    return (
+                      <div key={book.id} className="flex items-center gap-2">
+                        <Checkbox
+                          id={bookId}
+                          checked={isChecked}
+                          disabled={isLastChecked || updateMutation.isPending}
+                          onCheckedChange={(checked) => {
+                            const nextList: SourceBookId[] = checked
+                              ? [...allowed, book.id]
+                              : allowed.filter((id) => id !== book.id);
+                            updateMutation.mutate({ id: campaign.id, allowed_source_books: nextList });
+                          }}
+                        />
+                        <Label htmlFor={bookId} className="cursor-pointer">
+                          {tg(`sourceBooks.${book.id}`)}
+                        </Label>
+                      </div>
+                    );
+                  })}
+                </div>
+                {campaign.allowed_source_books.length === 1 && (
+                  <p className="text-xs text-muted-foreground mt-2">{t('campaign.sourceBooks.lastBookWarning')}</p>
+                )}
+                {updateMutation.isError &&
+                  updateMutation.variables &&
+                  'allowed_source_books' in updateMutation.variables && (
+                    <p className="text-sm text-destructive mt-1">{t('errors.saveFailed')}</p>
+                  )}
               </CardContent>
             </Card>
           </div>


### PR DESCRIPTION
Closes #40

## Summary
DMs can toggle which source books are allowed per campaign, and the builder's selectors filter reference data accordingly — built on the #39 foundation. Since the app ships 2024 PHB only, filtering is functionally a no-op today, but the hook, settings UI, and no-data-loss wiring are complete and proven correct via a simulated second book.

## What Changed
- **`src/hooks/useGameData.ts`** (new) — `useGameData(campaignSlug)` reads the campaign's `allowed_source_books` (via the cached `useCampaign`) and returns the species/classes/backgrounds/feats/subclasses registries run through `filterBySourceBooks`.
- **`CampaignDashboard.tsx`** — a "Source Books" toggle card (checkbox per `SOURCE_BOOKS`, label via i18n, persists via the existing `update` mutation). Deselect-all guard: the last enabled book's checkbox is disabled.
- **Selector wiring + no-data-loss** — `BasicsStep` (species/class/background), plus `SubclassPicker`/`ChoicePicker` prop seams (fed from `ClassStep`/`OriginStep`). Each picker shows the filtered list **unioned with the character's current value**, so an already-selected option from a now-disabled book still displays (with the existing destructive-badge indicator) and can be kept — new picks can't select disabled content.

## Notes
- `CharacterSheet.tsx` needs no wiring — it has no species/class/background edit dialogs (class changes go through `LevelControls`).
- `SubclassSource` has no `sourceBook` field yet, so subclass filtering is wired but inert until that field is added.

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 2016 pass (useGameData filtering incl. a simulated non-PHB book; settings toggle + deselect-all guard; BasicsStep no-data-loss with a disabled current species)
- [x] `npm run lint` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)