### PR TITLE
fix(supabase): enable local storage so portrait bucket migration applies

### DIFF
--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -107,7 +107,7 @@ port = 54324
 # sender_name = "Admin"
 
 [storage]
-enabled = false
+enabled = true
 # The maximum file size allowed (e.g. "5MB", "500KB").
 file_size_limit = "50MiB"
 


### PR DESCRIPTION
## Problem

`npm run supabase:reset` aborts when applying `20260606000000_add_portrait_storage.sql`:

```
ERROR: relation "storage.buckets" does not exist (SQLSTATE 42P01)
```

The migration inserts into `storage.buckets` and adds RLS policies on `storage.objects`, but `supabase/config.toml` had `[storage] enabled = false`, so the local stack never provisioned the `storage` schema.

## Fix

Set `[storage] enabled = true` in `supabase/config.toml`. With storage enabled, the `storage.*` tables exist before migrations run.

## Verification

Re-ran `supabase start` from a worktree — `20260606000000_add_portrait_storage.sql` now applies cleanly. The bucket insert and policies succeed (the `NOTICE ... skipping` lines are just the harmless `drop policy if exists` running on a fresh DB).

🤖 Generated with [Claude Code](https://claude.com/claude-code)