### PR TITLE
refactor(character-sheet): decompose into panels + WotC-inspired grid (#45)

### DIFF
--- a/src/components/character-sheet/AbilityScoresPanel.tsx
+++ b/src/components/character-sheet/AbilityScoresPanel.tsx
@@ -1,0 +1,50 @@
+import type { ResolvedCharacter } from '@/types/resolved';
+import { useTranslation } from 'react-i18next';
+
+export function AbilityScoresPanel({
+  abilities,
+  buildError,
+}: {
+  abilities: ResolvedCharacter['abilities'] | undefined;
+  buildError: string | null;
+}) {
+  const { t } = useTranslation('gamedata');
+  const { t: tc } = useTranslation('common');
+
+  if (!abilities) {
+    return (
+      <div className="sheet-panel text-center text-muted-foreground">
+        <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.abilities')}</h2>
+        <p>
+          {buildError
+            ? tc('characterSheet.buildError.abilities', { message: buildError })
+            : tc('characterSheet.emptyState.abilities')}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="sheet-panel">
+      <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.abilities')}</h2>
+      <div className="grid grid-cols-2 gap-3 sm:grid-cols-3 lg:grid-cols-2">
+        {(Object.keys(abilities) as Array<keyof typeof abilities>).map((ability) => {
+          const resolvedAbility = abilities[ability];
+          const modifier = resolvedAbility.modifier;
+          return (
+            <div key={ability} className="ability-shield">
+              <div className="text-xs uppercase tracking-wide text-muted-foreground">{t(`abilities.${ability}`)}</div>
+              <div className={`text-3xl font-bold leading-tight ${modifier >= 0 ? 'text-green-600' : 'text-red-600'}`}>
+                {modifier >= 0 ? '+' : ''}
+                {modifier}
+              </div>
+              <div className="mt-1 rounded-full border bg-card px-2 text-sm font-bold text-foreground">
+                {resolvedAbility.total}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/character-sheet/BackstoryPanel.tsx
+++ b/src/components/character-sheet/BackstoryPanel.tsx
@@ -1,0 +1,33 @@
+import { SectionHeader } from '@/components/character-sheet/SectionHeader';
+import type { Character } from '@/types/database';
+import { useTranslation } from 'react-i18next';
+
+export function BackstoryPanel({
+  character,
+  onEditBackstory,
+  onEditAppearance,
+}: {
+  character: Character;
+  onEditBackstory: () => void;
+  onEditAppearance: () => void;
+}) {
+  const { t: tc } = useTranslation('common');
+
+  return (
+    <>
+      {character.backstory && (
+        <div className="sheet-panel">
+          <SectionHeader title={tc('characterSheet.sections.backstory')} onEdit={onEditBackstory} />
+          <p className="text-foreground text-sm leading-relaxed whitespace-pre-wrap">{character.backstory}</p>
+        </div>
+      )}
+
+      {character.appearance && (
+        <div className="sheet-panel mt-6">
+          <SectionHeader title={tc('characterSheet.sections.appearance')} onEdit={onEditAppearance} />
+          <p className="text-foreground text-sm leading-relaxed whitespace-pre-wrap">{character.appearance}</p>
+        </div>
+      )}
+    </>
+  );
+}

--- a/src/components/character-sheet/CharacterSheetHeader.tsx
+++ b/src/components/character-sheet/CharacterSheetHeader.tsx
@@ -1,0 +1,171 @@
+import { Button } from '@/components/ui/button';
+import { PortraitUpload } from '@/components/character-sheet/PortraitUpload';
+import { LevelControls } from '@/components/character-sheet/LevelControls';
+import { useCharacterContext } from '@/hooks/useCharacterContext';
+import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
+import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
+import { DND_CLASSES, isBackgroundId, type ClassId } from '@/lib/dnd-helpers';
+import type { Character } from '@/types/database';
+import { Archive, Copy, Edit2, Trash2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export function CharacterSheetHeader({
+  character,
+  onEdit,
+  onClone,
+  onArchive,
+  onDelete,
+}: {
+  character: Character;
+  onEdit: () => void;
+  onClone: () => void;
+  onArchive: () => void;
+  onDelete: () => void;
+}) {
+  const { t } = useTranslation('gamedata');
+  const { t: tc } = useTranslation('common');
+  const { build, level: resolvedLevel } = useCharacterContext();
+
+  const alignmentName = character.alignment
+    ? t(`alignments.${character.alignment}`, { defaultValue: character.alignment })
+    : '';
+
+  // Lineage: find the lineage-choice decision made during character creation,
+  // scoped to the current species so stale entries from a prior species are ignored.
+  const lineageId: string | null = (() => {
+    if (!build || !character.species) return null;
+    const prefix = `lineage-choice:species:${character.species}:`;
+    const entry = Object.entries(build.choices).find(([key]) => key.startsWith(prefix));
+    if (!entry) return null;
+    const decision = entry[1];
+    return decision.type === 'lineage-choice' ? decision.lineageId : null;
+  })();
+
+  // Origin feat: derive badge info from the background source's grants.
+  // deriveOriginFeatInfo handles both shapes (feat grant and direct feat-magic-initiate-* feature).
+  const originFeatInfo = (() => {
+    if (!character.background || !isBackgroundId(character.background)) return null;
+    const bg = BACKGROUND_SOURCES.find((s) => s.id === character.background);
+    if (!bg) return null;
+    return deriveOriginFeatInfo(bg.grants);
+  })();
+
+  return (
+    <div className="bg-card border rounded-lg p-6 mb-6">
+      <div className="flex items-start justify-between mb-4">
+        <div className="flex items-start gap-4">
+          <PortraitUpload
+            characterId={character.id}
+            portraitUrl={character.portrait_url}
+            characterName={character.name}
+          />
+          <div>
+            <div className="text-sm text-muted-foreground mb-1">{tc('characterSheet.title')}</div>
+            <h1 className="hidden md:block text-3xl font-bold text-foreground">{character.name}</h1>
+          </div>
+        </div>
+        <div className="flex items-center gap-1">
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onEdit}
+            title={tc('characterSheet.dialogs.editCharacterInfo')}
+          >
+            <Edit2 size={16} />
+          </Button>
+          <Button variant="ghost" size="icon-sm" onClick={onClone} title={tc('buttons.clone')}>
+            <Copy size={16} />
+          </Button>
+          <Button variant="ghost" size="icon-sm" onClick={onArchive} title={tc('buttons.archive')}>
+            <Archive size={16} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon-sm"
+            onClick={onDelete}
+            title={tc('buttons.delete')}
+            className="text-destructive hover:text-destructive"
+          >
+            <Trash2 size={16} />
+          </Button>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
+        <div>
+          <span className="text-muted-foreground">{tc('characterSheet.fields.class')}</span>
+          <p className="text-foreground font-semibold">
+            {character.class ? t(`classes.${character.class}`, { defaultValue: character.class }) : ''}
+            {character.subclass
+              ? ` (${t(`subclasses.${character.subclass}.name`, { defaultValue: character.subclass })})`
+              : ''}
+          </p>
+        </div>
+        <div>
+          <span className="text-muted-foreground">{tc('characterSheet.fields.level')}</span>
+          <p className="text-foreground font-semibold">{resolvedLevel}</p>
+        </div>
+        <div>
+          <span className="text-muted-foreground">{tc('characterSheet.fields.species')}</span>
+          <p className="text-foreground font-semibold">
+            {character.species ? t(`species.${character.species}`, { defaultValue: character.species }) : ''}
+          </p>
+          {lineageId && character.species && (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {t(`lineages.${character.species}.${lineageId}`, { defaultValue: lineageId })}
+            </p>
+          )}
+        </div>
+        <div>
+          <span className="text-muted-foreground">{tc('characterSheet.fields.background')}</span>
+          <p className="text-foreground font-semibold">
+            {character.background
+              ? isBackgroundId(character.background)
+                ? t(`backgrounds.${character.background}`)
+                : character.background
+              : ''}
+          </p>
+          {originFeatInfo && (
+            <p className="text-xs text-muted-foreground mt-0.5">
+              {originFeatInfo.namespace === 'features'
+                ? t(`features.${originFeatInfo.id}.name` as `features.${string}.name`, {
+                    defaultValue: originFeatInfo.id,
+                  })
+                : t(`feats.${originFeatInfo.id}.name` as `feats.${string}.name`, {
+                    defaultValue: originFeatInfo.id,
+                  })}
+            </p>
+          )}
+        </div>
+        <div>
+          <span className="text-muted-foreground">{tc('characterSheet.fields.alignment')}</span>
+          <p className="text-foreground font-semibold">{alignmentName}</p>
+        </div>
+        {character.player_name && (
+          <div>
+            <span className="text-muted-foreground">{tc('characterSheet.fields.player')}</span>
+            <p className="text-foreground font-semibold">{character.player_name}</p>
+          </div>
+        )}
+        <div>
+          <span className="text-muted-foreground">{tc('characterSheet.fields.type')}</span>
+          <p className="text-foreground font-semibold uppercase">{tc(`characterType.${character.character_type}`)}</p>
+        </div>
+        {character.gender && (
+          <div>
+            <span className="text-muted-foreground">{tc('characterSheet.fields.gender')}</span>
+            <p className="text-foreground font-semibold">
+              {t(`gender.${character.gender}`, { defaultValue: character.gender })}
+            </p>
+          </div>
+        )}
+      </div>
+
+      {character.class && DND_CLASSES.some((c) => c.id === character.class) && (
+        <div className="mt-4 pt-4 border-t">
+          <LevelControls classId={character.class as ClassId} />
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/components/character-sheet/CombatPanel.tsx
+++ b/src/components/character-sheet/CombatPanel.tsx
@@ -1,0 +1,75 @@
+import type { ResolvedCharacter } from '@/types/resolved';
+import { useTranslation } from 'react-i18next';
+
+export function CombatPanel({
+  resolved,
+  abilities,
+  armorClass,
+  speedValue,
+  maxHP,
+  profBonus,
+  isStale,
+  buildError,
+}: {
+  resolved: ResolvedCharacter | null;
+  abilities: ResolvedCharacter['abilities'] | undefined;
+  armorClass: number | null;
+  speedValue: number | null | undefined;
+  maxHP: number | null | undefined;
+  profBonus: number;
+  isStale: boolean;
+  buildError: string | null;
+}) {
+  const { t: tc } = useTranslation('common');
+
+  return (
+    <div className="bg-card border-2 border-destructive/30 rounded-lg p-6">
+      <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.combat')}</h2>
+
+      {!resolved && (
+        <p className="text-sm text-muted-foreground mb-4">
+          {buildError
+            ? tc('characterSheet.buildError.combat', { message: buildError })
+            : tc('characterSheet.emptyState.combat')}
+        </p>
+      )}
+
+      <div className="grid grid-cols-2 gap-4 mb-6">
+        <div className={`bg-muted/50 p-4 rounded border text-center ${isStale ? 'opacity-50' : ''}`}>
+          <div className="text-xs text-muted-foreground mb-2">{tc('characterSheet.fields.armorClass')}</div>
+          <div className="text-4xl font-bold text-foreground">{armorClass}</div>
+        </div>
+
+        <div className="bg-muted/50 p-4 rounded border text-center">
+          <div className="text-xs text-muted-foreground mb-2">{tc('characterSheet.fields.initiative')}</div>
+          <div className="text-4xl font-bold text-foreground">
+            {resolved
+              ? (resolved.initiative >= 0 ? '+' : '') + resolved.initiative
+              : abilities
+                ? (abilities.dex.modifier >= 0 ? '+' : '') + abilities.dex.modifier
+                : '—'}
+          </div>
+        </div>
+      </div>
+
+      {/* HP Display (read-only) */}
+      <div className={`bg-muted/50 p-4 rounded border mb-4 ${isStale ? 'opacity-50' : ''}`}>
+        <div className="text-xs text-muted-foreground mb-2">{tc('characterSheet.fields.hitPoints')}</div>
+        <div className="text-2xl font-bold text-red-600">{maxHP ?? '—'}</div>
+      </div>
+
+      <div className={`text-xs text-muted-foreground ${isStale ? 'opacity-50' : ''}`}>
+        <div className="flex justify-between py-1">
+          <span>{tc('characterSheet.fields.proficiencyBonus')}</span>
+          <span className="font-mono font-bold text-foreground">+{profBonus}</span>
+        </div>
+        <div className="flex justify-between py-1">
+          <span>{tc('characterSheet.fields.speed')}</span>
+          <span className="font-mono font-bold text-foreground">
+            {speedValue != null ? tc('characterSheet.fields.speedFt', { value: speedValue }) : '—'}
+          </span>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/character-sheet/EquipmentPanel.test.tsx
+++ b/src/components/character-sheet/EquipmentPanel.test.tsx
@@ -1,0 +1,65 @@
+import { render, screen } from '@testing-library/react';
+import { EquipmentPanel } from '@/components/character-sheet/EquipmentPanel';
+
+// Mirror the lightweight i18n mock used by sibling panel tests: return the
+// provided defaultValue, otherwise the final dot-segment of the key.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string; qty?: number; weight?: number; name?: string }) => {
+      if (opts?.defaultValue !== undefined && key.startsWith('items')) return opts.defaultValue;
+      const segments = key.split('.');
+      return opts?.defaultValue ?? segments[segments.length - 1];
+    },
+  }),
+}));
+
+type ItemRow = { id: string; item_id: string; equipped?: boolean; quantity: number; source?: unknown };
+
+function renderPanel(items: ItemRow[]) {
+  return render(<EquipmentPanel itemsData={items} />);
+}
+
+describe('EquipmentPanel', () => {
+  it('renders a weapon with its damage dice and translated damage type', () => {
+    renderPanel([{ id: 'a', item_id: 'longsword', quantity: 1 }]);
+    // longsword => 1d8 slashing; the damage type translates to its last key segment.
+    expect(screen.getByText(/1d8 slashing/)).toBeInTheDocument();
+  });
+
+  it('renders an armor item with its base AC', () => {
+    renderPanel([{ id: 'b', item_id: 'chain-mail', quantity: 1 }]);
+    // chain-mail => baseAc 16
+    expect(screen.getByText(/AC 16/)).toBeInTheDocument();
+  });
+
+  it('treats packs as weightless (the pack special-case) rather than reading itemDef.weight', () => {
+    renderPanel([{ id: 'c', item_id: 'explorers-pack', quantity: 1 }]);
+    // qtyAndWeight key is mocked to its last segment; weight is passed as 0 for packs.
+    // Assert the panel renders the pack row without throwing on the missing weight.
+    expect(screen.getByText('qtyAndWeight')).toBeInTheDocument();
+  });
+
+  it('shows a source icon + tooltip for granted (non-loot) items', () => {
+    renderPanel([{ id: 'd', item_id: 'longsword', quantity: 1, source: { origin: 'background', id: 'acolyte' } }]);
+    // getGrantIcon returns an icon for background origin; tc(...sourceFrom) => 'sourceFrom' under the mock.
+    expect(screen.getByLabelText('sourceFrom')).toBeInTheDocument();
+  });
+
+  it('renders no source icon for loot-origin items (getGrantIcon returns null for loot)', () => {
+    renderPanel([
+      { id: 'e', item_id: 'longsword', quantity: 1, source: { origin: 'loot', description: 'Found in a chest' } },
+    ]);
+    expect(screen.queryByLabelText('sourceLoot')).not.toBeInTheDocument();
+    expect(screen.queryByLabelText('sourceFrom')).not.toBeInTheDocument();
+  });
+
+  it('highlights equipped items distinctly from carried ones', () => {
+    const { container } = renderPanel([
+      { id: 'e', item_id: 'longsword', quantity: 1, equipped: true },
+      { id: 'f', item_id: 'chain-mail', quantity: 1, equipped: false },
+    ]);
+    // Equipped rows carry the green highlight class; carried rows use the muted background.
+    expect(container.querySelector('.bg-green-50')).toBeInTheDocument();
+    expect(container.querySelector('.bg-muted\\/50')).toBeInTheDocument();
+  });
+});

--- a/src/components/character-sheet/EquipmentPanel.tsx
+++ b/src/components/character-sheet/EquipmentPanel.tsx
@@ -1,0 +1,77 @@
+import { getGrantIcon, getSourceDisplayName } from '@/lib/class-icons';
+import { getItemDef, getItemNameKey } from '@/lib/sources/items';
+import type { SourceTag } from '@/types/sources';
+import { Check } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+type ItemRow = { id: string; item_id: string; equipped?: boolean; quantity: number; source?: unknown };
+
+export function EquipmentPanel({ itemsData }: { itemsData: readonly ItemRow[] }) {
+  const { t } = useTranslation('gamedata');
+  const { t: tc } = useTranslation('common');
+
+  return (
+    <div className="sheet-panel">
+      <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.equipment')}</h2>
+      <div className="space-y-2 text-xs">
+        {itemsData.map((item) => {
+          const itemDef = getItemDef(item.item_id);
+          const type = itemDef?.type ?? 'gear';
+          const itemName = t(getItemNameKey(type, item.item_id), {
+            defaultValue: item.item_id.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase()),
+          });
+          const detail = (() => {
+            if (itemDef?.type === 'weapon') {
+              return ` — ${itemDef.damageDice} ${t(`damageTypes.${itemDef.damageType}`)}`;
+            }
+            if (itemDef?.type === 'armor') {
+              return ` — AC ${itemDef.baseAc}`;
+            }
+            return '';
+          })();
+          const itemSource = item.source as SourceTag | null;
+          const sourceTooltip = itemSource
+            ? itemSource.origin === 'loot'
+              ? tc('characterSheet.equipment.sourceLoot')
+              : tc('characterSheet.equipment.sourceFrom', {
+                  name: getSourceDisplayName(itemSource, t),
+                })
+            : null;
+          const SourceIcon = itemSource
+            ? getGrantIcon(itemSource, itemDef?.type === 'pack' ? 'pack' : undefined)
+            : null;
+          return (
+            <div
+              key={item.id}
+              className={`flex justify-between items-center py-2 px-2 rounded ${item.equipped ? 'bg-green-50 border border-green-200 dark:bg-green-950/20 dark:border-green-900' : 'bg-muted/50'}`}
+            >
+              <div>
+                <div className="font-semibold text-foreground">
+                  {itemName}
+                  {detail}
+                </div>
+                <div className="text-muted-foreground">
+                  {tc('characterSheet.fields.qtyAndWeight', {
+                    qty: item.quantity,
+                    weight: itemDef?.type !== 'pack' ? (itemDef?.weight ?? 0) : 0,
+                  })}
+                </div>
+              </div>
+              <div className="flex items-center gap-2">
+                {item.equipped && <Check className="size-4 text-green-600" />}
+                {SourceIcon && (
+                  <span title={sourceTooltip ?? undefined} className="inline-flex">
+                    <SourceIcon
+                      aria-label={sourceTooltip ?? undefined}
+                      className="size-5 text-muted-foreground shrink-0"
+                    />
+                  </span>
+                )}
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/character-sheet/FeaturesPanel.test.tsx
+++ b/src/components/character-sheet/FeaturesPanel.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from '@testing-library/react';
+import { FeaturesPanel } from '@/components/character-sheet/FeaturesPanel';
+import type { ResolvedFeature } from '@/types/resolved';
+
+// Lightweight i18n mock: return defaultValue when given, else the final key segment.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: { defaultValue?: string; source?: string; dc?: number; ability?: string }) => {
+      if (key === 'characterSheet.fields.source') return `source: ${opts?.source}`;
+      if (key === 'characterSheet.fields.saveDC') return `DC ${opts?.dc} ${opts?.ability}`;
+      const segments = key.split('.');
+      return opts?.defaultValue ?? segments[segments.length - 1];
+    },
+  }),
+}));
+
+function feature(partial: Partial<ResolvedFeature> & { source: ResolvedFeature['source'] }): ResolvedFeature {
+  return {
+    feature: { id: 'second-wind', name: 'Second Wind', description: 'Regain HP' },
+    ...partial,
+  };
+}
+
+describe('FeaturesPanel', () => {
+  it('renders feature name and description', () => {
+    render(<FeaturesPanel features={[feature({ source: { origin: 'class', id: 'fighter', level: 1 } })]} />);
+    expect(screen.getByText('Second Wind')).toBeInTheDocument();
+    expect(screen.getByText('Regain HP')).toBeInTheDocument();
+  });
+
+  it.each([
+    ['class', { origin: 'class', id: 'fighter', level: 1 }, 'fighter'],
+    ['subclass', { origin: 'subclass', id: 'champion', classId: 'fighter', level: 3 }, 'name'],
+    ['species', { origin: 'species', id: 'dwarf' }, 'dwarf'],
+    ['background', { origin: 'background', id: 'acolyte' }, 'acolyte'],
+  ] as const)('labels the source for %s origin', (_label, source, expectedSegment) => {
+    render(<FeaturesPanel features={[feature({ source })]} />);
+    expect(screen.getByText(new RegExp(`source: ${expectedSegment}`))).toBeInTheDocument();
+  });
+
+  it('uses the loot description as the source label for loot-origin features', () => {
+    render(<FeaturesPanel features={[feature({ source: { origin: 'loot', description: 'Cursed Blade' } })]} />);
+    expect(screen.getByText(/source: Cursed Blade/)).toBeInTheDocument();
+  });
+
+  it('renders the save DC line only when both saveDC and feature.saveDC are present', () => {
+    render(
+      <FeaturesPanel
+        features={[
+          feature({
+            feature: { id: 'breath-weapon', name: 'Breath Weapon', saveDC: { dcAbility: 'con' } },
+            source: { origin: 'species', id: 'dragonborn' },
+            saveDC: 13,
+          }),
+        ]}
+      />
+    );
+    expect(screen.getByText(/DC 13 con/)).toBeInTheDocument();
+  });
+
+  it('omits the save DC line when the resolved saveDC is absent', () => {
+    render(
+      <FeaturesPanel
+        features={[
+          feature({
+            feature: { id: 'breath-weapon', name: 'Breath Weapon', saveDC: { dcAbility: 'con' } },
+            source: { origin: 'species', id: 'dragonborn' },
+            // no resolved saveDC
+          }),
+        ]}
+      />
+    );
+    expect(screen.queryByText(/^DC /)).not.toBeInTheDocument();
+  });
+});

--- a/src/components/character-sheet/FeaturesPanel.tsx
+++ b/src/components/character-sheet/FeaturesPanel.tsx
@@ -1,0 +1,55 @@
+import type { ResolvedCharacter } from '@/types/resolved';
+import { useTranslation } from 'react-i18next';
+
+export function FeaturesPanel({ features }: { features: ResolvedCharacter['features'] }) {
+  const { t } = useTranslation('gamedata');
+  const { t: tc } = useTranslation('common');
+
+  return (
+    <div className="sheet-panel">
+      <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.featuresAndTraits')}</h2>
+      <div className="space-y-3">
+        {features.map((resolvedFeature, i) => (
+          <div key={i} className="bg-muted/50 p-3 rounded border">
+            <div className="font-semibold text-foreground text-sm mb-1">
+              {t(`features.${resolvedFeature.feature.id}.name`, {
+                defaultValue: resolvedFeature.feature.name ?? resolvedFeature.feature.id,
+              })}
+            </div>
+            <p className="text-xs text-muted-foreground">
+              {t(`features.${resolvedFeature.feature.id}.description`, {
+                defaultValue: resolvedFeature.feature.description ?? '',
+              })}
+            </p>
+            {resolvedFeature.source && (
+              <div className="text-xs text-muted-foreground/70 mt-1">
+                {tc('characterSheet.fields.source', {
+                  source:
+                    resolvedFeature.source.origin === 'class'
+                      ? t(`classes.${resolvedFeature.source.id}`)
+                      : resolvedFeature.source.origin === 'subclass'
+                        ? t(`subclasses.${resolvedFeature.source.id}.name`)
+                        : resolvedFeature.source.origin === 'species'
+                          ? t(`species.${resolvedFeature.source.id}`)
+                          : resolvedFeature.source.origin === 'background'
+                            ? t(`backgrounds.${resolvedFeature.source.id}`)
+                            : resolvedFeature.source.origin === 'loot'
+                              ? resolvedFeature.source.description
+                              : resolvedFeature.source.id,
+                })}
+              </div>
+            )}
+            {resolvedFeature.saveDC !== undefined && resolvedFeature.feature.saveDC && (
+              <div className="text-xs font-semibold text-foreground mt-1">
+                {tc('characterSheet.fields.saveDC', {
+                  dc: resolvedFeature.saveDC,
+                  ability: t(`abilities.${resolvedFeature.feature.saveDC.dcAbility}`),
+                })}
+              </div>
+            )}
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/character-sheet/PersonalityPanel.tsx
+++ b/src/components/character-sheet/PersonalityPanel.tsx
@@ -1,0 +1,39 @@
+import { SectionHeader } from '@/components/character-sheet/SectionHeader';
+import type { Character } from '@/types/database';
+import { useTranslation } from 'react-i18next';
+
+export function PersonalityPanel({ character, onEdit }: { character: Character; onEdit: () => void }) {
+  const { t: tc } = useTranslation('common');
+
+  return (
+    <div className="sheet-panel">
+      <SectionHeader title={tc('characterSheet.sections.personality')} onEdit={onEdit} />
+      <div className="space-y-3 text-xs">
+        {character.personality_traits && (
+          <div>
+            <div className="font-semibold text-muted-foreground mb-1">{tc('characterSheet.personality.traits')}</div>
+            <p className="text-foreground">{character.personality_traits}</p>
+          </div>
+        )}
+        {character.ideals && (
+          <div>
+            <div className="font-semibold text-muted-foreground mb-1">{tc('characterSheet.personality.ideals')}</div>
+            <p className="text-foreground">{character.ideals}</p>
+          </div>
+        )}
+        {character.bonds && (
+          <div>
+            <div className="font-semibold text-muted-foreground mb-1">{tc('characterSheet.personality.bonds')}</div>
+            <p className="text-foreground">{character.bonds}</p>
+          </div>
+        )}
+        {character.flaws && (
+          <div>
+            <div className="font-semibold text-muted-foreground mb-1">{tc('characterSheet.personality.flaws')}</div>
+            <p className="text-foreground">{character.flaws}</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/character-sheet/SavingThrowsPanel.tsx
+++ b/src/components/character-sheet/SavingThrowsPanel.tsx
@@ -1,0 +1,50 @@
+import { BonusBreakdown } from '@/components/character-sheet/BonusBreakdown';
+import type { ResolvedCharacter } from '@/types/resolved';
+import { useTranslation } from 'react-i18next';
+
+export function SavingThrowsPanel({
+  savingThrows,
+  buildError,
+}: {
+  savingThrows: ResolvedCharacter['savingThrows'] | undefined;
+  buildError: string | null;
+}) {
+  const { t } = useTranslation('gamedata');
+  const { t: tc } = useTranslation('common');
+
+  if (!savingThrows) {
+    return (
+      <div className="sheet-panel text-center text-muted-foreground">
+        <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.savingThrows')}</h2>
+        <p>
+          {buildError
+            ? tc('characterSheet.buildError.savingThrows', { message: buildError })
+            : tc('characterSheet.emptyState.savingThrows')}
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="sheet-panel">
+      <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.savingThrows')}</h2>
+      <div className="space-y-2 text-xs">
+        {(Object.keys(savingThrows) as Array<keyof typeof savingThrows>).map((ability) => {
+          const save = savingThrows[ability];
+          return (
+            <div key={ability} className="flex justify-between items-center text-foreground">
+              <span className="flex items-center gap-2">
+                <span
+                  aria-hidden
+                  className={`inline-block size-2.5 rounded-full border ${save.proficient ? 'bg-foreground border-foreground' : 'border-muted-foreground/50'}`}
+                />
+                <span className={save.proficient ? 'font-bold' : ''}>{t(`abilities.${ability}`)}</span>
+              </span>
+              <BonusBreakdown components={save.breakdown} total={save.bonus} />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/character-sheet/SectionHeader.tsx
+++ b/src/components/character-sheet/SectionHeader.tsx
@@ -1,0 +1,20 @@
+import { Button } from '@/components/ui/button';
+import { Edit2 } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export function SectionHeader({ title, onEdit }: { title: string; onEdit: () => void }) {
+  const { t } = useTranslation('common');
+  return (
+    <div className="flex items-center justify-between mb-4">
+      <h2 className="text-lg font-bold text-foreground">{title}</h2>
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={onEdit}
+        title={t('characterSheet.editSection', { section: title })}
+      >
+        <Edit2 size={14} />
+      </Button>
+    </div>
+  );
+}

--- a/src/components/character-sheet/SpellcastingPanel.tsx
+++ b/src/components/character-sheet/SpellcastingPanel.tsx
@@ -1,0 +1,51 @@
+import { isSpellId } from '@/lib/sources/spells';
+import { getSpellDisplayMeta } from '@/lib/spell-display';
+import type { ResolvedCharacter } from '@/types/resolved';
+import { useTranslation } from 'react-i18next';
+
+type Spellcasting = NonNullable<ResolvedCharacter['spellcasting']>;
+
+export function SpellcastingPanel({ spellcasting }: { spellcasting: Spellcasting }) {
+  const { t } = useTranslation('gamedata');
+  const { t: tc } = useTranslation('common');
+
+  return (
+    <div className="bg-card border border-purple-200 rounded-lg p-6">
+      <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.spells')}</h2>
+      <div className="space-y-3">
+        {spellcasting.cantrips.length > 0 && (
+          <div>
+            <div className="text-xs font-bold text-muted-foreground mb-2">{tc('characterSheet.sections.cantrips')}</div>
+            <div className="space-y-1">
+              {spellcasting.cantrips.map((cantrip, i) => (
+                <div key={i} className="text-sm text-foreground">
+                  &bull; {cantrip}
+                </div>
+              ))}
+            </div>
+          </div>
+        )}
+        {spellcasting.alwaysPreparedSpells.length > 0 && (
+          <div>
+            <div className="text-xs font-bold text-muted-foreground mb-2">
+              {tc('characterSheet.sections.alwaysPrepared')}
+            </div>
+            <div className="space-y-1">
+              {spellcasting.alwaysPreparedSpells.map((id, i) => {
+                const meta = getSpellDisplayMeta(id);
+                return (
+                  <div key={i} className="text-sm text-foreground">
+                    &bull; {isSpellId(id) ? t(`spells.${id}.name`) : id}
+                    {meta && (
+                      <span className="text-xs text-muted-foreground ml-2">{`(lvl ${meta.level} ${meta.school})`}</span>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/character-sheet/edit-dialogs/ConfirmActionDialog.tsx
+++ b/src/components/character-sheet/edit-dialogs/ConfirmActionDialog.tsx
@@ -1,0 +1,85 @@
+import { Button } from '@/components/ui/button';
+import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Input } from '@/components/ui/input';
+import { useTranslation } from 'react-i18next';
+
+export type ConfirmAction = 'archive' | 'delete' | 'clone';
+
+export function ConfirmActionDialog({
+  action,
+  characterName,
+  cloneName,
+  onCloneNameChange,
+  onConfirm,
+  onClose,
+  pending,
+}: {
+  action: ConfirmAction;
+  characterName: string;
+  cloneName: string;
+  onCloneNameChange: (value: string) => void;
+  onConfirm: () => void;
+  onClose: () => void;
+  pending: boolean;
+}) {
+  const { t: tc } = useTranslation('common');
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>
+            {action === 'archive'
+              ? tc('characterSheet.actions.archiveTitle')
+              : action === 'clone'
+                ? tc('characterSheet.actions.cloneTitle')
+                : tc('characterSheet.actions.deleteTitle')}
+          </DialogTitle>
+        </DialogHeader>
+        {action === 'clone' ? (
+          <div className="space-y-2">
+            <label htmlFor="clone-name" className="text-sm text-muted-foreground">
+              {tc('characterSheet.actions.cloneNameLabel')}
+            </label>
+            <Input
+              id="clone-name"
+              value={cloneName}
+              onChange={(e) => onCloneNameChange(e.target.value)}
+              onKeyDown={(e) => {
+                if (e.key === 'Enter' && cloneName.trim()) onConfirm();
+              }}
+            />
+          </div>
+        ) : (
+          <p className="text-sm text-muted-foreground">
+            {action === 'archive'
+              ? tc('characterSheet.actions.archiveConfirm', { name: characterName })
+              : tc('characterSheet.actions.deleteConfirm', { name: characterName })}
+          </p>
+        )}
+        <DialogFooter>
+          <Button variant="outline" onClick={onClose}>
+            {tc('buttons.cancel')}
+          </Button>
+          <Button
+            variant={action === 'delete' ? 'destructive' : 'default'}
+            onClick={onConfirm}
+            disabled={action === 'clone' && !cloneName.trim()}
+            pending={pending}
+          >
+            {action === 'archive'
+              ? tc('buttons.archive')
+              : action === 'clone'
+                ? tc('buttons.clone')
+                : tc('buttons.delete')}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/character-sheet/edit-dialogs/EditHeaderDialog.tsx
+++ b/src/components/character-sheet/edit-dialogs/EditHeaderDialog.tsx
@@ -1,0 +1,90 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { GenderToggle } from '@/components/ui/gender-toggle';
+import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import type { DndGender } from '@/lib/dnd-helpers';
+import type { Character } from '@/types/database';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ModalFooter } from './ModalFooter';
+
+export function EditHeaderDialog({
+  character,
+  onSave,
+  onClose,
+  saving,
+}: {
+  character: Character;
+  onSave: (updates: Partial<Character>) => void;
+  onClose: () => void;
+  saving: boolean;
+}) {
+  const { t: tc } = useTranslation('common');
+  const [form, setForm] = useState({
+    name: character.name,
+    player_name: character.player_name ?? '',
+    character_type: character.character_type,
+    gender: (character.gender ?? '') as DndGender | '',
+  });
+
+  const update = <K extends keyof typeof form>(key: K, value: (typeof form)[K]) =>
+    setForm((prev) => ({ ...prev, [key]: value }));
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>{tc('characterSheet.dialogs.editCharacterInfo')}</DialogTitle>
+        </DialogHeader>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div className="space-y-2">
+            <Label htmlFor="char-name">{tc('characterSheet.fields.name')}</Label>
+            <Input id="char-name" value={form.name} onChange={(e) => update('name', e.target.value)} autoFocus />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="char-player">{tc('characterSheet.fields.player')}</Label>
+            <Input
+              id="char-player"
+              value={form.player_name}
+              onChange={(e) => update('player_name', e.target.value)}
+              placeholder={tc('characterSheet.hints.leaveEmptyForNpcs')}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label>{tc('characterSheet.fields.type')}</Label>
+            <Select value={form.character_type} onValueChange={(val) => update('character_type', val as 'pc' | 'npc')}>
+              <SelectTrigger className="w-full">
+                <SelectValue>{tc(`characterType.${form.character_type}`)}</SelectValue>
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="pc">{tc('characterType.pc')}</SelectItem>
+                <SelectItem value="npc">{tc('characterType.npc')}</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
+          <div className="space-y-2">
+            <Label>{tc('characterSheet.fields.gender')}</Label>
+            <GenderToggle value={form.gender} onChange={(g) => update('gender', g)} />
+          </div>
+        </div>
+        <ModalFooter
+          onSave={() =>
+            onSave({
+              ...form,
+              player_name: form.player_name || null,
+              gender: form.gender === 'male' || form.gender === 'female' ? form.gender : null,
+            })
+          }
+          onCancel={onClose}
+          saving={saving}
+        />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/character-sheet/edit-dialogs/EditPersonalityDialog.tsx
+++ b/src/components/character-sheet/edit-dialogs/EditPersonalityDialog.tsx
@@ -1,0 +1,81 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Label } from '@/components/ui/label';
+import { Textarea } from '@/components/ui/textarea';
+import { useState } from 'react';
+import { useTranslation } from 'react-i18next';
+import { ModalFooter } from './ModalFooter';
+
+export function EditPersonalityDialog({
+  personality_traits,
+  ideals,
+  bonds,
+  flaws,
+  onSave,
+  onClose,
+  saving,
+}: {
+  personality_traits: string;
+  ideals: string;
+  bonds: string;
+  flaws: string;
+  onSave: (updates: { personality_traits: string; ideals: string; bonds: string; flaws: string }) => void;
+  onClose: () => void;
+  saving: boolean;
+}) {
+  const { t: tc } = useTranslation('common');
+  const [form, setForm] = useState({ personality_traits, ideals, bonds, flaws });
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-lg">
+        <DialogHeader>
+          <DialogTitle>{tc('characterSheet.dialogs.editPersonality')}</DialogTitle>
+        </DialogHeader>
+        <div className="space-y-4">
+          <div className="space-y-2">
+            <Label htmlFor="personality-traits">{tc('characterSheet.fields.personalityTraits')}</Label>
+            <Textarea
+              id="personality-traits"
+              value={form.personality_traits}
+              onChange={(e) => setForm((prev) => ({ ...prev, personality_traits: e.target.value }))}
+              rows={3}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="personality-ideals">{tc('characterSheet.personality.ideals')}</Label>
+            <Textarea
+              id="personality-ideals"
+              value={form.ideals}
+              onChange={(e) => setForm((prev) => ({ ...prev, ideals: e.target.value }))}
+              rows={2}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="personality-bonds">{tc('characterSheet.personality.bonds')}</Label>
+            <Textarea
+              id="personality-bonds"
+              value={form.bonds}
+              onChange={(e) => setForm((prev) => ({ ...prev, bonds: e.target.value }))}
+              rows={2}
+            />
+          </div>
+          <div className="space-y-2">
+            <Label htmlFor="personality-flaws">{tc('characterSheet.personality.flaws')}</Label>
+            <Textarea
+              id="personality-flaws"
+              value={form.flaws}
+              onChange={(e) => setForm((prev) => ({ ...prev, flaws: e.target.value }))}
+              rows={2}
+            />
+          </div>
+        </div>
+        <ModalFooter onSave={() => onSave(form)} onCancel={onClose} saving={saving} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/character-sheet/edit-dialogs/EditTextDialog.tsx
+++ b/src/components/character-sheet/edit-dialogs/EditTextDialog.tsx
@@ -1,0 +1,39 @@
+import { Dialog, DialogContent, DialogHeader, DialogTitle } from '@/components/ui/dialog';
+import { Textarea } from '@/components/ui/textarea';
+import { useState } from 'react';
+import { ModalFooter } from './ModalFooter';
+
+export function EditTextDialog({
+  title,
+  field,
+  value,
+  onSave,
+  onClose,
+  saving,
+}: {
+  title: string;
+  field: string;
+  value: string;
+  onSave: (updates: Record<string, string>) => void;
+  onClose: () => void;
+  saving: boolean;
+}) {
+  const [text, setText] = useState(value);
+
+  return (
+    <Dialog
+      open
+      onOpenChange={(open) => {
+        if (!open) onClose();
+      }}
+    >
+      <DialogContent className="sm:max-w-2xl">
+        <DialogHeader>
+          <DialogTitle>{title}</DialogTitle>
+        </DialogHeader>
+        <Textarea value={text} onChange={(e) => setText(e.target.value)} rows={10} autoFocus />
+        <ModalFooter onSave={() => onSave({ [field]: text })} onCancel={onClose} saving={saving} />
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/character-sheet/edit-dialogs/ModalFooter.tsx
+++ b/src/components/character-sheet/edit-dialogs/ModalFooter.tsx
@@ -1,0 +1,27 @@
+import { Button } from '@/components/ui/button';
+import { DialogFooter } from '@/components/ui/dialog';
+import { Save } from 'lucide-react';
+import { useTranslation } from 'react-i18next';
+
+export function ModalFooter({
+  onSave,
+  onCancel,
+  saving,
+}: {
+  onSave: () => void;
+  onCancel: () => void;
+  saving: boolean;
+}) {
+  const { t } = useTranslation('common');
+  return (
+    <DialogFooter>
+      <Button variant="outline" onClick={onCancel}>
+        {t('buttons.cancel')}
+      </Button>
+      <Button onClick={onSave} pending={saving}>
+        <Save size={14} />
+        {saving ? t('buttons.saving') : t('buttons.save')}
+      </Button>
+    </DialogFooter>
+  );
+}

--- a/src/index.css
+++ b/src/index.css
@@ -181,6 +181,50 @@ body,
     @apply grid grid-cols-1 md:grid-cols-2 lg:grid-cols-4 gap-6;
   }
 
+  /* WotC-inspired character sheet grid: stats (left) / combat (center, wider) / roleplay & gear (right).
+     Collapses to a single column on mobile, matching the flow of the official 5e sheet. */
+  .sheet-grid {
+    @apply grid gap-6;
+    grid-template-columns: 1fr;
+    grid-template-areas:
+      'left'
+      'center'
+      'right';
+  }
+
+  @media (min-width: 1024px) {
+    .sheet-grid {
+      grid-template-columns: minmax(0, 1fr) minmax(0, 1.4fr) minmax(0, 1fr);
+      grid-template-areas: 'left center right';
+      align-items: start;
+    }
+  }
+
+  .sheet-area-left {
+    grid-area: left;
+    @apply space-y-6;
+  }
+
+  .sheet-area-center {
+    grid-area: center;
+    @apply space-y-6;
+  }
+
+  .sheet-area-right {
+    grid-area: right;
+    @apply space-y-6;
+  }
+
+  /* Card shell shared by every character-sheet panel. */
+  .sheet-panel {
+    @apply bg-card border rounded-lg p-6;
+  }
+
+  /* Ability "shield" box — large modifier, small score pill below, echoing the official sheet. */
+  .ability-shield {
+    @apply flex flex-col items-center rounded-lg border bg-muted/50 px-3 py-3 text-center;
+  }
+
   .form-group {
     @apply mb-4;
   }

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -1,39 +1,36 @@
 import { getLogger } from '@/lib/logger';
 import { Button } from '@/components/ui/button';
-import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
-import { GenderToggle } from '@/components/ui/gender-toggle';
-import { Input } from '@/components/ui/input';
-import { Label } from '@/components/ui/label';
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { Skeleton } from '@/components/ui/skeleton';
-import { Textarea } from '@/components/ui/textarea';
+import { AbilityScoresPanel } from '@/components/character-sheet/AbilityScoresPanel';
 import { AttacksPanel } from '@/components/character-sheet/AttacksPanel';
-import { BonusBreakdown } from '@/components/character-sheet/BonusBreakdown';
+import { BackstoryPanel } from '@/components/character-sheet/BackstoryPanel';
+import { CharacterSheetHeader } from '@/components/character-sheet/CharacterSheetHeader';
+import { CombatPanel } from '@/components/character-sheet/CombatPanel';
 import { ConditionsPanel } from '@/components/character-sheet/ConditionsPanel';
+import { EquipmentPanel } from '@/components/character-sheet/EquipmentPanel';
+import { FeaturesPanel } from '@/components/character-sheet/FeaturesPanel';
 import { HitDicePanel } from '@/components/character-sheet/HitDicePanel';
-import { SpellSlotsPanel } from '@/components/character-sheet/SpellSlotsPanel';
-import { LevelControls } from '@/components/character-sheet/LevelControls';
 import { PendingChoicesPanel } from '@/components/character-sheet/PendingChoicesPanel';
+import { PersonalityPanel } from '@/components/character-sheet/PersonalityPanel';
 import { ProficienciesPanel } from '@/components/character-sheet/ProficienciesPanel';
 import { ResourcePoolsPanel } from '@/components/character-sheet/ResourcePoolsPanel';
+import { SavingThrowsPanel } from '@/components/character-sheet/SavingThrowsPanel';
 import { SkillsPanel } from '@/components/character-sheet/SkillsPanel';
-import { PortraitUpload } from '@/components/character-sheet/PortraitUpload';
+import { SpellcastingPanel } from '@/components/character-sheet/SpellcastingPanel';
+import { SpellSlotsPanel } from '@/components/character-sheet/SpellSlotsPanel';
+import { ConfirmActionDialog, type ConfirmAction } from '@/components/character-sheet/edit-dialogs/ConfirmActionDialog';
+import { EditHeaderDialog } from '@/components/character-sheet/edit-dialogs/EditHeaderDialog';
+import { EditPersonalityDialog } from '@/components/character-sheet/edit-dialogs/EditPersonalityDialog';
+import { EditTextDialog } from '@/components/character-sheet/edit-dialogs/EditTextDialog';
 import { buildRestUpdate } from '@/lib/rest';
-import { BACKGROUND_SOURCES } from '@/lib/sources/backgrounds';
-import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
-import { getGrantIcon, getSourceDisplayName } from '@/lib/class-icons';
-import { getItemDef, getItemNameKey } from '@/lib/sources/items';
-import { isSpellId } from '@/lib/sources/spells';
-import { getSpellDisplayMeta } from '@/lib/spell-display';
 import { useCharacter, useCharacterMutations } from '@/hooks/useCharacters';
 import { useCharacterBuildLevels, useCharacterItems } from '@/hooks/useCharacterBuild';
 import { usePageTitle } from '@/hooks/usePageTitle';
 import { CharacterProvider, useCharacterContext } from '@/hooks/useCharacterContext';
 import type { PersistedItem } from '@/lib/resolver/index';
 import type { SourceTag } from '@/types/sources';
-import { DND_CLASSES, getProficiencyBonus, isBackgroundId, type ClassId, type DndGender } from '@/lib/dnd-helpers';
+import { getProficiencyBonus } from '@/lib/dnd-helpers';
 import type { Character } from '@/types/database';
-import { Archive, Check, Copy, Edit2, Save, Trash2 } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
 import { useNavigate, useParams } from 'react-router-dom';
@@ -45,38 +42,6 @@ const logger = getLogger('character-sheet');
 
 type EditSection = 'header' | 'personality' | 'backstory' | 'appearance' | null;
 
-function SectionHeader({ title, onEdit }: { title: string; onEdit: () => void }) {
-  const { t } = useTranslation('common');
-  return (
-    <div className="flex items-center justify-between mb-4">
-      <h2 className="text-lg font-bold text-foreground">{title}</h2>
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={onEdit}
-        title={t('characterSheet.editSection', { section: title })}
-      >
-        <Edit2 size={14} />
-      </Button>
-    </div>
-  );
-}
-
-function ModalFooter({ onSave, onCancel, saving }: { onSave: () => void; onCancel: () => void; saving: boolean }) {
-  const { t } = useTranslation('common');
-  return (
-    <DialogFooter>
-      <Button variant="outline" onClick={onCancel}>
-        {t('buttons.cancel')}
-      </Button>
-      <Button onClick={onSave} pending={saving}>
-        <Save size={14} />
-        {saving ? t('buttons.saving') : t('buttons.save')}
-      </Button>
-    </DialogFooter>
-  );
-}
-
 function CharacterSheetInner({
   character,
   itemsData,
@@ -86,13 +51,12 @@ function CharacterSheetInner({
   itemsData: Array<{ id: string; item_id: string; equipped?: boolean; quantity: number; source?: unknown }>;
   characterId: string;
 }) {
-  const { t } = useTranslation('gamedata');
   const { t: tc } = useTranslation('common');
   const [editSection, setEditSection] = useState<EditSection>(null);
 
   const navigate = useNavigate();
   const { campaignSlug } = useParams<{ campaignSlug: string }>();
-  const [confirmAction, setConfirmAction] = useState<'archive' | 'delete' | 'clone' | null>(null);
+  const [confirmAction, setConfirmAction] = useState<ConfirmAction | null>(null);
   const [cloneName, setCloneName] = useState('');
 
   usePageTitle(character.name);
@@ -101,11 +65,9 @@ function CharacterSheetInner({
   const {
     character: ctxCharacter,
     rows,
-    build,
     resolved,
     buildError,
     buildWarnings,
-    level: resolvedLevel,
     isDirty,
     markSaved,
   } = useCharacterContext();
@@ -215,22 +177,6 @@ function CharacterSheetInner({
     );
   };
 
-  const buildErrorBanner = buildError ? (
-    <div className="mb-6 p-4 bg-destructive/10 border border-destructive/50 rounded-lg text-destructive text-sm">
-      {tc('characterSheet.errors.buildFailed', { message: buildError })}
-    </div>
-  ) : null;
-
-  const buildWarningBanner =
-    buildWarnings.length > 0 ? (
-      <div className="mb-6 p-4 bg-amber-50/50 dark:bg-amber-950/20 border border-amber-500/40 rounded-lg text-amber-700 dark:text-amber-400 text-sm">
-        {tc('characterSheet.warnings.buildIncomplete', { message: buildWarnings.join('; ') })}
-      </div>
-    ) : null;
-
-  const alignmentName = character.alignment
-    ? t(`alignments.${character.alignment}`, { defaultValue: character.alignment })
-    : '';
   const profBonus = resolved?.proficiencyBonus ?? getProficiencyBonus(character.level);
 
   // Combat stats — prefer resolved pipeline values, fall back to pre-calculated DB columns.
@@ -245,31 +191,24 @@ function CharacterSheetInner({
   const skills = resolved?.skills;
   const savingThrows = resolved?.savingThrows;
 
-  // Lineage: find the lineage-choice decision made during character creation,
-  // scoped to the current species so stale entries from a prior species are ignored.
-  const lineageId: string | null = (() => {
-    if (!build || !character.species) return null;
-    const prefix = `lineage-choice:species:${character.species}:`;
-    const entry = Object.entries(build.choices).find(([key]) => key.startsWith(prefix));
-    if (!entry) return null;
-    const decision = entry[1];
-    return decision.type === 'lineage-choice' ? decision.lineageId : null;
-  })();
-
-  // Origin feat: derive badge info from the background source's grants.
-  // deriveOriginFeatInfo handles both shapes (feat grant and direct feat-magic-initiate-* feature).
-  const originFeatInfo = (() => {
-    if (!character.background || !isBackgroundId(character.background)) return null;
-    const bg = BACKGROUND_SOURCES.find((s) => s.id === character.background);
-    if (!bg) return null;
-    return deriveOriginFeatInfo(bg.grants);
-  })();
+  const hasPersonality = character.personality_traits || character.ideals || character.bonds || character.flaws;
+  const hasSpells =
+    resolved?.spellcasting &&
+    (resolved.spellcasting.cantrips.length > 0 || resolved.spellcasting.alwaysPreparedSpells.length > 0);
 
   return (
     <div className="min-h-screen bg-muted/30">
       <div className="max-w-7xl mx-auto p-8">
-        {buildErrorBanner}
-        {buildWarningBanner}
+        {buildError && (
+          <div className="mb-6 p-4 bg-destructive/10 border border-destructive/50 rounded-lg text-destructive text-sm">
+            {tc('characterSheet.errors.buildFailed', { message: buildError })}
+          </div>
+        )}
+        {buildWarnings.length > 0 && (
+          <div className="mb-6 p-4 bg-amber-50/50 dark:bg-amber-950/20 border border-amber-500/40 rounded-lg text-amber-700 dark:text-amber-400 text-sm">
+            {tc('characterSheet.warnings.buildIncomplete', { message: buildWarnings.join('; ') })}
+          </div>
+        )}
         {saveFailed && (
           <div className="mb-6 p-4 bg-destructive/10 border border-destructive/50 rounded-lg text-destructive text-sm flex items-center justify-between">
             <span>{tc('errors.saveFailed')}</span>
@@ -279,215 +218,32 @@ function CharacterSheetInner({
           </div>
         )}
 
-        {/* Header */}
-        <div className="bg-card border rounded-lg p-6 mb-6">
-          <div className="flex items-start justify-between mb-4">
-            <div className="flex items-start gap-4">
-              <PortraitUpload
-                characterId={character.id}
-                portraitUrl={character.portrait_url}
-                characterName={character.name}
-              />
-              <div>
-                <div className="text-sm text-muted-foreground mb-1">{tc('characterSheet.title')}</div>
-                <h1 className="hidden md:block text-3xl font-bold text-foreground">{character.name}</h1>
-              </div>
-            </div>
-            <div className="flex items-center gap-1">
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => setEditSection('header')}
-                title={tc('characterSheet.dialogs.editCharacterInfo')}
-              >
-                <Edit2 size={16} />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => {
-                  setCloneName(tc('characterSheet.actions.copyOfName', { name: character.name }));
-                  setConfirmAction('clone');
-                }}
-                title={tc('buttons.clone')}
-              >
-                <Copy size={16} />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => setConfirmAction('archive')}
-                title={tc('buttons.archive')}
-              >
-                <Archive size={16} />
-              </Button>
-              <Button
-                variant="ghost"
-                size="icon-sm"
-                onClick={() => setConfirmAction('delete')}
-                title={tc('buttons.delete')}
-                className="text-destructive hover:text-destructive"
-              >
-                <Trash2 size={16} />
-              </Button>
-            </div>
-          </div>
-
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-            <div>
-              <span className="text-muted-foreground">{tc('characterSheet.fields.class')}</span>
-              <p className="text-foreground font-semibold">
-                {character.class ? t(`classes.${character.class}`, { defaultValue: character.class }) : ''}
-                {character.subclass
-                  ? ` (${t(`subclasses.${character.subclass}.name`, { defaultValue: character.subclass })})`
-                  : ''}
-              </p>
-            </div>
-            <div>
-              <span className="text-muted-foreground">{tc('characterSheet.fields.level')}</span>
-              <p className="text-foreground font-semibold">{resolvedLevel}</p>
-            </div>
-            <div>
-              <span className="text-muted-foreground">{tc('characterSheet.fields.species')}</span>
-              <p className="text-foreground font-semibold">
-                {character.species ? t(`species.${character.species}`, { defaultValue: character.species }) : ''}
-              </p>
-              {lineageId && character.species && (
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  {t(`lineages.${character.species}.${lineageId}`, { defaultValue: lineageId })}
-                </p>
-              )}
-            </div>
-            <div>
-              <span className="text-muted-foreground">{tc('characterSheet.fields.background')}</span>
-              <p className="text-foreground font-semibold">
-                {character.background
-                  ? isBackgroundId(character.background)
-                    ? t(`backgrounds.${character.background}`)
-                    : character.background
-                  : ''}
-              </p>
-              {originFeatInfo && (
-                <p className="text-xs text-muted-foreground mt-0.5">
-                  {originFeatInfo.namespace === 'features'
-                    ? t(`features.${originFeatInfo.id}.name` as `features.${string}.name`, {
-                        defaultValue: originFeatInfo.id,
-                      })
-                    : t(`feats.${originFeatInfo.id}.name` as `feats.${string}.name`, {
-                        defaultValue: originFeatInfo.id,
-                      })}
-                </p>
-              )}
-            </div>
-            <div>
-              <span className="text-muted-foreground">{tc('characterSheet.fields.alignment')}</span>
-              <p className="text-foreground font-semibold">{alignmentName}</p>
-            </div>
-            {character.player_name && (
-              <div>
-                <span className="text-muted-foreground">{tc('characterSheet.fields.player')}</span>
-                <p className="text-foreground font-semibold">{character.player_name}</p>
-              </div>
-            )}
-            <div>
-              <span className="text-muted-foreground">{tc('characterSheet.fields.type')}</span>
-              <p className="text-foreground font-semibold uppercase">
-                {tc(`characterType.${character.character_type}`)}
-              </p>
-            </div>
-            {character.gender && (
-              <div>
-                <span className="text-muted-foreground">{tc('characterSheet.fields.gender')}</span>
-                <p className="text-foreground font-semibold">
-                  {t(`gender.${character.gender}`, { defaultValue: character.gender })}
-                </p>
-              </div>
-            )}
-          </div>
-
-          {/* Level Controls */}
-          {character.class && DND_CLASSES.some((c) => c.id === character.class) && (
-            <div className="mt-4 pt-4 border-t">
-              <LevelControls classId={character.class as ClassId} />
-            </div>
-          )}
-        </div>
+        <CharacterSheetHeader
+          character={character}
+          onEdit={() => setEditSection('header')}
+          onClone={() => {
+            setCloneName(tc('characterSheet.actions.copyOfName', { name: character.name }));
+            setConfirmAction('clone');
+          }}
+          onArchive={() => setConfirmAction('archive')}
+          onDelete={() => setConfirmAction('delete')}
+        />
 
         {/* Pending Choices Panel */}
         <div className="mb-6">
           <PendingChoicesPanel />
         </div>
 
-        {/* Three Column Layout */}
-        <div className="grid grid-cols-1 lg:grid-cols-3 gap-6 mb-6">
-          {/* Left Column: Abilities & Skills */}
-          <div className="lg:col-span-1 space-y-6">
-            {/* Ability Scores */}
-            {abilities ? (
-              <div className="bg-card border rounded-lg p-6">
-                <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.abilities')}</h2>
-                <div className="space-y-3">
-                  {(Object.keys(abilities) as Array<keyof typeof abilities>).map((ability) => {
-                    const resolvedAbility = abilities[ability];
-                    const modifier = resolvedAbility.modifier;
-                    return (
-                      <div key={ability} className="bg-muted/50 p-3 rounded border">
-                        <div className="text-xs text-muted-foreground mb-1">{t(`abilities.${ability}`)}</div>
-                        <div className="flex items-end justify-between">
-                          <div className="text-sm font-bold text-foreground">{resolvedAbility.total}</div>
-                          <div className={`text-lg font-bold ${modifier >= 0 ? 'text-green-600' : 'text-red-600'}`}>
-                            {modifier >= 0 ? '+' : ''}
-                            {modifier}
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : (
-              <div className="bg-card border rounded-lg p-6 text-center text-muted-foreground">
-                <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.abilities')}</h2>
-                <p>
-                  {buildError
-                    ? tc('characterSheet.buildError.abilities', { message: buildError })
-                    : tc('characterSheet.emptyState.abilities')}
-                </p>
-              </div>
-            )}
-
-            {/* Saving Throws */}
-            {savingThrows ? (
-              <div className="bg-card border rounded-lg p-6">
-                <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.savingThrows')}</h2>
-                <div className="space-y-2 text-xs">
-                  {(Object.keys(savingThrows) as Array<keyof typeof savingThrows>).map((ability) => {
-                    const save = savingThrows[ability];
-                    return (
-                      <div key={ability} className="flex justify-between items-center text-foreground">
-                        <span className={save.proficient ? 'font-bold' : ''}>{t(`abilities.${ability}`)}</span>
-                        <BonusBreakdown components={save.breakdown} total={save.bonus} />
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            ) : (
-              <div className="bg-card border rounded-lg p-6 text-center text-muted-foreground">
-                <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.savingThrows')}</h2>
-                <p>
-                  {buildError
-                    ? tc('characterSheet.buildError.savingThrows', { message: buildError })
-                    : tc('characterSheet.emptyState.savingThrows')}
-                </p>
-              </div>
-            )}
-
-            {/* Skills */}
+        {/* WotC-inspired layout: stats (left) / combat (center) / roleplay & gear (right) */}
+        <div className="sheet-grid mb-6">
+          {/* Left Column: Abilities, Saving Throws, Skills */}
+          <div className="sheet-area-left">
+            <AbilityScoresPanel abilities={abilities} buildError={buildError} />
+            <SavingThrowsPanel savingThrows={savingThrows} buildError={buildError} />
             {skills ? (
               <SkillsPanel skills={skills} />
             ) : (
-              <div className="bg-card border rounded-lg p-6 text-center text-muted-foreground">
+              <div className="sheet-panel text-center text-muted-foreground">
                 <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.skills')}</h2>
                 <p>
                   {buildError
@@ -499,61 +255,20 @@ function CharacterSheetInner({
           </div>
 
           {/* Center Column: Combat & Features */}
-          <div className="lg:col-span-1 space-y-6">
-            {/* Combat Stats */}
-            <div className="bg-card border-2 border-destructive/30 rounded-lg p-6">
-              <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.combat')}</h2>
+          <div className="sheet-area-center">
+            <CombatPanel
+              resolved={resolved}
+              abilities={abilities}
+              armorClass={armorClass}
+              speedValue={speedValue}
+              maxHP={maxHP}
+              profBonus={profBonus}
+              isStale={isStale}
+              buildError={buildError}
+            />
 
-              {!resolved && (
-                <p className="text-sm text-muted-foreground mb-4">
-                  {buildError
-                    ? tc('characterSheet.buildError.combat', { message: buildError })
-                    : tc('characterSheet.emptyState.combat')}
-                </p>
-              )}
-
-              <div className="grid grid-cols-2 gap-4 mb-6">
-                <div className={`bg-muted/50 p-4 rounded border text-center ${isStale ? 'opacity-50' : ''}`}>
-                  <div className="text-xs text-muted-foreground mb-2">{tc('characterSheet.fields.armorClass')}</div>
-                  <div className="text-4xl font-bold text-foreground">{armorClass}</div>
-                </div>
-
-                <div className="bg-muted/50 p-4 rounded border text-center">
-                  <div className="text-xs text-muted-foreground mb-2">{tc('characterSheet.fields.initiative')}</div>
-                  <div className="text-4xl font-bold text-foreground">
-                    {resolved
-                      ? (resolved.initiative >= 0 ? '+' : '') + resolved.initiative
-                      : abilities
-                        ? (abilities.dex.modifier >= 0 ? '+' : '') + abilities.dex.modifier
-                        : '—'}
-                  </div>
-                </div>
-              </div>
-
-              {/* HP Display (read-only) */}
-              <div className={`bg-muted/50 p-4 rounded border mb-4 ${isStale ? 'opacity-50' : ''}`}>
-                <div className="text-xs text-muted-foreground mb-2">{tc('characterSheet.fields.hitPoints')}</div>
-                <div className="text-2xl font-bold text-red-600">{maxHP ?? '—'}</div>
-              </div>
-
-              <div className={`text-xs text-muted-foreground ${isStale ? 'opacity-50' : ''}`}>
-                <div className="flex justify-between py-1">
-                  <span>{tc('characterSheet.fields.proficiencyBonus')}</span>
-                  <span className="font-mono font-bold text-foreground">+{profBonus}</span>
-                </div>
-                <div className="flex justify-between py-1">
-                  <span>{tc('characterSheet.fields.speed')}</span>
-                  <span className="font-mono font-bold text-foreground">
-                    {speedValue != null ? tc('characterSheet.fields.speedFt', { value: speedValue }) : '—'}
-                  </span>
-                </div>
-              </div>
-            </div>
-
-            {/* Conditions */}
             <ConditionsPanel character={character} onUpdate={handleUpdate} />
 
-            {/* Rest buttons + Hit Dice + Spell Slots */}
             {resolved && (
               <>
                 <div className="flex gap-2">
@@ -569,247 +284,26 @@ function CharacterSheetInner({
               </>
             )}
 
-            {/* Attacks */}
             {resolved && <AttacksPanel attacks={resolved.attacks} weaponMasteries={resolved.weaponMasteries} />}
-
-            {/* Proficiencies */}
             {resolved && <ProficienciesPanel resolved={resolved} />}
-
-            {/* Resource Pools */}
             {resolved && <ResourcePoolsPanel resolved={resolved} />}
-
-            {/* Features */}
-            {resolved?.features && resolved.features.length > 0 && (
-              <div className="bg-card border rounded-lg p-6">
-                <h2 className="text-lg font-bold text-foreground mb-4">
-                  {tc('characterSheet.sections.featuresAndTraits')}
-                </h2>
-                <div className="space-y-3">
-                  {resolved.features.map((resolvedFeature, i) => (
-                    <div key={i} className="bg-muted/50 p-3 rounded border">
-                      <div className="font-semibold text-foreground text-sm mb-1">
-                        {t(`features.${resolvedFeature.feature.id}.name`, {
-                          defaultValue: resolvedFeature.feature.name ?? resolvedFeature.feature.id,
-                        })}
-                      </div>
-                      <p className="text-xs text-muted-foreground">
-                        {t(`features.${resolvedFeature.feature.id}.description`, {
-                          defaultValue: resolvedFeature.feature.description ?? '',
-                        })}
-                      </p>
-                      {resolvedFeature.source && (
-                        <div className="text-xs text-muted-foreground/70 mt-1">
-                          {tc('characterSheet.fields.source', {
-                            source:
-                              resolvedFeature.source.origin === 'class'
-                                ? t(`classes.${resolvedFeature.source.id}`)
-                                : resolvedFeature.source.origin === 'subclass'
-                                  ? t(`subclasses.${resolvedFeature.source.id}.name`)
-                                  : resolvedFeature.source.origin === 'species'
-                                    ? t(`species.${resolvedFeature.source.id}`)
-                                    : resolvedFeature.source.origin === 'background'
-                                      ? t(`backgrounds.${resolvedFeature.source.id}`)
-                                      : resolvedFeature.source.origin === 'loot'
-                                        ? resolvedFeature.source.description
-                                        : resolvedFeature.source.id,
-                          })}
-                        </div>
-                      )}
-                      {resolvedFeature.saveDC !== undefined && resolvedFeature.feature.saveDC && (
-                        <div className="text-xs font-semibold text-foreground mt-1">
-                          {tc('characterSheet.fields.saveDC', {
-                            dc: resolvedFeature.saveDC,
-                            ability: t(`abilities.${resolvedFeature.feature.saveDC.dcAbility}`),
-                          })}
-                        </div>
-                      )}
-                    </div>
-                  ))}
-                </div>
-              </div>
-            )}
+            {resolved?.features && resolved.features.length > 0 && <FeaturesPanel features={resolved.features} />}
           </div>
 
-          {/* Right Column: Equipment & Spells */}
-          <div className="lg:col-span-1 space-y-6">
-            {/* Equipment */}
-            {itemsData.length > 0 && (
-              <div className="bg-card border rounded-lg p-6">
-                <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.equipment')}</h2>
-                <div className="space-y-2 text-xs">
-                  {itemsData.map((item) => {
-                    const itemDef = getItemDef(item.item_id);
-                    const type = itemDef?.type ?? 'gear';
-                    const itemName = t(getItemNameKey(type, item.item_id), {
-                      defaultValue: item.item_id.replace(/-/g, ' ').replace(/\b\w/g, (c: string) => c.toUpperCase()),
-                    });
-                    const detail = (() => {
-                      if (itemDef?.type === 'weapon') {
-                        return ` — ${itemDef.damageDice} ${t(`damageTypes.${itemDef.damageType}`)}`;
-                      }
-                      if (itemDef?.type === 'armor') {
-                        return ` — AC ${itemDef.baseAc}`;
-                      }
-                      return '';
-                    })();
-                    const itemSource = item.source as SourceTag | null;
-                    const sourceTooltip = itemSource
-                      ? itemSource.origin === 'loot'
-                        ? tc('characterSheet.equipment.sourceLoot')
-                        : tc('characterSheet.equipment.sourceFrom', {
-                            name: getSourceDisplayName(itemSource, t),
-                          })
-                      : null;
-                    const SourceIcon = itemSource
-                      ? getGrantIcon(itemSource, itemDef?.type === 'pack' ? 'pack' : undefined)
-                      : null;
-                    return (
-                      <div
-                        key={item.id}
-                        className={`flex justify-between items-center py-2 px-2 rounded ${item.equipped ? 'bg-green-50 border border-green-200 dark:bg-green-950/20 dark:border-green-900' : 'bg-muted/50'}`}
-                      >
-                        <div>
-                          <div className="font-semibold text-foreground">
-                            {itemName}
-                            {detail}
-                          </div>
-                          <div className="text-muted-foreground">
-                            {tc('characterSheet.fields.qtyAndWeight', {
-                              qty: item.quantity,
-                              weight: itemDef?.type !== 'pack' ? (itemDef?.weight ?? 0) : 0,
-                            })}
-                          </div>
-                        </div>
-                        <div className="flex items-center gap-2">
-                          {item.equipped && <Check className="size-4 text-green-600" />}
-                          {SourceIcon && (
-                            <span title={sourceTooltip ?? undefined} className="inline-flex">
-                              <SourceIcon
-                                aria-label={sourceTooltip ?? undefined}
-                                className="size-5 text-muted-foreground shrink-0"
-                              />
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
-              </div>
-            )}
-
-            {/* Spells */}
-            {/* knownSpells is not yet rendered — no UI surface exists for it.
-                When leveled known-spell grants land, extend this guard to include
-                resolved.spellcasting.knownSpells.length > 0 as well. */}
-            {resolved?.spellcasting &&
-              (resolved.spellcasting.cantrips.length > 0 || resolved.spellcasting.alwaysPreparedSpells.length > 0) && (
-                <div className="bg-card border border-purple-200 rounded-lg p-6">
-                  <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.spells')}</h2>
-                  <div className="space-y-3">
-                    {resolved.spellcasting.cantrips.length > 0 && (
-                      <div>
-                        <div className="text-xs font-bold text-muted-foreground mb-2">
-                          {tc('characterSheet.sections.cantrips')}
-                        </div>
-                        <div className="space-y-1">
-                          {resolved.spellcasting.cantrips.map((cantrip, i) => (
-                            <div key={i} className="text-sm text-foreground">
-                              &bull; {cantrip}
-                            </div>
-                          ))}
-                        </div>
-                      </div>
-                    )}
-                    {resolved.spellcasting.alwaysPreparedSpells.length > 0 && (
-                      <div>
-                        <div className="text-xs font-bold text-muted-foreground mb-2">
-                          {tc('characterSheet.sections.alwaysPrepared')}
-                        </div>
-                        <div className="space-y-1">
-                          {resolved.spellcasting.alwaysPreparedSpells.map((id, i) => {
-                            const meta = getSpellDisplayMeta(id);
-                            return (
-                              <div key={i} className="text-sm text-foreground">
-                                &bull; {isSpellId(id) ? t(`spells.${id}.name`) : id}
-                                {meta && (
-                                  <span className="text-xs text-muted-foreground ml-2">
-                                    {`(lvl ${meta.level} ${meta.school})`}
-                                  </span>
-                                )}
-                              </div>
-                            );
-                          })}
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-
-            {/* Personality */}
-            {(character.personality_traits || character.ideals || character.bonds || character.flaws) && (
-              <div className="bg-card border rounded-lg p-6">
-                <SectionHeader
-                  title={tc('characterSheet.sections.personality')}
-                  onEdit={() => setEditSection('personality')}
-                />
-                <div className="space-y-3 text-xs">
-                  {character.personality_traits && (
-                    <div>
-                      <div className="font-semibold text-muted-foreground mb-1">
-                        {tc('characterSheet.personality.traits')}
-                      </div>
-                      <p className="text-foreground">{character.personality_traits}</p>
-                    </div>
-                  )}
-                  {character.ideals && (
-                    <div>
-                      <div className="font-semibold text-muted-foreground mb-1">
-                        {tc('characterSheet.personality.ideals')}
-                      </div>
-                      <p className="text-foreground">{character.ideals}</p>
-                    </div>
-                  )}
-                  {character.bonds && (
-                    <div>
-                      <div className="font-semibold text-muted-foreground mb-1">
-                        {tc('characterSheet.personality.bonds')}
-                      </div>
-                      <p className="text-foreground">{character.bonds}</p>
-                    </div>
-                  )}
-                  {character.flaws && (
-                    <div>
-                      <div className="font-semibold text-muted-foreground mb-1">
-                        {tc('characterSheet.personality.flaws')}
-                      </div>
-                      <p className="text-foreground">{character.flaws}</p>
-                    </div>
-                  )}
-                </div>
-              </div>
-            )}
+          {/* Right Column: Equipment, Spells & Personality */}
+          <div className="sheet-area-right">
+            {itemsData.length > 0 && <EquipmentPanel itemsData={itemsData} />}
+            {hasSpells && <SpellcastingPanel spellcasting={resolved.spellcasting!} />}
+            {hasPersonality && <PersonalityPanel character={character} onEdit={() => setEditSection('personality')} />}
           </div>
         </div>
 
-        {/* Full Width Backstory */}
-        {character.backstory && (
-          <div className="bg-card border rounded-lg p-6">
-            <SectionHeader title={tc('characterSheet.sections.backstory')} onEdit={() => setEditSection('backstory')} />
-            <p className="text-foreground text-sm leading-relaxed whitespace-pre-wrap">{character.backstory}</p>
-          </div>
-        )}
-
-        {character.appearance && (
-          <div className="bg-card border rounded-lg p-6 mt-6">
-            <SectionHeader
-              title={tc('characterSheet.sections.appearance')}
-              onEdit={() => setEditSection('appearance')}
-            />
-            <p className="text-foreground text-sm leading-relaxed whitespace-pre-wrap">{character.appearance}</p>
-          </div>
-        )}
+        {/* Full Width Backstory & Appearance */}
+        <BackstoryPanel
+          character={character}
+          onEditBackstory={() => setEditSection('backstory')}
+          onEditAppearance={() => setEditSection('appearance')}
+        />
       </div>
 
       {/* Edit Dialogs */}
@@ -853,66 +347,19 @@ function CharacterSheetInner({
         />
       )}
 
-      {/* Archive / Delete Confirmation */}
+      {/* Archive / Delete / Clone Confirmation */}
       {confirmAction && (
-        <Dialog
-          open
-          onOpenChange={(open) => {
-            if (!open) setConfirmAction(null);
-          }}
-        >
-          <DialogContent className="sm:max-w-md">
-            <DialogHeader>
-              <DialogTitle>
-                {confirmAction === 'archive'
-                  ? tc('characterSheet.actions.archiveTitle')
-                  : confirmAction === 'clone'
-                    ? tc('characterSheet.actions.cloneTitle')
-                    : tc('characterSheet.actions.deleteTitle')}
-              </DialogTitle>
-            </DialogHeader>
-            {confirmAction === 'clone' ? (
-              <div className="space-y-2">
-                <label htmlFor="clone-name" className="text-sm text-muted-foreground">
-                  {tc('characterSheet.actions.cloneNameLabel')}
-                </label>
-                <Input
-                  id="clone-name"
-                  value={cloneName}
-                  onChange={(e) => setCloneName(e.target.value)}
-                  onKeyDown={(e) => {
-                    if (e.key === 'Enter' && cloneName.trim()) handleClone();
-                  }}
-                />
-              </div>
-            ) : (
-              <p className="text-sm text-muted-foreground">
-                {confirmAction === 'archive'
-                  ? tc('characterSheet.actions.archiveConfirm', { name: character.name })
-                  : tc('characterSheet.actions.deleteConfirm', { name: character.name })}
-              </p>
-            )}
-            <DialogFooter>
-              <Button variant="outline" onClick={() => setConfirmAction(null)}>
-                {tc('buttons.cancel')}
-              </Button>
-              <Button
-                variant={confirmAction === 'delete' ? 'destructive' : 'default'}
-                onClick={
-                  confirmAction === 'archive' ? handleArchive : confirmAction === 'clone' ? handleClone : handleDelete
-                }
-                disabled={confirmAction === 'clone' && !cloneName.trim()}
-                pending={updateMutation.isPending || removeMutation.isPending || cloneMutation.isPending}
-              >
-                {confirmAction === 'archive'
-                  ? tc('buttons.archive')
-                  : confirmAction === 'clone'
-                    ? tc('buttons.clone')
-                    : tc('buttons.delete')}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+        <ConfirmActionDialog
+          action={confirmAction}
+          characterName={character.name}
+          cloneName={cloneName}
+          onCloneNameChange={setCloneName}
+          onConfirm={
+            confirmAction === 'archive' ? handleArchive : confirmAction === 'clone' ? handleClone : handleDelete
+          }
+          onClose={() => setConfirmAction(null)}
+          pending={updateMutation.isPending || removeMutation.isPending || cloneMutation.isPending}
+        />
       )}
     </div>
   );
@@ -981,197 +428,5 @@ export default function CharacterSheet() {
     >
       <CharacterSheetInner character={character} itemsData={itemsData} characterId={character.id} />
     </CharacterProvider>
-  );
-}
-
-// --- Edit Dialogs ---
-
-function EditHeaderDialog({
-  character,
-  onSave,
-  onClose,
-  saving,
-}: {
-  character: Character;
-  onSave: (updates: Partial<Character>) => void;
-  onClose: () => void;
-  saving: boolean;
-}) {
-  const { t: tc } = useTranslation('common');
-  const [form, setForm] = useState({
-    name: character.name,
-    player_name: character.player_name ?? '',
-    character_type: character.character_type,
-    gender: (character.gender ?? '') as DndGender | '',
-  });
-
-  const update = <K extends keyof typeof form>(key: K, value: (typeof form)[K]) =>
-    setForm((prev) => ({ ...prev, [key]: value }));
-
-  return (
-    <Dialog
-      open
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
-    >
-      <DialogContent className="sm:max-w-md">
-        <DialogHeader>
-          <DialogTitle>{tc('characterSheet.dialogs.editCharacterInfo')}</DialogTitle>
-        </DialogHeader>
-        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
-          <div className="space-y-2">
-            <Label htmlFor="char-name">{tc('characterSheet.fields.name')}</Label>
-            <Input id="char-name" value={form.name} onChange={(e) => update('name', e.target.value)} autoFocus />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="char-player">{tc('characterSheet.fields.player')}</Label>
-            <Input
-              id="char-player"
-              value={form.player_name}
-              onChange={(e) => update('player_name', e.target.value)}
-              placeholder={tc('characterSheet.hints.leaveEmptyForNpcs')}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label>{tc('characterSheet.fields.type')}</Label>
-            <Select value={form.character_type} onValueChange={(val) => update('character_type', val as 'pc' | 'npc')}>
-              <SelectTrigger className="w-full">
-                <SelectValue>{tc(`characterType.${form.character_type}`)}</SelectValue>
-              </SelectTrigger>
-              <SelectContent>
-                <SelectItem value="pc">{tc('characterType.pc')}</SelectItem>
-                <SelectItem value="npc">{tc('characterType.npc')}</SelectItem>
-              </SelectContent>
-            </Select>
-          </div>
-          <div className="space-y-2">
-            <Label>{tc('characterSheet.fields.gender')}</Label>
-            <GenderToggle value={form.gender} onChange={(g) => update('gender', g)} />
-          </div>
-        </div>
-        <ModalFooter
-          onSave={() =>
-            onSave({
-              ...form,
-              player_name: form.player_name || null,
-              gender: form.gender === 'male' || form.gender === 'female' ? form.gender : null,
-            })
-          }
-          onCancel={onClose}
-          saving={saving}
-        />
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function EditPersonalityDialog({
-  personality_traits,
-  ideals,
-  bonds,
-  flaws,
-  onSave,
-  onClose,
-  saving,
-}: {
-  personality_traits: string;
-  ideals: string;
-  bonds: string;
-  flaws: string;
-  onSave: (updates: { personality_traits: string; ideals: string; bonds: string; flaws: string }) => void;
-  onClose: () => void;
-  saving: boolean;
-}) {
-  const { t: tc } = useTranslation('common');
-  const [form, setForm] = useState({ personality_traits, ideals, bonds, flaws });
-
-  return (
-    <Dialog
-      open
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
-    >
-      <DialogContent className="sm:max-w-lg">
-        <DialogHeader>
-          <DialogTitle>{tc('characterSheet.dialogs.editPersonality')}</DialogTitle>
-        </DialogHeader>
-        <div className="space-y-4">
-          <div className="space-y-2">
-            <Label htmlFor="personality-traits">{tc('characterSheet.fields.personalityTraits')}</Label>
-            <Textarea
-              id="personality-traits"
-              value={form.personality_traits}
-              onChange={(e) => setForm((prev) => ({ ...prev, personality_traits: e.target.value }))}
-              rows={3}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="personality-ideals">{tc('characterSheet.personality.ideals')}</Label>
-            <Textarea
-              id="personality-ideals"
-              value={form.ideals}
-              onChange={(e) => setForm((prev) => ({ ...prev, ideals: e.target.value }))}
-              rows={2}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="personality-bonds">{tc('characterSheet.personality.bonds')}</Label>
-            <Textarea
-              id="personality-bonds"
-              value={form.bonds}
-              onChange={(e) => setForm((prev) => ({ ...prev, bonds: e.target.value }))}
-              rows={2}
-            />
-          </div>
-          <div className="space-y-2">
-            <Label htmlFor="personality-flaws">{tc('characterSheet.personality.flaws')}</Label>
-            <Textarea
-              id="personality-flaws"
-              value={form.flaws}
-              onChange={(e) => setForm((prev) => ({ ...prev, flaws: e.target.value }))}
-              rows={2}
-            />
-          </div>
-        </div>
-        <ModalFooter onSave={() => onSave(form)} onCancel={onClose} saving={saving} />
-      </DialogContent>
-    </Dialog>
-  );
-}
-
-function EditTextDialog({
-  title,
-  field,
-  value,
-  onSave,
-  onClose,
-  saving,
-}: {
-  title: string;
-  field: string;
-  value: string;
-  onSave: (updates: Record<string, string>) => void;
-  onClose: () => void;
-  saving: boolean;
-}) {
-  const [text, setText] = useState(value);
-
-  return (
-    <Dialog
-      open
-      onOpenChange={(open) => {
-        if (!open) onClose();
-      }}
-    >
-      <DialogContent className="sm:max-w-2xl">
-        <DialogHeader>
-          <DialogTitle>{title}</DialogTitle>
-        </DialogHeader>
-        <Textarea value={text} onChange={(e) => setText(e.target.value)} rows={10} autoFocus />
-        <ModalFooter onSave={() => onSave({ [field]: text })} onCancel={onClose} saving={saving} />
-      </DialogContent>
-    </Dialog>
   );
 }


### PR DESCRIPTION
Closes #45.

## What

Decomposes the 1177-line `CharacterSheet.tsx` monolith into composable panel components and applies a WotC-inspired responsive layout. **Pure presentational refactor — no behaviour change.**

### F.1 — Panel decomposition
New components under `src/components/character-sheet/`:
- `CharacterSheetHeader` — portrait, name, class/level/species/background/alignment/player/type/gender grid, origin-feat & lineage badges, action buttons (edit/clone/archive/delete), level controls
- `AbilityScoresPanel`, `SavingThrowsPanel`, `CombatPanel`, `FeaturesPanel`, `EquipmentPanel`, `SpellcastingPanel`, `PersonalityPanel`, `BackstoryPanel`
- Shared `SectionHeader`

Edit dialogs moved to `src/components/character-sheet/edit-dialogs/`: `EditHeaderDialog`, `EditPersonalityDialog`, `EditTextDialog`, `ConfirmActionDialog` (archive/delete/clone), and shared `ModalFooter`.

### F.2 — WotC-inspired CSS grid (main deliverable)
- `.sheet-grid` named-area grid in `src/index.css`: **stats** (left) / **combat** (center, wider) / **roleplay & gear** (right); collapses to a single column on mobile
- Ability "shield" boxes: large modifier with small score pill below
- Saving-throw proficiency dots (filled/unfilled)

### Preserved behaviour
Autosave (debounce + unmount flush), level controls, short/long rest, clone/archive/delete, conditions, hit-dice & spell-slot panels, portrait upload, pending choices, attacks, proficiencies, resource pools, weapon mastery, Heroic Inspiration/exhaustion (via existing ConditionsPanel), and all empty/error/stale states — unchanged.

## Testing
- `npm run typecheck` ✅
- `npm run lint` ✅ (`--max-warnings 0`)
- `npm run test` ✅ 2043 passed
- `npm run test:bdd` — character-sheet scenarios (view/edit-backstory/level-down) pass. 2 pre-existing failures (acolyte/sage origin feat) are unrelated to this PR and confirmed identical on `main` HEAD — tracked by #183.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
