### PR TITLE
feat(campaigns): order list by recent session activity, not updated_at

### DIFF
--- a/features/campaigns/steps/campaigns.steps.ts
+++ b/features/campaigns/steps/campaigns.steps.ts
@@ -205,17 +205,28 @@ Given('another campaign named {string} exists', function (this: DndWorld, name: 
   seedRow(this, makeCampaignRow({ name }));
 });
 
+// "Last played" seeds a session dated accordingly — the campaign list orders by the
+// `last_activity_at` computed field (most recent session date, falling back to
+// created_at), not by `updated_at`, so activity must be modeled as a real session.
+function seedPlayedSession(world: DndWorld, name: string, daysAgo: number): void {
+  const playedOn = new Date(Date.now() - daysAgo * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const row = makeCampaignRow({ name });
+  seedRow(world, row);
+  world.db.seed('sessions', [
+    ...world.db.rows('sessions'),
+    { id: `s-${row.id}`, campaign_id: row.id, session_number: 1, date: playedOn },
+  ]);
+}
+
 Given(
   'a campaign named {string} exists and was last played {int} weeks ago',
   function (this: DndWorld, name: string, weeks: number) {
-    const updatedAt = new Date(Date.now() - weeks * 7 * 24 * 60 * 60 * 1000).toISOString();
-    seedRow(this, makeCampaignRow({ name, updated_at: updatedAt }));
+    seedPlayedSession(this, name, weeks * 7);
   }
 );
 
 Given('a campaign named {string} exists and was last played yesterday', function (this: DndWorld, name: string) {
-  const updatedAt = new Date(Date.now() - 1 * 24 * 60 * 60 * 1000).toISOString();
-  seedRow(this, makeCampaignRow({ name, updated_at: updatedAt }));
+  seedPlayedSession(this, name, 1);
 });
 
 Given('a campaign named {string} exists with no theme set', function (this: DndWorld, name: string) {

--- a/features/steps/support/stateful-supabase.ts
+++ b/features/steps/support/stateful-supabase.ts
@@ -239,9 +239,26 @@ export function createStatefulSupabase(): { supabase: unknown; db: StatefulDb } 
         let result = matched;
         if (this.s.orderBy) {
           const { col, ascending } = this.s.orderBy;
+          // `last_activity_at` is a PostgREST computed field on campaigns (see migration
+          // 20260607000000): most recent session date, falling back to created_at. Mirror
+          // it here by reading the related sessions from the store so list-ordering tests
+          // exercise the real sort key rather than a missing column.
+          const valueFor = (r: Row): string => {
+            if (col === 'last_activity_at') {
+              const dates = store
+                .get('sessions')
+                .filter((s) => s.campaign_id === r.id)
+                .map((s) => s.date as string | null)
+                .filter((d): d is string => d != null)
+                .map((d) => new Date(d).toISOString());
+              if (dates.length > 0) return dates.reduce((max, d) => (d > max ? d : max));
+              return new Date(r.created_at as string).toISOString();
+            }
+            return r[col] as string;
+          };
           result = [...result].sort((a, b) => {
-            const av = a[col] as string;
-            const bv = b[col] as string;
+            const av = valueFor(a);
+            const bv = valueFor(b);
             const cmp = av < bv ? -1 : av > bv ? 1 : 0;
             return ascending ? cmp : -cmp;
           });

--- a/src/hooks/useCampaigns.test.ts
+++ b/src/hooks/useCampaigns.test.ts
@@ -11,8 +11,25 @@ import {
 
 vi.mock('@/lib/supabase', () => import('@/test/mocks/supabase'));
 
+import { createElement, type ReactNode } from 'react';
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query';
+import { ThemeProvider } from '@/components/ThemeProvider';
 import { useCampaigns, useCampaign, useCampaignMutations } from '@/hooks/useCampaigns';
-import type { Campaign } from '@/types/database';
+import type { Campaign, CampaignSummary } from '@/types/database';
+import { CAMPAIGN_SUMMARY_COLS } from '@/lib/query-columns';
+
+// Wrapper that exposes its QueryClient so tests can seed and inspect the cache
+// (the shared createWrapper() keeps its client private).
+function wrapperWithClient(): { queryClient: QueryClient; Wrapper: (props: { children: ReactNode }) => ReactNode } {
+  // gcTime: Infinity keeps observer-less cache entries (seeded directly via
+  // setQueryData) alive so the mutation's in-place patches are observable.
+  const queryClient = new QueryClient({
+    defaultOptions: { queries: { retry: false, gcTime: Infinity }, mutations: { retry: false } },
+  });
+  const Wrapper = ({ children }: { children: ReactNode }): ReactNode =>
+    createElement(ThemeProvider, null, createElement(QueryClientProvider, { client: queryClient }, children));
+  return { queryClient, Wrapper };
+}
 
 const baseCampaign: Campaign = {
   id: 'camp-1',
@@ -40,6 +57,22 @@ describeListQuery(
   baseCampaign,
   null
 );
+
+describe('useCampaigns ordering', () => {
+  it('orders by the last_activity_at computed field, descending', async () => {
+    // Ordering is done server-side by the PostgREST `last_activity_at` computed
+    // field (most recent session date, falling back to created_at), decoupling list
+    // order from `updated_at` so theme/metadata edits don't reorder campaigns.
+    mockQueryResult.data = [baseCampaign];
+
+    const { result } = renderHook(() => useCampaigns(), { wrapper: createWrapper() });
+
+    await waitFor(() => expect(result.current.isSuccess).toBe(true));
+
+    expect(supabase.select).toHaveBeenCalledWith(CAMPAIGN_SUMMARY_COLS);
+    expect(supabase.order).toHaveBeenCalledWith('last_activity_at', { ascending: false });
+  });
+});
 
 describeSingleQuery(
   'useCampaign',
@@ -90,6 +123,44 @@ describe('useCampaignMutations', () => {
     await waitFor(() => expect(result.current.update.isSuccess).toBe(true));
     expect(supabase.update).toHaveBeenCalledWith(expect.objectContaining({ name: 'Updated Name' }));
     expect(supabase.eq).toHaveBeenCalledWith('id', 'camp-1');
+  });
+
+  it('update patches the list and detail caches in place rather than refetching', async () => {
+    const { queryClient, Wrapper } = wrapperWithClient();
+    const campA: Campaign = { ...baseCampaign, id: 'camp-1', slug: 'a', theme: null };
+    const campB: Campaign = { ...baseCampaign, id: 'camp-2', slug: 'b', theme: 'sylvan' };
+    // Seed a two-item list. A refetch would replace it with mockQueryResult.data
+    // (a single object), so an intact [A, B] proves the cache was patched in place.
+    queryClient.setQueryData(['campaigns'], [campA, campB]);
+    queryClient.setQueryData(['campaign', 'a'], campA);
+
+    mockQueryResult.data = { ...campA, theme: 'arcane' };
+
+    const { result } = renderHook(() => useCampaignMutations(), { wrapper: Wrapper });
+    result.current.update.mutate({ id: 'camp-1', theme: 'arcane' });
+    await waitFor(() => expect(result.current.update.isSuccess).toBe(true));
+
+    const list = queryClient.getQueryData<CampaignSummary[]>(['campaigns'])!;
+    expect(list.map((c) => c.id)).toEqual(['camp-1', 'camp-2']); // order preserved, B untouched
+    expect(list[0].theme).toBe('arcane'); // matching row patched
+    expect('allowed_source_books' in list[0]).toBe(false); // projected down to the summary shape
+    expect(queryClient.getQueryData<Campaign>(['campaign', 'a'])!.theme).toBe('arcane');
+  });
+
+  it('update on rename refreshes the old-slug detail cache without a round-trip', async () => {
+    const { queryClient, Wrapper } = wrapperWithClient();
+    const original: Campaign = { ...baseCampaign, id: 'camp-1', slug: 'old-name', name: 'Old Name' };
+    queryClient.setQueryData(['campaign', 'old-name'], original);
+
+    mockQueryResult.data = { ...original, slug: 'new-name', name: 'New Name', previous_slugs: ['old-name'] };
+
+    const { result } = renderHook(() => useCampaignMutations(), { wrapper: Wrapper });
+    result.current.update.mutate({ id: 'camp-1', name: 'New Name' });
+    await waitFor(() => expect(result.current.update.isSuccess).toBe(true));
+
+    // onMutate captured 'old-name' by id; onSuccess wrote the fresh row to both keys.
+    expect(queryClient.getQueryData<Campaign>(['campaign', 'new-name'])!.name).toBe('New Name');
+    expect(queryClient.getQueryData<Campaign>(['campaign', 'old-name'])!.name).toBe('New Name');
   });
 
   it('archive sets archived_at to an ISO string', async () => {

--- a/src/hooks/useCampaigns.ts
+++ b/src/hooks/useCampaigns.ts
@@ -10,11 +10,15 @@ export function useCampaigns() {
   return useQuery({
     queryKey: ['campaigns'],
     queryFn: async () => {
+      // Order by the `last_activity_at` computed field (most recent session date,
+      // falling back to created_at) rather than `updated_at`, so non-activity edits
+      // like theme changes don't reorder the list. The field is a PostgREST computed
+      // column defined in migration 20260607000000; ordering by it needs no select.
       const { data, error } = await supabase
         .from('campaigns')
         .select(CAMPAIGN_SUMMARY_COLS)
         .is('archived_at', null)
-        .order('updated_at', { ascending: false });
+        .order('last_activity_at', { ascending: false });
       if (error) throw error;
       return (data || []) as unknown as CampaignSummary[];
     },
@@ -40,6 +44,23 @@ export function useCampaign(slug: string | undefined) {
 
 // --- Mutations ---
 
+/** Project a full campaign row down to the summary shape held in the list cache. */
+function toCampaignSummary(c: Campaign): CampaignSummary {
+  return {
+    id: c.id,
+    slug: c.slug,
+    previous_slugs: c.previous_slugs,
+    name: c.name,
+    description: c.description,
+    setting: c.setting,
+    status: c.status,
+    theme: c.theme,
+    created_at: c.created_at,
+    updated_at: c.updated_at,
+    archived_at: c.archived_at,
+  };
+}
+
 export function useCampaignMutations() {
   const queryClient = useQueryClient();
 
@@ -64,10 +85,29 @@ export function useCampaignMutations() {
       if (error) throw error;
       return data as Campaign;
     },
-    onSuccess: (data) => {
-      invalidate();
-      queryClient.invalidateQueries({ queryKey: ['campaign'] });
+    // Capture the campaign's slug before the write so onSuccess can tell whether a
+    // rename changed it (a rename moves the slug; the page may still be keyed on the
+    // old one, reachable via previous_slugs).
+    onMutate: ({ id }) => {
+      const entry = queryClient
+        .getQueriesData<Campaign>({ queryKey: ['campaign'] })
+        .find(([, cached]) => cached?.id === id);
+      return { previousSlug: entry?.[1]?.slug };
+    },
+    onSuccess: (data, _variables, context) => {
+      // The PATCH returns the full updated row, so refresh the caches in place rather
+      // than refetching. List order is keyed on the `last_activity_at` computed field,
+      // not `updated_at`, so a metadata edit never reorders the list — only its fields.
       queryClient.setQueryData(['campaign', data.slug], data);
+      queryClient.setQueryData<CampaignSummary[]>(['campaigns'], (old) =>
+        old?.map((c) => (c.id === data.id ? toCampaignSummary(data) : c))
+      );
+      // On rename, also refresh the old-slug detail entry so a page still mounted on it
+      // shows the new data without a round-trip (the old slug now resolves to this row).
+      const { previousSlug } = context ?? {};
+      if (previousSlug && previousSlug !== data.slug) {
+        queryClient.setQueryData(['campaign', previousSlug], data);
+      }
     },
   });
 

--- a/src/types/supabase.ts
+++ b/src/types/supabase.ts
@@ -201,8 +201,6 @@ export type Database = {
           character_type: string
           class: string | null
           conditions: string[]
-          hit_dice_used: Json
-          spell_slots_used: Json
           created_at: string
           exhaustion_level: number
           eye_color: string | null
@@ -211,6 +209,7 @@ export type Database = {
           hair_color: string | null
           height: string | null
           heroic_inspiration: boolean
+          hit_dice_used: Json
           hit_points_max: number | null
           id: string
           ideals: string | null
@@ -228,6 +227,7 @@ export type Database = {
           slug: string
           species: string | null
           speed: number | null
+          spell_slots_used: Json
           status: string
           subclass: string | null
           updated_at: string
@@ -246,8 +246,6 @@ export type Database = {
           character_type: string
           class?: string | null
           conditions?: string[]
-          hit_dice_used?: Json
-          spell_slots_used?: Json
           created_at?: string
           exhaustion_level?: number
           eye_color?: string | null
@@ -256,6 +254,7 @@ export type Database = {
           hair_color?: string | null
           height?: string | null
           heroic_inspiration?: boolean
+          hit_dice_used?: Json
           hit_points_max?: number | null
           id?: string
           ideals?: string | null
@@ -273,6 +272,7 @@ export type Database = {
           slug?: string
           species?: string | null
           speed?: number | null
+          spell_slots_used?: Json
           status?: string
           subclass?: string | null
           updated_at?: string
@@ -291,8 +291,6 @@ export type Database = {
           character_type?: string
           class?: string | null
           conditions?: string[]
-          hit_dice_used?: Json
-          spell_slots_used?: Json
           created_at?: string
           exhaustion_level?: number
           eye_color?: string | null
@@ -301,6 +299,7 @@ export type Database = {
           hair_color?: string | null
           height?: string | null
           heroic_inspiration?: boolean
+          hit_dice_used?: Json
           hit_points_max?: number | null
           id?: string
           ideals?: string | null
@@ -318,6 +317,7 @@ export type Database = {
           slug?: string
           species?: string | null
           speed?: number | null
+          spell_slots_used?: Json
           status?: string
           subclass?: string | null
           updated_at?: string
@@ -498,6 +498,10 @@ export type Database = {
     Functions: {
       generate_slug: {
         Args: { entity_id: string; entity_name: string }
+        Returns: string
+      }
+      last_activity_at: {
+        Args: { c: Database["public"]["Tables"]["campaigns"]["Row"] }
         Returns: string
       }
     }

--- a/supabase/migrations/20260607000000_add_campaign_last_activity_at.sql
+++ b/supabase/migrations/20260607000000_add_campaign_last_activity_at.sql
@@ -1,0 +1,26 @@
+-- Migration: campaign last_activity_at computed field
+-- Adds a PostgREST computed field on `campaigns` returning the most recent recorded
+-- session date, falling back to the campaign's created_at when it has no dated
+-- sessions. This lets the campaign list sort by real play activity instead of
+-- `updated_at`, so non-activity edits (e.g. changing the theme) no longer reorder it.
+--
+-- SECURITY INVOKER (the default): the function runs as the calling role, so the
+-- permissive per-table RLS policies apply to its `sessions` read just like a direct
+-- query would. Follows the search_path hardening convention — empty search_path with
+-- schema-qualified references; see 20260602000000_harden_function_search_path.sql.
+
+CREATE OR REPLACE FUNCTION public.last_activity_at(c public.campaigns)
+RETURNS timestamptz
+LANGUAGE sql
+STABLE
+SET search_path = ''
+AS $$
+  SELECT coalesce(max(s.date)::timestamptz, c.created_at)
+  FROM public.sessions s
+  WHERE s.campaign_id = c.id;
+$$;
+
+-- PostgREST executes computed fields as the request role; grant execute explicitly
+-- (mirrors the per-table GRANTs in the initial schema) rather than relying on the
+-- default PUBLIC execute privilege.
+GRANT EXECUTE ON FUNCTION public.last_activity_at(public.campaigns) TO anon, authenticated;


### PR DESCRIPTION
## Why

Switching a campaign's theme reordered the campaign list, because the list was sorted by `updated_at` and a theme write bumps it. More broadly, the list order was coupled to any metadata edit, and each campaign update fired redundant refetches (a theme change made 6 network calls — PATCH + preflight, plus two GET refetches each with their own preflight).

## What changed

**Server-side ordering by real play activity**
- New migration `20260607000000_add_campaign_last_activity_at.sql` adds a PostgREST **computed field** `last_activity_at(campaigns)` = `coalesce(max(session.date), created_at)`. `SECURITY INVOKER`, `SET search_path = ''`, schema-qualified, explicit `GRANT EXECUTE` — matches the existing function-hardening convention.
- `useCampaigns()` now orders by `last_activity_at` (descending) server-side. Non-activity edits (theme, name, etc.) no longer reorder the list.
- `src/types/supabase.ts` regenerated.

**In-place cache updates on campaign update (no refetch)**
- `useCampaignMutations().update` now patches the `['campaigns']` list and `['campaign', slug]` detail caches from the row the PATCH already returns, instead of invalidating + refetching.
- `onMutate` captures the pre-update slug so a **rename** stays correct — the fresh row is written to both the old- and new-slug keys (the old slug still resolves via `previous_slugs`), so a page mounted on the old slug updates without a round-trip.
- `create`/`archive` keep their list invalidation (membership genuinely changes there).
- **A theme change drops from 6 network calls to 2.**

**BDD harness kept faithful**
- The "last played N ago" steps now seed a real session on that date (was bumping `updated_at`), and the stateful Supabase mock computes the `last_activity_at` sort key from the sessions store.

## Verification

- typecheck (app + `features/`) ✅ · lint ✅
- **2085 unit tests** ✅ (new ordering + cache-update tests)
- **80 BDD scenarios / 504 steps** ✅
- Migration applied to local DB and verified via REST: ordering works with/without selecting the field; a future-dated session reorders correctly and reverts on cleanup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
