### PR TITLE
feat(character): portrait upload UI

### DIFF
--- a/src/components/character-sheet/PortraitUpload.test.tsx
+++ b/src/components/character-sheet/PortraitUpload.test.tsx
@@ -1,0 +1,99 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { PortraitUpload } from '@/components/character-sheet/PortraitUpload';
+import type { UsePortraitUploadResult } from '@/hooks/usePortraitUpload';
+
+vi.mock('react-i18next', () => ({
+  useTranslation: (_ns?: string) => ({
+    t: (key: string) => {
+      const segments = key.split('.');
+      return segments[segments.length - 1];
+    },
+  }),
+}));
+
+// Mutable state shared across all test renders
+const mockHookState: UsePortraitUploadResult = {
+  upload: vi.fn().mockResolvedValue(undefined),
+  remove: vi.fn().mockResolvedValue(undefined),
+  isUploading: false,
+  isRemoving: false,
+  error: null,
+};
+
+vi.mock('@/hooks/usePortraitUpload', () => ({
+  usePortraitUpload: () => mockHookState,
+}));
+
+describe('PortraitUpload', () => {
+  const baseProps = {
+    characterId: 'char-1',
+    characterName: 'Aldric',
+    portraitUrl: null,
+  } as const;
+
+  beforeEach(() => {
+    vi.mocked(mockHookState.upload).mockClear();
+    vi.mocked(mockHookState.remove).mockClear();
+    mockHookState.isUploading = false;
+    mockHookState.isRemoving = false;
+    mockHookState.error = null;
+  });
+
+  it('renders initial placeholder with character name initial when no portrait', () => {
+    render(<PortraitUpload {...baseProps} />);
+    expect(screen.getByRole('button', { name: /upload/i })).toHaveTextContent('A');
+  });
+
+  it('renders an img element when portraitUrl is provided', () => {
+    render(<PortraitUpload {...baseProps} portraitUrl="https://example.com/portrait.jpg" />);
+    const img = screen.getByRole('img', { name: 'Aldric' });
+    expect(img).toBeInTheDocument();
+    expect(img).toHaveAttribute('src', expect.stringContaining('https://example.com/portrait.jpg'));
+  });
+
+  it('shows a remove button when portraitUrl is provided', () => {
+    render(<PortraitUpload {...baseProps} portraitUrl="https://example.com/portrait.jpg" />);
+    expect(screen.getByRole('button', { name: /remove/i })).toBeInTheDocument();
+  });
+
+  it('does not show a remove button when portraitUrl is null', () => {
+    render(<PortraitUpload {...baseProps} />);
+    expect(screen.queryByRole('button', { name: /remove/i })).not.toBeInTheDocument();
+  });
+
+  it('calls upload with the file and characterId when a valid image is selected', async () => {
+    render(<PortraitUpload {...baseProps} />);
+
+    const file = new File(['img'], 'portrait.png', { type: 'image/png' });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    await userEvent.upload(input, file);
+
+    expect(mockHookState.upload).toHaveBeenCalledWith(file, 'char-1');
+  });
+
+  it('does not call upload and shows error when a non-image file is selected', async () => {
+    render(<PortraitUpload {...baseProps} />);
+
+    const file = new File(['data'], 'doc.pdf', { type: 'application/pdf' });
+    const input = document.querySelector('input[type="file"]') as HTMLInputElement;
+    // Use fireEvent to bypass the `accept="image/*"` filter that userEvent enforces;
+    // we want the onChange handler to run so we can assert the guard inside it fires.
+    Object.defineProperty(input, 'files', { value: [file], writable: false });
+    fireEvent.change(input);
+
+    expect(mockHookState.upload).not.toHaveBeenCalled();
+    expect(screen.getByRole('alert')).toHaveTextContent('notAnImage');
+  });
+
+  it('replaces placeholder button with aria-busy spinner when isUploading is true', () => {
+    mockHookState.isUploading = true;
+
+    render(<PortraitUpload {...baseProps} />);
+
+    // The interactive placeholder button is replaced by a non-interactive div[aria-busy]
+    expect(screen.queryByRole('button', { name: /upload/i })).not.toBeInTheDocument();
+    expect(document.querySelector('[aria-busy="true"]')).toBeInTheDocument();
+  });
+});

--- a/src/components/character-sheet/PortraitUpload.tsx
+++ b/src/components/character-sheet/PortraitUpload.tsx
@@ -49,7 +49,7 @@ export function PortraitUpload({ characterId, portraitUrl, characterName }: Port
     try {
       await remove(characterId, portraitUrl);
     } catch {
-      setLocalError(t('portrait.errors.uploadFailed'));
+      setLocalError(t('portrait.errors.removeFailed'));
     }
   };
 

--- a/src/components/character-sheet/PortraitUpload.tsx
+++ b/src/components/character-sheet/PortraitUpload.tsx
@@ -1,0 +1,128 @@
+import * as React from 'react';
+import { useRef, useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { Loader2, X } from 'lucide-react';
+import { usePortraitUpload } from '@/hooks/usePortraitUpload';
+import { ValidationError } from '@/components/ui/validation-error';
+import { Button } from '@/components/ui/button';
+
+interface PortraitUploadProps {
+  characterId: string;
+  portraitUrl: string | null;
+  characterName: string;
+}
+
+export function PortraitUpload({ characterId, portraitUrl, characterName }: PortraitUploadProps): React.JSX.Element {
+  const { t } = useTranslation('common');
+  const { upload, remove, isUploading, isRemoving, error } = usePortraitUpload();
+  const [cacheBust, setCacheBust] = useState<number>(Date.now());
+  const [localError, setLocalError] = useState<string>('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const initial = characterName.charAt(0).toUpperCase();
+  const isWorking = isUploading || isRemoving;
+
+  const handleFileChange = async (e: React.ChangeEvent<HTMLInputElement>): Promise<void> => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+
+    if (!file.type.startsWith('image/')) {
+      setLocalError(t('portrait.errors.notAnImage'));
+      e.target.value = '';
+      return;
+    }
+
+    setLocalError('');
+
+    try {
+      await upload(file, characterId);
+      setCacheBust(Date.now());
+    } catch {
+      setLocalError(t('portrait.errors.uploadFailed'));
+    } finally {
+      e.target.value = '';
+    }
+  };
+
+  const handleRemove = async (): Promise<void> => {
+    setLocalError('');
+    try {
+      await remove(characterId, portraitUrl);
+    } catch {
+      setLocalError(t('portrait.errors.uploadFailed'));
+    }
+  };
+
+  const handleClick = (): void => {
+    if (!isWorking) {
+      fileInputRef.current?.click();
+    }
+  };
+
+  const displayError = localError || (error?.message ?? '');
+
+  return (
+    <div className="flex flex-col items-center gap-2">
+      {/* Hidden file input */}
+      <input
+        ref={fileInputRef}
+        type="file"
+        accept="image/*"
+        className="hidden"
+        onChange={handleFileChange}
+        aria-label={t('portrait.upload')}
+      />
+
+      {/* Portrait circle */}
+      <div className="relative">
+        {isWorking ? (
+          <div className="size-24 rounded-full bg-muted flex items-center justify-center" aria-busy="true">
+            <Loader2 className="size-8 animate-spin text-muted-foreground" />
+          </div>
+        ) : portraitUrl ? (
+          <button
+            type="button"
+            onClick={handleClick}
+            className="size-24 rounded-full overflow-hidden focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2"
+            title={t('portrait.change')}
+            aria-label={t('portrait.change')}
+          >
+            <img
+              src={`${portraitUrl}?v=${cacheBust}`}
+              alt={characterName}
+              className="size-24 rounded-full object-cover"
+            />
+          </button>
+        ) : (
+          <button
+            type="button"
+            onClick={handleClick}
+            className="size-24 rounded-full bg-muted flex items-center justify-center text-2xl font-bold text-muted-foreground focus:outline-none focus:ring-2 focus:ring-ring focus:ring-offset-2 hover:bg-muted/80 transition-colors"
+            title={t('portrait.upload')}
+            aria-label={t('portrait.upload')}
+          >
+            {initial}
+          </button>
+        )}
+
+        {/* Remove button — only shown when portrait exists and not working */}
+        {portraitUrl && !isWorking && (
+          <Button
+            variant="ghost"
+            size="icon"
+            className="absolute -top-1 -right-1 size-6 rounded-full bg-destructive text-destructive-foreground hover:bg-destructive/90 p-0"
+            onClick={handleRemove}
+            title={t('portrait.remove')}
+            aria-label={t('portrait.remove')}
+          >
+            <X className="size-3" />
+          </Button>
+        )}
+      </div>
+
+      {isUploading && <span className="text-xs text-muted-foreground">{t('portrait.uploading')}</span>}
+
+      {displayError && <ValidationError message={displayError} />}
+    </div>
+  );
+}

--- a/src/hooks/usePortraitUpload.test.ts
+++ b/src/hooks/usePortraitUpload.test.ts
@@ -47,7 +47,9 @@ describe('usePortraitUpload', () => {
         expect.objectContaining({ contentType: 'image/jpeg', upsert: true })
       );
       expect(bucketRef.getPublicUrl).toHaveBeenCalledWith(`${characterId}/portrait.jpg`);
-      expect(supabase.update).toHaveBeenCalled();
+      // The update mutation destructures { id, ...updates } — id goes to .eq(), updates go to .update()
+      expect(supabase.update).toHaveBeenCalledWith({ portrait_url: publicUrl });
+      expect(supabase.eq).toHaveBeenCalledWith('id', characterId);
       expect(result.current.error).toBeNull();
     });
 
@@ -84,7 +86,8 @@ describe('usePortraitUpload', () => {
 
       const bucketRef = supabase.storage.from('character-portraits');
       expect(bucketRef.remove).toHaveBeenCalledWith([`${characterId}/portrait.jpg`]);
-      expect(supabase.update).toHaveBeenCalled();
+      expect(supabase.update).toHaveBeenCalledWith({ portrait_url: null });
+      expect(supabase.eq).toHaveBeenCalledWith('id', characterId);
     });
 
     it('returns early without calling anything when currentPortraitUrl is null', async () => {

--- a/src/hooks/usePortraitUpload.test.ts
+++ b/src/hooks/usePortraitUpload.test.ts
@@ -1,0 +1,102 @@
+import { vi, describe, it, expect, beforeEach } from 'vitest';
+import { act, renderHook, waitFor } from '@testing-library/react';
+import { createWrapper } from '@/test/wrapper';
+import { supabase, mockQueryResult, mockStorageResult, setupMockReset } from '@/test/hook-test-helpers';
+import { usePortraitUpload } from '@/hooks/usePortraitUpload';
+
+vi.mock('@/lib/supabase', () => import('@/test/mocks/supabase'));
+vi.mock('@/lib/resize-image', () => ({
+  resizeImage: vi.fn().mockResolvedValue(new Blob(['img'], { type: 'image/jpeg' })),
+}));
+
+setupMockReset();
+
+// Helper: a fake image File
+function makeImageFile(name = 'portrait.png'): File {
+  return new File(['img'], name, { type: 'image/png' });
+}
+
+describe('usePortraitUpload', () => {
+  const characterId = 'char-1';
+  const publicUrl = 'https://example.com/char-1/portrait.jpg';
+
+  // Ensure the bucketRef spies are cleared between tests (setupMockReset handles storage.from,
+  // but we also clear bucketRef methods directly here for safety).
+  beforeEach(() => {
+    vi.mocked(supabase.storage.from).mockClear();
+  });
+
+  describe('upload', () => {
+    it('calls storage.upload with the correct path and upsert, then persists publicUrl', async () => {
+      mockStorageResult.error = null;
+      mockStorageResult.publicUrl = publicUrl;
+      // update mutation must succeed
+      mockQueryResult.data = { id: characterId, portrait_url: publicUrl };
+
+      const { result } = renderHook(() => usePortraitUpload(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.upload(makeImageFile(), characterId);
+      });
+
+      const bucketRef = supabase.storage.from('character-portraits');
+      expect(supabase.storage.from).toHaveBeenCalledWith('character-portraits');
+      expect(bucketRef.upload).toHaveBeenCalledWith(
+        `${characterId}/portrait.jpg`,
+        expect.any(Blob),
+        expect.objectContaining({ contentType: 'image/jpeg', upsert: true })
+      );
+      expect(bucketRef.getPublicUrl).toHaveBeenCalledWith(`${characterId}/portrait.jpg`);
+      expect(supabase.update).toHaveBeenCalled();
+      expect(result.current.error).toBeNull();
+    });
+
+    it('sets error state and does NOT call update when storage upload fails', async () => {
+      mockStorageResult.error = { message: 'Storage error' };
+
+      const { result } = renderHook(() => usePortraitUpload(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        try {
+          await result.current.upload(makeImageFile(), characterId);
+        } catch {
+          // expected
+        }
+      });
+
+      expect(result.current.error).toBeInstanceOf(Error);
+      expect(supabase.update).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('remove', () => {
+    it('calls storage.remove with the correct path and sets portrait_url to null', async () => {
+      mockStorageResult.error = null;
+      mockQueryResult.data = { id: characterId, portrait_url: null };
+
+      const { result } = renderHook(() => usePortraitUpload(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.remove(characterId, 'https://example.com/old.jpg');
+      });
+
+      await waitFor(() => expect(result.current.isRemoving).toBe(false));
+
+      const bucketRef = supabase.storage.from('character-portraits');
+      expect(bucketRef.remove).toHaveBeenCalledWith([`${characterId}/portrait.jpg`]);
+      expect(supabase.update).toHaveBeenCalled();
+    });
+
+    it('returns early without calling anything when currentPortraitUrl is null', async () => {
+      const { result } = renderHook(() => usePortraitUpload(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        await result.current.remove(characterId, null);
+      });
+
+      const bucketRef = supabase.storage.from('character-portraits');
+      expect(bucketRef.remove).not.toHaveBeenCalled();
+      expect(supabase.update).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/hooks/usePortraitUpload.test.ts
+++ b/src/hooks/usePortraitUpload.test.ts
@@ -69,6 +69,35 @@ describe('usePortraitUpload', () => {
       expect(result.current.error).toBeInstanceOf(Error);
       expect(supabase.update).not.toHaveBeenCalled();
     });
+
+    it('surfaces error and leaves the uploaded file when the DB update fails after a successful storage upload', async () => {
+      mockStorageResult.error = null;
+      mockStorageResult.publicUrl = publicUrl;
+      mockQueryResult.error = { message: 'DB update failed' };
+
+      const { result } = renderHook(() => usePortraitUpload(), { wrapper: createWrapper() });
+
+      const bucketRef = supabase.storage.from('character-portraits');
+
+      await act(async () => {
+        try {
+          await result.current.upload(makeImageFile(), characterId);
+        } catch {
+          // expected — DB update throws, hook re-throws
+        }
+      });
+
+      // Storage upload was called (storage succeeded)
+      expect(bucketRef.upload).toHaveBeenCalled();
+      // DB update was also called (distinguishes this from storage-failure case)
+      expect(supabase.update).toHaveBeenCalledWith({ portrait_url: publicUrl });
+      // Hook surfaces the error
+      expect(result.current.error).toBeInstanceOf(Error);
+      // Storage remove was NOT called — orphan file is a deliberate trade-off
+      expect(bucketRef.remove).not.toHaveBeenCalled();
+      // isUploading resets to false after failure
+      expect(result.current.isUploading).toBe(false);
+    });
   });
 
   describe('remove', () => {
@@ -100,6 +129,22 @@ describe('usePortraitUpload', () => {
       const bucketRef = supabase.storage.from('character-portraits');
       expect(bucketRef.remove).not.toHaveBeenCalled();
       expect(supabase.update).not.toHaveBeenCalled();
+    });
+
+    it('still nulls portrait_url in the DB when storage.remove fails', async () => {
+      mockStorageResult.error = { message: 'remove failed' };
+      mockQueryResult.data = { id: characterId, portrait_url: null };
+
+      const { result } = renderHook(() => usePortraitUpload(), { wrapper: createWrapper() });
+
+      await act(async () => {
+        // Should NOT reject — storage errors are swallowed, DB update still proceeds
+        await result.current.remove(characterId, 'https://example.com/portrait.jpg');
+      });
+
+      // DB update is still called with portrait_url: null despite storage failure
+      expect(supabase.update).toHaveBeenCalledWith({ portrait_url: null });
+      expect(supabase.eq).toHaveBeenCalledWith('id', characterId);
     });
   });
 });

--- a/src/hooks/usePortraitUpload.ts
+++ b/src/hooks/usePortraitUpload.ts
@@ -2,6 +2,9 @@ import { useState } from 'react';
 import { supabase } from '@/lib/supabase';
 import { resizeImage } from '@/lib/resize-image';
 import { useCharacterMutations } from '@/hooks/useCharacters';
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('portrait');
 
 const BUCKET = 'character-portraits';
 
@@ -59,8 +62,8 @@ export function usePortraitUpload(): UsePortraitUploadResult {
       const path = portraitPath(characterId);
       const { error: storageError } = await supabase.storage.from(BUCKET).remove([path]);
       if (storageError) {
-        console.error('Failed to remove portrait from storage:', storageError);
         // Log but don't throw — the DB update (portrait_url → null) should still proceed
+        logger.warn('Failed to remove portrait from storage:', storageError);
       }
 
       await update.mutateAsync({ id: characterId, portrait_url: null });

--- a/src/hooks/usePortraitUpload.ts
+++ b/src/hooks/usePortraitUpload.ts
@@ -1,0 +1,76 @@
+import { useState } from 'react';
+import { supabase } from '@/lib/supabase';
+import { resizeImage } from '@/lib/resize-image';
+import { useCharacterMutations } from '@/hooks/useCharacters';
+
+const BUCKET = 'character-portraits';
+
+function portraitPath(characterId: string): string {
+  return `${characterId}/portrait.jpg`;
+}
+
+export interface UsePortraitUploadResult {
+  upload: (file: File, characterId: string) => Promise<void>;
+  remove: (characterId: string, currentPortraitUrl: string | null) => Promise<void>;
+  isUploading: boolean;
+  isRemoving: boolean;
+  error: Error | null;
+}
+
+export function usePortraitUpload(): UsePortraitUploadResult {
+  const [isUploading, setIsUploading] = useState<boolean>(false);
+  const [isRemoving, setIsRemoving] = useState<boolean>(false);
+  const [error, setError] = useState<Error | null>(null);
+
+  const { update } = useCharacterMutations();
+
+  const upload = async (file: File, characterId: string): Promise<void> => {
+    setIsUploading(true);
+    setError(null);
+    try {
+      const blob = await resizeImage(file, 512);
+      const path = portraitPath(characterId);
+
+      const { error: storageError } = await supabase.storage
+        .from(BUCKET)
+        .upload(path, blob, { contentType: 'image/jpeg', upsert: true });
+
+      if (storageError) throw storageError;
+
+      const {
+        data: { publicUrl },
+      } = supabase.storage.from(BUCKET).getPublicUrl(path);
+
+      await update.mutateAsync({ id: characterId, portrait_url: publicUrl });
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      setIsUploading(false);
+    }
+  };
+
+  const remove = async (characterId: string, currentPortraitUrl: string | null): Promise<void> => {
+    if (!currentPortraitUrl) return;
+
+    setIsRemoving(true);
+    setError(null);
+    try {
+      const path = portraitPath(characterId);
+      const { error: storageError } = await supabase.storage.from(BUCKET).remove([path]);
+      if (storageError) {
+        console.error('Failed to remove portrait from storage:', storageError);
+        // Log but don't throw — the DB update (portrait_url → null) should still proceed
+      }
+
+      await update.mutateAsync({ id: characterId, portrait_url: null });
+    } catch (err) {
+      setError(err instanceof Error ? err : new Error(String(err)));
+      throw err;
+    } finally {
+      setIsRemoving(false);
+    }
+  };
+
+  return { upload, remove, isUploading, isRemoving, error };
+}

--- a/src/lib/query-columns.test.ts
+++ b/src/lib/query-columns.test.ts
@@ -14,6 +14,10 @@ describe('CHARACTER_SUMMARY_COLS', () => {
   it('does not contain race (word boundary match)', () => {
     expect(CHARACTER_SUMMARY_COLS).not.toMatch(/\brace\b/);
   });
+
+  it('contains portrait_url for list thumbnails (word boundary match)', () => {
+    expect(CHARACTER_SUMMARY_COLS).toMatch(/\bportrait_url\b/);
+  });
 });
 
 describe('CHARACTER_DETAIL_COLS', () => {

--- a/src/lib/query-columns.ts
+++ b/src/lib/query-columns.ts
@@ -4,7 +4,7 @@ export const CAMPAIGN_DETAIL_COLS =
   'id, slug, previous_slugs, name, description, setting, status, image_url, dm_notes, theme, created_at, updated_at, archived_at, allowed_source_books' as const;
 
 export const CHARACTER_SUMMARY_COLS =
-  'id, slug, previous_slugs, campaign_id, name, player_name, character_type, species, class, subclass, level, hit_points_max, armor_class, updated_at' as const;
+  'id, slug, previous_slugs, campaign_id, name, player_name, character_type, species, class, subclass, level, hit_points_max, armor_class, portrait_url, updated_at' as const;
 export const CHARACTER_DETAIL_COLS =
   'id, slug, previous_slugs, campaign_id, name, player_name, character_type, species, class, subclass, background, alignment, gender, size, age, height, weight, eye_color, hair_color, skin_color, level, hit_points_max, armor_class, speed, proficiency_bonus, heroic_inspiration, exhaustion_level, conditions, hit_dice_used, spell_slots_used, personality_traits, ideals, bonds, flaws, appearance, backstory, notes, portrait_url, is_active, status, created_at, updated_at' as const;
 

--- a/src/lib/resize-image.test.ts
+++ b/src/lib/resize-image.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { resizeImage } from '@/lib/resize-image';
+
+// NOTE: jsdom does not implement canvas.toBlob, so pixel-math / scaling behavior
+// cannot be unit-tested here. These tests cover only the guard path (non-image rejection).
+// The full resize pipeline is exercised indirectly via the usePortraitUpload hook tests,
+// where resizeImage is mocked out.
+
+describe('resizeImage', () => {
+  it('rejects when the file is not an image', async () => {
+    const file = new File(['hello'], 'test.txt', { type: 'text/plain' });
+    await expect(resizeImage(file, 512)).rejects.toThrow('Expected an image file but received type "text/plain"');
+  });
+
+  it('rejects for an empty MIME type', async () => {
+    const file = new File(['data'], 'no-type', { type: '' });
+    await expect(resizeImage(file, 512)).rejects.toThrow('Expected an image file');
+  });
+});

--- a/src/lib/resize-image.ts
+++ b/src/lib/resize-image.ts
@@ -1,0 +1,60 @@
+/**
+ * Resizes an image file to fit within a square of `maxDim × maxDim` pixels,
+ * preserving aspect ratio. Output is always JPEG at 85% quality.
+ *
+ * Only the guard (non-image rejection) is unit-tested here; the canvas pixel
+ * math cannot be exercised in jsdom (toBlob is unimplemented).
+ */
+export async function resizeImage(file: File, maxDim: number): Promise<Blob> {
+  if (!file.type.startsWith('image/')) {
+    return Promise.reject(new Error(`Expected an image file but received type "${file.type}"`));
+  }
+
+  return new Promise<Blob>((resolve, reject) => {
+    const reader = new FileReader();
+
+    reader.onerror = () => reject(new Error('Failed to read file'));
+
+    reader.onload = (readerEvent) => {
+      const img = new Image();
+
+      img.onerror = () => reject(new Error('Failed to decode image'));
+
+      img.onload = () => {
+        const { width, height } = img;
+        const longestEdge = Math.max(width, height);
+        const scale = longestEdge > maxDim ? maxDim / longestEdge : 1;
+        const targetWidth = Math.round(width * scale);
+        const targetHeight = Math.round(height * scale);
+
+        const canvas = document.createElement('canvas');
+        canvas.width = targetWidth;
+        canvas.height = targetHeight;
+
+        const ctx = canvas.getContext('2d');
+        if (!ctx) {
+          reject(new Error('Could not obtain 2D canvas context'));
+          return;
+        }
+
+        ctx.drawImage(img, 0, 0, targetWidth, targetHeight);
+
+        canvas.toBlob(
+          (blob) => {
+            if (!blob) {
+              reject(new Error('canvas.toBlob produced null'));
+              return;
+            }
+            resolve(blob);
+          },
+          'image/jpeg',
+          0.85
+        );
+      };
+
+      img.src = readerEvent.target?.result as string;
+    };
+
+    reader.readAsDataURL(file);
+  });
+}

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -841,7 +841,8 @@
     "uploading": "Uploading...",
     "errors": {
       "notAnImage": "Please select an image file (JPEG, PNG, or WebP)",
-      "uploadFailed": "Portrait upload failed — please try again"
+      "uploadFailed": "Portrait upload failed — please try again",
+      "removeFailed": "Failed to remove portrait — please try again"
     }
   },
   "validation": {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -834,6 +834,16 @@
     "noDate": "No date",
     "selectCampaignFirst": "{{label}} (select a campaign first)"
   },
+  "portrait": {
+    "upload": "Upload portrait",
+    "change": "Change portrait",
+    "remove": "Remove portrait",
+    "uploading": "Uploading...",
+    "errors": {
+      "notAnImage": "Please select an image file (JPEG, PNG, or WebP)",
+      "uploadFailed": "Portrait upload failed — please try again"
+    }
+  },
   "validation": {
     "nameRequired": "Name is required",
     "titleRequired": "Title is required",

--- a/src/pages/CharacterList.tsx
+++ b/src/pages/CharacterList.tsx
@@ -198,13 +198,26 @@ export default function CharacterList() {
                 }`}
               >
                 <div className="flex items-start justify-between mb-4">
-                  <div>
-                    <h3 className="text-xl font-bold text-foreground mb-1">{character.name}</h3>
-                    {character.player_name && (
-                      <p className="text-sm text-muted-foreground">
-                        {t('characterList.player', { name: character.player_name })}
-                      </p>
+                  <div className="flex items-center gap-3">
+                    {character.portrait_url ? (
+                      <img
+                        src={character.portrait_url}
+                        alt={character.name}
+                        className="size-12 rounded-full object-cover shrink-0"
+                      />
+                    ) : (
+                      <div className="size-12 rounded-full bg-muted flex items-center justify-center text-lg font-bold text-muted-foreground shrink-0">
+                        {character.name.charAt(0).toUpperCase()}
+                      </div>
                     )}
+                    <div>
+                      <h3 className="text-xl font-bold text-foreground mb-1">{character.name}</h3>
+                      {character.player_name && (
+                        <p className="text-sm text-muted-foreground">
+                          {t('characterList.player', { name: character.player_name })}
+                        </p>
+                      )}
+                    </div>
                   </div>
                   <span
                     className={`px-3 py-1 rounded-full text-xs font-semibold uppercase ${

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -17,6 +17,7 @@ import { PendingChoicesPanel } from '@/components/character-sheet/PendingChoices
 import { ProficienciesPanel } from '@/components/character-sheet/ProficienciesPanel';
 import { ResourcePoolsPanel } from '@/components/character-sheet/ResourcePoolsPanel';
 import { SkillsPanel } from '@/components/character-sheet/SkillsPanel';
+import { PortraitUpload } from '@/components/character-sheet/PortraitUpload';
 import { buildRestUpdate } from '@/lib/rest';
 import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
 import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
@@ -281,9 +282,16 @@ function CharacterSheetInner({
         {/* Header */}
         <div className="bg-card border rounded-lg p-6 mb-6">
           <div className="flex items-start justify-between mb-4">
-            <div>
-              <div className="text-sm text-muted-foreground mb-1">{tc('characterSheet.title')}</div>
-              <h1 className="hidden md:block text-3xl font-bold text-foreground">{character.name}</h1>
+            <div className="flex items-start gap-4">
+              <PortraitUpload
+                characterId={character.id}
+                portraitUrl={character.portrait_url}
+                characterName={character.name}
+              />
+              <div>
+                <div className="text-sm text-muted-foreground mb-1">{tc('characterSheet.title')}</div>
+                <h1 className="hidden md:block text-3xl font-bold text-foreground">{character.name}</h1>
+              </div>
             </div>
             <div className="flex items-center gap-1">
               <Button

--- a/src/test/hook-test-helpers.ts
+++ b/src/test/hook-test-helpers.ts
@@ -1,6 +1,6 @@
 import { renderHook, waitFor } from '@testing-library/react';
 import { createWrapper } from '@/test/wrapper';
-import { supabase, mockQueryResult } from '@/test/mocks/supabase';
+import { supabase, mockQueryResult, mockStorageResult } from '@/test/mocks/supabase';
 
 // Minimal shape of result.current that all hook results share.
 interface QueryResult {
@@ -32,10 +32,31 @@ export function setupMockReset(): void {
   beforeEach(() => {
     mockQueryResult.data = null;
     mockQueryResult.error = null;
+    mockStorageResult.data = null;
+    mockStorageResult.error = null;
+    mockStorageResult.publicUrl = '';
     for (const key of Object.keys(supabase)) {
       const fn = supabase[key as keyof typeof supabase];
       if (typeof fn === 'function' && 'mockClear' in fn) {
         vi.mocked(fn as ReturnType<typeof vi.fn>).mockClear();
+      }
+    }
+    // Clear storage spies
+    const { storage } = supabase;
+    if (storage) {
+      for (const key of Object.keys(storage)) {
+        const fn = storage[key as keyof typeof storage];
+        if (typeof fn === 'function' && 'mockClear' in fn) {
+          vi.mocked(fn as ReturnType<typeof vi.fn>).mockClear();
+        }
+      }
+      // Clear bucket ref spies via storage.from()
+      const bucketRef = storage.from('character-portraits');
+      for (const key of Object.keys(bucketRef)) {
+        const fn = bucketRef[key as keyof typeof bucketRef];
+        if (typeof fn === 'function' && 'mockClear' in fn) {
+          vi.mocked(fn as ReturnType<typeof vi.fn>).mockClear();
+        }
       }
     }
   });
@@ -269,4 +290,4 @@ export async function withSuppressedRejections(fn: () => Promise<void>): Promise
 }
 
 // Re-export commonly needed test utilities so files only need one import line.
-export { renderHook, waitFor, createWrapper, supabase, mockQueryResult };
+export { renderHook, waitFor, createWrapper, supabase, mockQueryResult, mockStorageResult };

--- a/src/test/mocks/supabase-factory.ts
+++ b/src/test/mocks/supabase-factory.ts
@@ -34,17 +34,57 @@ type MockBuilder = Record<MethodName, (...args: unknown[]) => MockBuilder> & {
 };
 
 export interface SupabaseMockResult {
-  supabase: MockBuilder;
+  supabase: MockBuilder & { storage: MockStorage };
   mockQueryResult: { data: unknown; error: unknown };
+  mockStorageResult: { data: unknown; error: unknown; publicUrl: string };
+}
+
+export interface MockBucketRef {
+  upload: (...args: unknown[]) => Promise<{ data: unknown; error: unknown }>;
+  remove: (...args: unknown[]) => Promise<{ data: unknown; error: unknown }>;
+  getPublicUrl: (...args: unknown[]) => { data: { publicUrl: string } };
+}
+
+export interface MockStorage {
+  from: (...args: unknown[]) => MockBucketRef;
 }
 
 export function createSupabaseMock(spyWrap: SpyWrap = (fn) => fn): SupabaseMockResult {
   const mockQueryResult: { data: unknown; error: unknown } = { data: null, error: null };
-  const builder = {} as MockBuilder;
+  const mockStorageResult: { data: unknown; error: unknown; publicUrl: string } = {
+    data: null,
+    error: null,
+    publicUrl: '',
+  };
+
+  const builder = {} as MockBuilder & { storage: MockStorage };
   const self = () => builder;
   for (const m of METHODS) {
     builder[m] = spyWrap(self) as MockBuilder[typeof m];
   }
   builder.then = (resolve, reject) => Promise.resolve({ ...mockQueryResult }).then(resolve, reject);
-  return { supabase: builder, mockQueryResult };
+
+  // Stable bucket reference — storage.from() always returns the same bucketRef object
+  // so that spy assertions can be made on the same references across multiple calls.
+  const bucketRef: MockBucketRef = {
+    upload: spyWrap(async () => ({
+      data: mockStorageResult.data,
+      error: mockStorageResult.error,
+    })) as MockBucketRef['upload'],
+    remove: spyWrap(async () => ({
+      data: mockStorageResult.data,
+      error: mockStorageResult.error,
+    })) as MockBucketRef['remove'],
+    getPublicUrl: spyWrap(() => ({
+      data: { publicUrl: mockStorageResult.publicUrl },
+    })) as MockBucketRef['getPublicUrl'],
+  };
+
+  const storage: MockStorage = {
+    from: spyWrap(() => bucketRef) as MockStorage['from'],
+  };
+
+  builder.storage = storage;
+
+  return { supabase: builder, mockQueryResult, mockStorageResult };
 }

--- a/src/test/mocks/supabase.ts
+++ b/src/test/mocks/supabase.ts
@@ -3,4 +3,4 @@ import { createSupabaseMock } from '@/test/mocks/supabase-factory';
 
 const mock = createSupabaseMock(((fn) => vi.fn(fn as never)) as Parameters<typeof createSupabaseMock>[0]);
 
-export const { supabase, mockQueryResult } = mock;
+export const { supabase, mockQueryResult, mockStorageResult } = mock;

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -176,6 +176,7 @@ export type CharacterSummary = Pick<
   | 'level'
   | 'hit_points_max'
   | 'armor_class'
+  | 'portrait_url'
   | 'updated_at'
 >;
 export type SessionSummary = Pick<

--- a/supabase/migrations/20260606000000_add_portrait_storage.sql
+++ b/supabase/migrations/20260606000000_add_portrait_storage.sql
@@ -17,21 +17,25 @@ on conflict (id) do nothing;
 -- current no-auth development state, but MUST be tightened when authentication lands:
 -- replace the permissive policies with user-scoped ones (e.g. auth.uid() = owner).
 
+drop policy if exists "character-portraits: public select" on storage.objects;
 create policy "character-portraits: public select"
   on storage.objects
   for select
   using (bucket_id = 'character-portraits');
 
+drop policy if exists "character-portraits: public insert" on storage.objects;
 create policy "character-portraits: public insert"
   on storage.objects
   for insert
   with check (bucket_id = 'character-portraits');
 
+drop policy if exists "character-portraits: public update" on storage.objects;
 create policy "character-portraits: public update"
   on storage.objects
   for update
   using (bucket_id = 'character-portraits');
 
+drop policy if exists "character-portraits: public delete" on storage.objects;
 create policy "character-portraits: public delete"
   on storage.objects
   for delete

--- a/supabase/migrations/20260606000000_add_portrait_storage.sql
+++ b/supabase/migrations/20260606000000_add_portrait_storage.sql
@@ -1,0 +1,38 @@
+-- Create the character-portraits storage bucket.
+-- This is a PUBLIC bucket (unauthenticated reads allowed) for character portrait images.
+-- File size limit: 1 MB. Accepted MIME types: JPEG, PNG, WebP.
+insert into storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+values (
+  'character-portraits',
+  'character-portraits',
+  true,
+  1048576,
+  array['image/jpeg', 'image/png', 'image/webp']
+)
+on conflict (id) do nothing;
+
+-- RLS policies for storage.objects scoped to the character-portraits bucket.
+-- WARNING: These policies are intentionally PERMISSIVE — they allow any anonymous
+-- user to read, upload, update, and delete portraits. This is acceptable for the
+-- current no-auth development state, but MUST be tightened when authentication lands:
+-- replace the permissive policies with user-scoped ones (e.g. auth.uid() = owner).
+
+create policy "character-portraits: public select"
+  on storage.objects
+  for select
+  using (bucket_id = 'character-portraits');
+
+create policy "character-portraits: public insert"
+  on storage.objects
+  for insert
+  with check (bucket_id = 'character-portraits');
+
+create policy "character-portraits: public update"
+  on storage.objects
+  for update
+  using (bucket_id = 'character-portraits');
+
+create policy "character-portraits: public delete"
+  on storage.objects
+  for delete
+  using (bucket_id = 'character-portraits');


### PR DESCRIPTION
Closes #48

## Summary
Upload, display, and remove character portraits (the `portrait_url` column already existed with no UI). Portraits are resized client-side, stored in a Supabase Storage bucket, and shown on the character sheet header + character list cards.

## ⚠️ Security caveat (please review before deploy)
The migration creates a **public** `character-portraits` bucket with **fully permissive** RLS policies (any anonymous user can read/insert/update/delete) — this is intentional for the app's current **no-auth** state and is flagged with a TODO in the migration SQL. **Replace these with `auth.uid()`-scoped policies when authentication lands.** The bucket must be created on deploy (no live DB in this run to apply the migration).

## What Changed
- **Migration** `…_add_portrait_storage.sql` — public bucket (1 MB limit; jpeg/png/webp) + 4 permissive storage.objects policies (commented as auth-pending).
- **`src/lib/resize-image.ts`** — thin canvas resize (longest edge → 512px, jpeg@0.85).
- **`src/hooks/usePortraitUpload.ts`** — `upload`/`remove` (resize → storage upsert at `${characterId}/portrait.jpg` → getPublicUrl → persist via the existing `update` mutation; remove is storage-delete-tolerant). Returns `isUploading`/`isRemoving`/`error`.
- **`PortraitUpload.tsx`** — placeholder-initials vs `<img>` (cache-busted on re-upload), file picker, remove, spinner, non-image guard.
- **Display** — sheet header slot + list-card thumbnail; `CHARACTER_SUMMARY_COLS` + `CharacterSummary` extended with `portrait_url` for the list.
- **Test mock** — extended the Supabase mock with a `storage` stub (`mockStorageResult`).

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 2040 pass (hook: upload/error/remove/null; component: placeholder/img/upload-trigger/disabled; resize guards)
- [x] `npm run lint` clean

Note: jsdom lacks canvas, so `resizeImage`'s pixel math isn't unit-tested — it's mocked in the hook tests; only its input guard is covered.

🤖 Generated with [Claude Code](https://claude.com/claude-code)