### PR TITLE
Fix character-builder UAT issues + target 2024 WotC PDF export

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -19,18 +19,18 @@ missing: 0 · stub: 0 · partial: 2 · complete: 10 · golden-verified: 0/12
 
 | id | status | detail | golden |
 | --- | --- | --- | --- |
-| barbarian | complete | 20 levels, subclass@3, ASI@4/8/12/16/19 | — |
-| bard | complete | 20 levels, subclass@3, ASI@4/8/12/16/19 | — |
-| cleric | complete | 20 levels, subclass@3, ASI@4/8/12/16/19 | — |
-| druid | complete | 20 levels, subclass@3, ASI@4/8/12/16/19 | — |
-| fighter | partial | missing ASI at level(s) 12, 16, 19 | — |
-| monk | complete | 20 levels, subclass@3, ASI@4/8/12/16/19 | — |
-| paladin | complete | 20 levels, subclass@3, ASI@4/8/12/16/19 | — |
-| ranger | complete | 20 levels, subclass@3, ASI@4/8/12/16/19 | — |
-| rogue | partial | missing ASI at level(s) 12, 16, 19 | — |
-| sorcerer | complete | 20 levels, subclass@3, ASI@4/8/12/16/19 | — |
-| warlock | complete | 20 levels, subclass@3, ASI@4/8/12/16/19 | — |
-| wizard | complete | 20 levels, subclass@3, ASI@4/8/12/16/19 | — |
+| barbarian | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| bard | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| cleric | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| druid | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| fighter | partial | missing ASI at level(s) 12, 16; missing ASI or Epic Boon at level 19 | — |
+| monk | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| paladin | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| ranger | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| rogue | partial | missing ASI at level(s) 12, 16; missing ASI or Epic Boon at level 19 | — |
+| sorcerer | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| warlock | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| wizard | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
 
 ### subclasses — 3/48 structurally complete (6%)
 

--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -20,17 +20,17 @@ missing: 0 · stub: 0 · partial: 2 · complete: 10 · golden-verified: 0/12
 | id | status | detail | golden |
 | --- | --- | --- | --- |
 | barbarian | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
-| bard | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
-| cleric | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
-| druid | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| bard | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
+| cleric | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
+| druid | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
 | fighter | partial | missing ASI at level(s) 12, 16; missing ASI or Epic Boon at level 19 | — |
-| monk | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
-| paladin | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
-| ranger | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| monk | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
+| paladin | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
+| ranger | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
 | rogue | partial | missing ASI at level(s) 12, 16; missing ASI or Epic Boon at level 19 | — |
-| sorcerer | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
-| warlock | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
-| wizard | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| sorcerer | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
+| warlock | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
+| wizard | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
 
 ### subclasses — 3/48 structurally complete (6%)
 

--- a/public/assets/README.md
+++ b/public/assets/README.md
@@ -6,8 +6,8 @@ the Coast character sheet is copyrighted and cannot be redistributed here.
 
 ## To enable PDF export
 
-1. Obtain a **form-fillable** D&D character-sheet PDF (e.g. the official WotC fillable
-   sheet, or a community form such as MorePurpleMoreBetter's).
+1. Obtain the **official 2024 WotC form-fillable** character sheet (© 2024 Wizards of the
+   Coast, the one distributed with the 2024 Player's Handbook).
 2. Save it in this folder as:
 
    ```
@@ -18,10 +18,18 @@ the Coast character sheet is copyrighted and cannot be redistributed here.
    pipeline fetches (`src/lib/pdf-export.ts`).
 
 3. The field-name binding in `src/lib/pdf-field-map.ts` (`TEXT_FIELD_NAMES` /
-   `CHECK_FIELD_NAMES`) targets the **2014 WotC fillable form** field names. No stable
-   2024 fillable form with documented field names is publicly distributed, so the 2024
-   concepts that the 2014 sheet has no field for (Heroic Inspiration, Exhaustion level,
-   Weapon Mastery, Origin Feat) are folded into the **Features & Traits** text block.
+   `CHECK_FIELD_NAMES`) targets the **official 2024 WotC sheet**. That sheet ships with
+   auto-generated, semantically-opaque field names (`Text1`, `Check Box37`, …), so the
+   binding values look meaningless on their own — each line carries a `// → label` comment
+   recording which cell it fills. The map covers the page-1 statblock (identity, abilities,
+   saves, skills, combat, attacks, class features / species traits / feats, proficiencies)
+   and the page-2 header (spellcasting stats, appearance, backstory, languages, equipment,
+   alignment). 2024 concepts with no dedicated field (Exhaustion, Weapon Mastery) are folded
+   into the Class Features block.
+
+> The map is keyed to the official 2024 sheet's exact field names. A _different_ fillable
+> form (2014 WotC, MPMB, other community sheets) uses a different naming scheme and will not
+> fill — see the next section.
 
 ## If the exported PDF comes out blank
 

--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -314,6 +314,44 @@ describe('ChoicePicker feat-choice', () => {
     fireEvent.click(screen.getByRole('button', { name: /clear/i }));
     expect(onClear).toHaveBeenCalledWith(FEAT_CHOICE.choiceKey);
   });
+
+  it('disables a feat already granted elsewhere (unavailableFeats) and flags it', () => {
+    const unavailable = new Set(['lucky'] as unknown as import('@/lib/dnd-helpers').FeatId[]);
+    render(
+      <ChoicePicker
+        choice={FEAT_CHOICE}
+        currentDecision={undefined}
+        onDecide={vi.fn()}
+        onClear={vi.fn()}
+        unavailableFeats={unavailable}
+      />
+    );
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios[0].disabled).toBe(false); // alert
+    expect(radios[1].disabled).toBe(true); // lucky — granted elsewhere
+    expect(radios[2].disabled).toBe(false); // skilled
+    expect(screen.getByText('alreadyGranted')).toBeInTheDocument();
+  });
+
+  it('does NOT disable the feat that is the current selection even if in unavailableFeats', () => {
+    const unavailable = new Set(['lucky'] as unknown as import('@/lib/dnd-helpers').FeatId[]);
+    const currentDecision: ChoiceDecision = {
+      type: 'feat-choice',
+      featId: 'lucky' as import('@/lib/dnd-helpers').FeatId,
+    };
+    render(
+      <ChoicePicker
+        choice={FEAT_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        onClear={vi.fn()}
+        unavailableFeats={unavailable}
+      />
+    );
+    const radios = screen.getAllByRole('radio') as HTMLInputElement[];
+    expect(radios[1].checked).toBe(true);
+    expect(radios[1].disabled).toBe(false);
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -36,6 +36,12 @@ interface ChoicePickerProps {
    * (no-data-loss union). Falls back to the full FEAT_SOURCES when undefined.
    */
   readonly allowedFeats?: readonly FeatSource[];
+  /**
+   * Feat ids the character already has from another source and that cannot be
+   * taken again (non-repeatable). For feat-choice prompts these are shown but
+   * disabled, so e.g. a Human can't pick a feat their background already granted.
+   */
+  readonly unavailableFeats?: ReadonlySet<FeatId>;
 }
 
 const ALL_SKILL_IDS: readonly SkillId[] = DND_SKILLS.map((s) => s.id);
@@ -49,7 +55,14 @@ function isLanguageId(id: string): id is LanguageId {
   return (ALL_LANGUAGE_IDS as readonly string[]).includes(id);
 }
 
-export function ChoicePicker({ choice, currentDecision, onDecide, onClear, allowedFeats }: ChoicePickerProps) {
+export function ChoicePicker({
+  choice,
+  currentDecision,
+  onDecide,
+  onClear,
+  allowedFeats,
+  unavailableFeats,
+}: ChoicePickerProps) {
   const { t } = useTranslation('gamedata');
   const { t: tc } = useTranslation('common');
 
@@ -265,6 +278,9 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear, allow
             const label = t(nameKey, { defaultValue: featId });
             const description = t(descKey, { defaultValue: '' });
             const isDisabledBook = featId === currentFeatId && !basePool.includes(featId);
+            // Already granted elsewhere and non-repeatable → show but block re-selection
+            // (never blocks the current pick, so a valid selection stays changeable).
+            const isAlreadyGranted = (unavailableFeats?.has(featId) ?? false) && featId !== currentFeatId;
             return (
               <div
                 key={featId}
@@ -275,14 +291,23 @@ export function ChoicePicker({ choice, currentDecision, onDecide, onClear, allow
                   id={radioId}
                   name={`choice-feat-${choice.choiceKey}`}
                   checked={currentFeatId === featId}
+                  disabled={isAlreadyGranted}
                   onChange={() => onDecide(choice.choiceKey, { type: 'feat-choice', featId })}
-                  className="mt-1 size-4 text-primary"
+                  className="mt-1 size-4 text-primary disabled:opacity-50"
                 />
-                <Label htmlFor={radioId} className="flex-1 cursor-pointer">
+                <Label
+                  htmlFor={radioId}
+                  className={`flex-1 ${isAlreadyGranted ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}`}
+                >
                   <span className="font-medium">{label}</span>
                   {isDisabledBook && (
                     <Badge variant="destructive" className="text-xs ml-2">
                       {tc('characterBuilder.hints.disabledSourceBook')}
+                    </Badge>
+                  )}
+                  {isAlreadyGranted && (
+                    <Badge variant="secondary" className="text-xs ml-2">
+                      {tc('characterBuilder.hints.alreadyGranted')}
                     </Badge>
                   )}
                   {description ? (

--- a/src/components/character-builder/ClassStep.test.tsx
+++ b/src/components/character-builder/ClassStep.test.tsx
@@ -340,7 +340,9 @@ describe('ClassStep', () => {
     );
   });
 
-  it('hides empty-state when only L1 class features are present', () => {
+  it('shows the no-choices notice when only L1 class features are present (no actionable choices)', () => {
+    // Display-only features (e.g. Barbarian Rage / Unarmored Defense) are not choices, so the
+    // soft notice still surfaces to tell the user there's nothing to decide on this step.
     mockContextValue.resolved = {
       spellcasting: null,
       features: rogueL1Features(),
@@ -349,7 +351,10 @@ describe('ClassStep', () => {
 
     render(<ClassStep />);
 
-    expect(screen.queryByText('noClassChoices')).toBeNull();
+    // The features still render above the notice...
+    expect(screen.getAllByText('name').length).toBeGreaterThan(0);
+    // ...and the notice is shown because there are no actionable choices.
+    expect(screen.getByText('noClassChoices')).toBeTruthy();
   });
 
   it('renders a feature-choice picker for class-origin pending choices', () => {

--- a/src/components/character-builder/ClassStep.tsx
+++ b/src/components/character-builder/ClassStep.tsx
@@ -1,4 +1,5 @@
 import { Badge } from '@/components/ui/badge';
+import { InfoIcon } from 'lucide-react';
 import { Label } from '@/components/ui/label';
 import { SubclassPicker } from '@/components/character-sheet/SubclassPicker';
 import { ChoicePicker } from '@/components/character-builder/ChoicePicker';
@@ -87,13 +88,11 @@ export function ClassStep() {
   }, [resolved]);
   const hasLevelOneFeatures = levelOneClassFeatures.length > 0;
 
-  const hasAnyContent =
-    hasFightingStyles ||
-    hasSpellcasting ||
-    hasLevelOneFeatures ||
-    hasSubclassChoices ||
-    hasFeatureChoices ||
-    hasSpellChoices;
+  // Interactive choices the user must act on (excludes display-only content like the
+  // spellcasting summary and granted level-1 features). When none are present we surface a
+  // soft notice so the step doesn't look broken — e.g. a level-1 Barbarian sees Rage and
+  // Unarmored Defense but has no class choices to make here.
+  const hasAnyChoices = hasFightingStyles || hasSubclassChoices || hasFeatureChoices || hasSpellChoices;
 
   return (
     <div className="space-y-6">
@@ -261,8 +260,14 @@ export function ClassStep() {
         </div>
       )}
 
-      {!hasAnyContent && (
-        <p className="text-muted-foreground text-sm">{tc('characterBuilder.classFeatures.noClassChoices')}</p>
+      {resolved && !hasAnyChoices && (
+        <div
+          className="flex items-start gap-2 p-3 rounded-md border border-border bg-muted/30 text-sm text-muted-foreground"
+          role="note"
+        >
+          <InfoIcon aria-hidden className="size-4 mt-0.5 shrink-0" />
+          <span>{tc('characterBuilder.classFeatures.noClassChoices')}</span>
+        </div>
       )}
     </div>
   );

--- a/src/components/character-builder/OriginStep.test.tsx
+++ b/src/components/character-builder/OriginStep.test.tsx
@@ -503,6 +503,41 @@ describe('OriginStep', () => {
     expect(featRadios.length).toBeGreaterThan(0);
   });
 
+  it('shows the source label and locks out a feat the background already granted', () => {
+    // Human origin feat-choice (Savage Attacker is in the pool) + Soldier background that
+    // already grants Savage Attacker → that radio must be disabled, and a "from <species>"
+    // source label must render above the picker.
+    mockBundles = [
+      {
+        source: { origin: 'species', id: 'human' as const },
+        grants: [
+          {
+            type: 'feat-choice' as const,
+            key: 'feat-choice:species:human:0' as ChoiceKey,
+            from: ['alert', 'savage-attacker'] as unknown as readonly import('@/lib/dnd-helpers').FeatId[],
+            category: 'origin' as const,
+          },
+        ],
+      },
+      {
+        source: { origin: 'background', id: 'soldier' as const },
+        grants: [{ type: 'feat' as const, featId: 'savage-attacker' as import('@/lib/dnd-helpers').FeatId }],
+      },
+    ] as readonly GrantBundle[];
+
+    render(<OriginStep />);
+
+    const featRadios = (screen.getAllByRole('radio') as HTMLInputElement[]).filter((r) =>
+      r.name?.startsWith('choice-feat-')
+    );
+    // Pool order ['alert', 'savage-attacker'] → alert enabled, savage-attacker disabled.
+    expect(featRadios).toHaveLength(2);
+    expect(featRadios[0].disabled).toBe(false);
+    expect(featRadios[1].disabled).toBe(true);
+    // Source attribution label is rendered (interpolated "from {{source}}").
+    expect(screen.getByText('fromSource')).toBeInTheDocument();
+  });
+
   it('does not render a species-origin feat-choice picker when no such pending choice exists', () => {
     mockResolved = {
       ...makeDefaultResolved(),

--- a/src/components/character-builder/OriginStep.test.tsx
+++ b/src/components/character-builder/OriginStep.test.tsx
@@ -264,16 +264,15 @@ describe('OriginStep', () => {
     expect(screen.queryByText('originFeatTitle')).toBeNull();
   });
 
-  it('renders ChoicePicker for tool-choice when background grants a tool proficiency choice', () => {
+  it('does not render a tool-choice picker (tool picks are owned by the Proficiencies step)', () => {
     mockCharacter = buildSeedCharacter({ background: 'acolyte' });
     mockBundles = [makeAcolyteAsiBundle(), makeAcolyteToolChoiceBundle()];
 
     render(<OriginStep />);
 
-    expect(screen.getByText('toolProficiencyTitle')).toBeTruthy();
-    // ChoicePicker renders checkboxes for each tool
-    const checkboxes = screen.getAllByRole('checkbox');
-    expect(checkboxes.length).toBeGreaterThan(0);
+    // Tool proficiency choices were duplicated on both Origin and Proficiencies; they now live
+    // only in the Proficiencies (Details) step.
+    expect(screen.queryByText('toolProficiencyTitle')).toBeNull();
   });
 
   it('does not render a language-choice picker (language picks are unified in DetailsStep)', () => {
@@ -519,18 +518,21 @@ describe('OriginStep', () => {
 
   it('fires makeChoice with the correct choiceKey and feat-choice decision when a feat radio is changed', () => {
     const featChoiceKey = createChoiceKey('feat-choice', 'species', 'human', 0);
-    mockResolved = {
-      ...makeDefaultResolved(),
-      pendingChoices: [
-        {
-          type: 'feat-choice' as const,
-          choiceKey: featChoiceKey,
-          source: { origin: 'species', id: 'human' } as const,
-          from: ['alert'] as unknown as readonly import('@/lib/dnd-helpers').FeatId[],
-          category: 'origin' as const,
-        },
-      ],
-    };
+    // The picker is now sourced from grant bundles (so it persists after selection), not from
+    // resolved.pendingChoices — provide the species feat-choice grant in the bundles.
+    mockBundles = [
+      {
+        source: { origin: 'species', id: 'human' as const },
+        grants: [
+          {
+            type: 'feat-choice' as const,
+            key: featChoiceKey,
+            from: ['alert'] as unknown as readonly import('@/lib/dnd-helpers').FeatId[],
+            category: 'origin' as const,
+          },
+        ],
+      },
+    ] as readonly GrantBundle[];
 
     render(<OriginStep />);
 

--- a/src/components/character-builder/OriginStep.tsx
+++ b/src/components/character-builder/OriginStep.tsx
@@ -2,7 +2,8 @@ import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
 import { useCharacterContext } from '@/hooks/useCharacterContext';
 import { useGameData } from '@/hooks/useGameData';
-import { type SpeciesId } from '@/lib/dnd-helpers';
+import { type FeatId, type SpeciesId } from '@/lib/dnd-helpers';
+import { FEAT_SOURCES } from '@/lib/sources';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
 import { getChoiceSourceName } from '@/lib/character-builder/choice-source-name';
 import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
@@ -61,6 +62,26 @@ export function OriginStep() {
       }));
   }, [bundles]);
 
+  // Feats the character already has from any source AND that can't be taken again, so the
+  // species origin-feat picker can lock them out (e.g. Soldier grants Savage Attacker, which
+  // a Human must not also pick). Repeatable feats (magic-initiate, etc.) stay selectable.
+  const unavailableFeats = useMemo<ReadonlySet<FeatId>>(() => {
+    const repeatable = new Set(FEAT_SOURCES.filter((f) => f.repeatable).map((f) => f.id));
+    const granted = new Set<FeatId>();
+    for (const bundle of bundles) {
+      for (const grant of bundle.grants) {
+        if (grant.type === 'feat' && !repeatable.has(grant.featId)) granted.add(grant.featId);
+      }
+    }
+    for (const featId of build?.feats ?? []) {
+      if (!repeatable.has(featId)) granted.add(featId);
+    }
+    for (const decision of Object.values(build?.choices ?? {})) {
+      if (decision?.type === 'feat-choice' && !repeatable.has(decision.featId)) granted.add(decision.featId);
+    }
+    return granted;
+  }, [bundles, build]);
+
   const backgroundName = background
     ? t(`backgrounds.${background}` as `backgrounds.${string}`, { defaultValue: background })
     : null;
@@ -83,12 +104,18 @@ export function OriginStep() {
         <div className="space-y-4">
           {speciesFeatChoices.map((choice) => (
             <div key={choice.choiceKey}>
+              <p className="text-xs text-muted-foreground mb-1">
+                {tc('characterBuilder.pendingChoices.fromSource', {
+                  source: getChoiceSourceName(choice.choiceKey, t),
+                })}
+              </p>
               <ChoicePicker
                 choice={choice}
                 currentDecision={build?.choices[choice.choiceKey]}
                 onDecide={(choiceKey, decision) => context.makeChoice(choiceKey, decision)}
                 onClear={(choiceKey) => context.clearChoice(choiceKey)}
                 allowedFeats={gameData.feats}
+                unavailableFeats={unavailableFeats}
               />
             </div>
           ))}

--- a/src/components/character-builder/OriginStep.tsx
+++ b/src/components/character-builder/OriginStep.tsx
@@ -2,11 +2,10 @@ import { Badge } from '@/components/ui/badge';
 import { Label } from '@/components/ui/label';
 import { useCharacterContext } from '@/hooks/useCharacterContext';
 import { useGameData } from '@/hooks/useGameData';
-import { type SpeciesId, type ToolProficiencyId } from '@/lib/dnd-helpers';
+import { type SpeciesId } from '@/lib/dnd-helpers';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
 import { getChoiceSourceName } from '@/lib/character-builder/choice-source-name';
 import { deriveOriginFeatInfo } from '@/lib/character-builder/origin-feat-info';
-import type { ChoiceDecision } from '@/types/choices';
 import type { PendingChoice } from '@/types/resolved';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
@@ -46,28 +45,21 @@ export function OriginStep() {
     );
   }, [resolved]);
 
-  // Pending species-origin feat-choices (e.g. Human Versatile origin feat picker).
+  // Species-origin feat-choices (e.g. Human Versatile origin feat picker). Collected from the
+  // grant bundles rather than resolved.pendingChoices so the picker STAYS rendered after a feat
+  // is chosen — otherwise the selection vanishes and the user can't change a misclick. The
+  // ChoicePicker shows the current selection and a Clear button for re-selection.
   const speciesFeatChoices = useMemo<readonly Extract<PendingChoice, { type: 'feat-choice' }>[]>(() => {
-    return (resolved?.pendingChoices ?? []).filter(
-      (c): c is Extract<PendingChoice, { type: 'feat-choice' }> =>
-        c.type === 'feat-choice' && c.source.origin === 'species'
-    );
-  }, [resolved]);
-
-  // Synthesize tool-choice and language-choice PendingChoices from background grants
-  const backgroundToolChoiceGrants = collectGrantsByType(bundles, 'proficiency-choice').filter(
-    (tg) => tg.source.origin === 'background' && tg.grant.category === 'tool'
-  );
-  const backgroundToolChoices: readonly (PendingChoice & { type: 'tool-choice' })[] = backgroundToolChoiceGrants.map(
-    ({ grant, source }) => ({
-      type: 'tool-choice' as const,
-      choiceKey: grant.key,
-      source,
-      category: 'tool' as const,
-      count: grant.count,
-      from: grant.from as readonly ToolProficiencyId[] | null,
-    })
-  );
+    return collectGrantsByType(bundles, 'feat-choice')
+      .filter(({ source }) => source.origin === 'species')
+      .map(({ grant, source }) => ({
+        type: 'feat-choice' as const,
+        choiceKey: grant.key,
+        source,
+        from: grant.from,
+        category: grant.category,
+      }));
+  }, [bundles]);
 
   const backgroundName = background
     ? t(`backgrounds.${background}` as `backgrounds.${string}`, { defaultValue: background })
@@ -143,28 +135,8 @@ export function OriginStep() {
         </div>
       )}
 
-      {/* Tool proficiency choices */}
-      {background && backgroundToolChoices.length > 0 && (
-        <div className="space-y-2">
-          <Label className="text-base font-semibold">
-            {tc('characterBuilder.backgroundStep.toolProficiencyTitle')}
-          </Label>
-          <div className="space-y-4">
-            {backgroundToolChoices.map((choice) => {
-              const decision = build?.choices[choice.choiceKey];
-              return (
-                <ChoicePicker
-                  key={choice.choiceKey}
-                  choice={choice}
-                  currentDecision={decision as ChoiceDecision | undefined}
-                  onDecide={(key, d) => context.makeChoice(key, d)}
-                  onClear={(key) => context.clearChoice(key)}
-                />
-              );
-            })}
-          </div>
-        </div>
-      )}
+      {/* Tool proficiency choices are owned by the Proficiencies (Details) step to avoid
+          duplicating the picker in two places — see ProficienciesStep. */}
 
       {/* Feat-origin feature-choices (e.g. magic-initiate spellcasting class, elemental-adept element).
           Renders only when such a choice is pending — i.e. the feat is in build.feats but the user

--- a/src/components/character-builder/ProficienciesStep.tsx
+++ b/src/components/character-builder/ProficienciesStep.tsx
@@ -12,6 +12,7 @@ import {
   type ToolProficiencyId,
 } from '@/lib/dnd-helpers';
 import { getChoiceSourceName } from '@/lib/character-builder/choice-source-name';
+import { pickMostRestrictiveChoiceWithRoom } from '@/lib/character-builder/route-choice';
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
@@ -99,8 +100,11 @@ export function ProficienciesStep() {
 
     // Which choice, if any, currently holds this language
     const choiceHoldingLang = eligibleChoices.find((lc) => getSelectedLanguages(lc.choiceKey).includes(langId));
-    // First eligible choice that still has room — target for a new check
-    const choiceWithRoom = eligibleChoices.find((lc) => getSelectedLanguages(lc.choiceKey).length < lc.count);
+    // Route a new selection to the most restrictive eligible grant with room (smallest pool).
+    const choiceWithRoom = pickMostRestrictiveChoiceWithRoom(
+      eligibleChoices,
+      (lc) => getSelectedLanguages(lc.choiceKey).length
+    );
 
     let checkbox: React.ReactNode = null;
     if (isGranted) {

--- a/src/components/character-builder/SkillsStep.test.tsx
+++ b/src/components/character-builder/SkillsStep.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import { SkillsStep } from '@/components/character-builder/SkillsStep';
 import type { ResolvedCharacter, ResolvedSkill } from '@/types/resolved';
 import type { CharacterBuild, ChoiceDecision, ChoiceKey } from '@/types/choices';
@@ -282,6 +282,45 @@ describe('SkillsStep skill-choice multi-source routing', () => {
       type: 'skill-choice',
       skills: ['perception'],
     });
+  });
+
+  it('renders a single source icon when one source grants two skill-choices', () => {
+    // Barbarian L1 (choose 2) + L3 Primal Knowledge (choose 1) both list the same skills.
+    // A skill in both pools is eligible for two grants from the SAME source, so the row must
+    // show one Barbarian icon — not two identical ones.
+    const pool: readonly SkillId[] = [
+      'athletics',
+      'animalhandling',
+      'intimidation',
+      'nature',
+      'perception',
+      'survival',
+    ];
+    mockContextValue.bundles = [
+      {
+        source: { origin: 'class', id: 'barbarian', level: 1 },
+        grants: [
+          { type: 'proficiency-choice', category: 'skill', key: BARBARIAN_SKILL_KEY, count: 2, from: [...pool] },
+        ],
+      },
+      {
+        source: { origin: 'class', id: 'barbarian', level: 3 },
+        grants: [
+          {
+            type: 'proficiency-choice',
+            category: 'skill',
+            key: 'skill-choice:class:barbarian:1' as ChoiceKey,
+            count: 1,
+            from: [...pool],
+          },
+        ],
+      },
+    ];
+    render(<SkillsStep />);
+    const athletics = document.querySelector('#skill-athletics') as HTMLInputElement;
+    const row = athletics.closest('.gap-3') as HTMLElement;
+    // getSourceDisplayName(class:barbarian) → mocked i18n returns the last key segment 'barbarian'.
+    expect(within(row).getAllByLabelText('barbarian')).toHaveLength(1);
   });
 
   it('disables a skill checkbox only when every eligible pool is full', () => {

--- a/src/components/character-builder/SkillsStep.tsx
+++ b/src/components/character-builder/SkillsStep.tsx
@@ -3,6 +3,7 @@ import { Badge } from '@/components/ui/badge';
 import { ExpertiseChoicePicker } from '@/components/character-sheet/ExpertiseChoicePicker';
 import { useCharacterContext } from '@/hooks/useCharacterContext';
 import { getChoiceSourceName } from '@/lib/character-builder/choice-source-name';
+import { pickMostRestrictiveChoiceWithRoom } from '@/lib/character-builder/route-choice';
 import { SourceIcon, getSourceDisplayName } from '@/lib/class-icons';
 import type { ChoiceKey } from '@/types/choices';
 import type { SourceTag } from '@/types/sources';
@@ -122,7 +123,12 @@ export function SkillsStep() {
           // Every choice this skill is eligible for (could be multiple sources, e.g. Elf + Barbarian)
           const eligibleChoices = skillChoices.filter((sc) => sc.from.includes(skill.id));
           const choiceHoldingSkill = eligibleChoices.find((sc) => getSelectedSkills(sc.choiceKey).includes(skill.id));
-          const choiceWithRoom = eligibleChoices.find((sc) => getSelectedSkills(sc.choiceKey).length < sc.count);
+          // Route a new selection to the most restrictive eligible grant with room (smallest pool),
+          // so e.g. Athletics consumes the narrow Barbarian list before the "any skill" Human grant.
+          const choiceWithRoom = pickMostRestrictiveChoiceWithRoom(
+            eligibleChoices,
+            (sc) => getSelectedSkills(sc.choiceKey).length
+          );
 
           let checkbox: React.ReactNode = null;
           if (eligibleChoices.length > 0) {

--- a/src/components/character-builder/SkillsStep.tsx
+++ b/src/components/character-builder/SkillsStep.tsx
@@ -11,6 +11,11 @@ import { ABILITY_ABBREVIATIONS, DND_SKILLS, type SkillId, type ToolProficiencyId
 import { useMemo } from 'react';
 import { useTranslation } from 'react-i18next';
 
+/** Stable identity for a grant source, so multiple grants from the same source dedupe to one icon. */
+function sourceKey(source: SourceTag): string {
+  return `${source.origin}:${'id' in source ? source.id : source.description}`;
+}
+
 interface SkillChoiceInfo {
   readonly choiceKey: ChoiceKey;
   readonly source: SourceTag;
@@ -189,17 +194,27 @@ export function SkillsStep() {
                 {t(`skills.${skill.id}`)}
                 <span className="text-xs text-muted-foreground ml-1">({abbrev})</span>
               </label>
-              {/* Source icons — one per eligible grant, hover to see the source name */}
+              {/* Source icons — one per DISTINCT source, hover to see the source name.
+                  A single source can grant more than one skill-choice (e.g. Barbarian's
+                  level-1 list plus the level-3 Primal Knowledge pick), so dedupe by source
+                  to avoid rendering two identical icons on the same skill row. */}
               {eligibleChoices.length > 0 && (
                 <div className="flex items-center gap-1 shrink-0">
-                  {eligibleChoices.map((sc) => {
-                    const sourceName = getSourceDisplayName(sc.source, t);
-                    return (
-                      <span key={sc.choiceKey} title={sourceName} aria-label={sourceName} className="inline-flex">
-                        <SourceIcon source={sc.source} className="size-3.5 text-muted-foreground" />
-                      </span>
-                    );
-                  })}
+                  {Array.from(new Map(eligibleChoices.map((sc) => [sourceKey(sc.source), sc.source])).values()).map(
+                    (source) => {
+                      const sourceName = getSourceDisplayName(source, t);
+                      return (
+                        <span
+                          key={sourceKey(source)}
+                          title={sourceName}
+                          aria-label={sourceName}
+                          className="inline-flex"
+                        >
+                          <SourceIcon source={source} className="size-3.5 text-muted-foreground" />
+                        </span>
+                      );
+                    }
+                  )}
                 </div>
               )}
             </div>

--- a/src/hooks/useCharacterContext.test.tsx
+++ b/src/hooks/useCharacterContext.test.tsx
@@ -63,6 +63,12 @@ describe('resolveChoiceSequence', () => {
     expect(resolveChoiceSequence('skill-choice:background:soldier:0', rows)).toBe(0);
   });
 
+  it('routes feat (origin feat) choices to sequence 0', () => {
+    // Regression: a feat-origin key carries a feat id ("skilled"), not a class id. It used to
+    // fall through to the class branch and throw `No active level row found for class "skilled"`.
+    expect(resolveChoiceSequence('skill-choice:feat:skilled:0', rows)).toBe(0);
+  });
+
   it('routes class choices to the matching level row', () => {
     expect(resolveChoiceSequence('skill-choice:class:fighter:0', rows)).toBe(1);
   });

--- a/src/hooks/useCharacterContext.tsx
+++ b/src/hooks/useCharacterContext.tsx
@@ -73,7 +73,7 @@ function resolveSubclassToClassId(subclassId: string): string {
  * Determine which row sequence a choice key belongs to.
  *
  * Key format: `category:origin:id:index`
- * Keys with `:species:` or `:background:` go to sequence-0.
+ * Keys with `:species:`, `:background:`, or `:feat:` go to sequence-0 (the creation row).
  * Keys with `:class:` go to the matching level row (by class_id embedded in the key).
  * Keys with `:subclass:` resolve the parent class then go to its first active level row.
  * Unknown origins cause `parseChoiceKey` to throw.
@@ -82,7 +82,10 @@ function resolveSubclassToClassId(subclassId: string): string {
 export function resolveChoiceSequence(choiceKey: string, rows: readonly BuildLevelRow[]): number {
   const { origin, id: classId } = parseChoiceKey(choiceKey);
 
-  if (origin === 'species' || origin === 'background') {
+  // Species, background, and feat (origin feat) sub-choices are part of character creation and
+  // are stored in the creation row's choices JSONB. Feat keys carry a feat id (e.g. "skilled"),
+  // not a class id, so they have no level row of their own.
+  if (origin === 'species' || origin === 'background' || origin === 'feat') {
     return 0;
   }
 
@@ -185,7 +188,8 @@ function applyDecisionToRows(rows: BuildLevelRow[], choiceKey: ChoiceKey, decisi
 
   const { origin, id: classId } = parseChoiceKey(choiceKey);
   let targetSeq: number;
-  if (origin === 'species' || origin === 'background') {
+  // Species, background, and feat (origin feat) sub-choices live in the creation row (sequence 0).
+  if (origin === 'species' || origin === 'background' || origin === 'feat') {
     targetSeq = 0;
   } else if (origin === 'subclass') {
     const parentClassId = resolveSubclassToClassId(classId);

--- a/src/lib/character-builder/route-choice.test.ts
+++ b/src/lib/character-builder/route-choice.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { pickMostRestrictiveChoiceWithRoom } from './route-choice';
+
+interface TestChoice {
+  readonly id: string;
+  readonly from: readonly string[];
+  readonly count: number;
+}
+
+describe('pickMostRestrictiveChoiceWithRoom', () => {
+  const human: TestChoice = { id: 'human', from: ['a', 'b', 'c', 'd', 'e'], count: 1 }; // broad pool
+  const barbarian: TestChoice = { id: 'barbarian', from: ['a', 'b'], count: 2 }; // narrow pool
+
+  it('routes to the grant with the smallest pool (most restrictive)', () => {
+    const pick = pickMostRestrictiveChoiceWithRoom([human, barbarian], () => 0);
+    expect(pick?.id).toBe('barbarian');
+  });
+
+  it('ignores the more restrictive grant once it is full', () => {
+    // barbarian holds its full 2; only human has room left
+    const selected: Record<string, number> = { barbarian: 2, human: 0 };
+    const pick = pickMostRestrictiveChoiceWithRoom([human, barbarian], (c) => selected[c.id]);
+    expect(pick?.id).toBe('human');
+  });
+
+  it('returns undefined when no eligible choice has room', () => {
+    const selected: Record<string, number> = { barbarian: 2, human: 1 };
+    const pick = pickMostRestrictiveChoiceWithRoom([human, barbarian], (c) => selected[c.id]);
+    expect(pick).toBeUndefined();
+  });
+
+  it('keeps the earlier element on a pool-size tie (stable)', () => {
+    const first: TestChoice = { id: 'first', from: ['a', 'b'], count: 1 };
+    const second: TestChoice = { id: 'second', from: ['a', 'b'], count: 1 };
+    const pick = pickMostRestrictiveChoiceWithRoom([first, second], () => 0);
+    expect(pick?.id).toBe('first');
+  });
+
+  it('returns undefined for an empty eligible list', () => {
+    expect(pickMostRestrictiveChoiceWithRoom([], () => 0)).toBeUndefined();
+  });
+});

--- a/src/lib/character-builder/route-choice.ts
+++ b/src/lib/character-builder/route-choice.ts
@@ -1,0 +1,37 @@
+/**
+ * Routing helper for proficiency-style choices where a single item (skill, language, tool)
+ * may be eligible for more than one grant — e.g. Athletics is granted by both Human (choose
+ * any 1 skill) and Barbarian (choose 2 from a 6-skill list).
+ *
+ * When the user checks such an item we want it to consume the *most restrictive* eligible
+ * grant first: the one with the smallest pool. Filling the narrow Barbarian bucket before the
+ * "any skill" Human bucket leaves the broad grant free for skills that can only come from it,
+ * which maximizes how many distinct skills the player can ultimately select.
+ */
+
+interface RoutableChoice {
+  readonly from: readonly unknown[];
+  readonly count: number;
+}
+
+/**
+ * Among `eligible` choices that still have room, return the one with the smallest `from` pool
+ * (most restrictive). Ties keep the earlier element (stable). Returns `undefined` when none has
+ * room.
+ *
+ * @param eligible      Choices the item is eligible for (the item is in each `from` pool).
+ * @param selectedCount Returns how many items a given choice currently holds.
+ */
+export function pickMostRestrictiveChoiceWithRoom<T extends RoutableChoice>(
+  eligible: readonly T[],
+  selectedCount: (choice: T) => number
+): T | undefined {
+  let best: T | undefined;
+  for (const choice of eligible) {
+    if (selectedCount(choice) >= choice.count) continue;
+    if (best === undefined || choice.from.length < best.from.length) {
+      best = choice;
+    }
+  }
+  return best;
+}

--- a/src/lib/class-icons.tsx
+++ b/src/lib/class-icons.tsx
@@ -71,7 +71,7 @@ export function getSourceDisplayName(source: SourceTag, tGamedata: TFunction<'ga
     case 'background':
       return tGamedata(`backgrounds.${source.id}`, { defaultValue: source.id });
     case 'feat':
-      return source.id;
+      return tGamedata(`feats.${source.id}.name`, { defaultValue: source.id });
     case 'item':
       return tGamedata(getItemNameKey('gear', source.id), { defaultValue: source.id });
     case 'bundle':

--- a/src/lib/class-icons.tsx
+++ b/src/lib/class-icons.tsx
@@ -1,11 +1,8 @@
 import React from 'react';
 import type { ClassId } from '@/lib/dnd-helpers';
 import { CLASS_SOURCES } from '@/lib/sources/classes';
-import { getBundleNameKey } from '@/lib/sources/bundles';
-import { getItemNameKey } from '@/lib/sources/items';
 import type { SourceTag } from '@/types/sources';
 import type { BundleCategory } from '@/types/items';
-import type { TFunction } from 'i18next';
 import {
   Axe,
   Backpack,
@@ -56,32 +53,9 @@ const BUNDLE_TO_CLASS: ReadonlyMap<string, ClassId> = (() => {
   return map;
 })();
 
-/**
- * Resolve a user-friendly display name for a grant source (race name, class name,
- * background name, bundle/item name, etc.) using the gamedata namespace.
- */
-export function getSourceDisplayName(source: SourceTag, tGamedata: TFunction<'gamedata'>): string {
-  switch (source.origin) {
-    case 'species':
-      return tGamedata(`species.${source.id}`, { defaultValue: source.id });
-    case 'class':
-      return tGamedata(`classes.${source.id}`, { defaultValue: source.id });
-    case 'subclass':
-      return tGamedata(`subclasses.${source.id}.name`, { defaultValue: source.id });
-    case 'background':
-      return tGamedata(`backgrounds.${source.id}`, { defaultValue: source.id });
-    case 'feat':
-      return tGamedata(`feats.${source.id}.name`, { defaultValue: source.id });
-    case 'item':
-      return tGamedata(getItemNameKey('gear', source.id), { defaultValue: source.id });
-    case 'bundle':
-      return tGamedata(getBundleNameKey(source.id), { defaultValue: source.id });
-    case 'pack':
-      return tGamedata(getItemNameKey('pack', source.id), { defaultValue: source.id });
-    case 'loot':
-      return source.description;
-  }
-}
+// Re-exported from the React-free `source-display` module so existing importers
+// (and their test mocks of `@/lib/class-icons`) keep working unchanged.
+export { getSourceDisplayName } from '@/lib/source-display';
 
 /**
  * Resolve an icon for an equipment grant based on its source and (optionally) bundle category.

--- a/src/lib/pdf-export.test.ts
+++ b/src/lib/pdf-export.test.ts
@@ -1,8 +1,13 @@
 import { describe, it, expect, vi, afterEach } from 'vitest';
 import { PDFDocument } from 'pdf-lib';
 import { exportCharacterPdf, fillCharacterPdf, PdfTemplateError } from '@/lib/pdf-export';
+import i18n from '@/lib/i18n';
 import type { Character } from '@/types/database';
 import type { ResolvedAbility, ResolvedCharacter } from '@/types/resolved';
+import type { SourceTag } from '@/types/sources';
+
+const tg = i18n.getFixedT('en', 'gamedata');
+const NO_FEATS: ReadonlyMap<string, SourceTag> = new Map();
 
 function ability(score: number): ResolvedAbility {
   return { base: score, bonuses: [], total: score, modifier: Math.floor((score - 10) / 2) };
@@ -124,7 +129,7 @@ describe('fillCharacterPdf', () => {
   it('fills matching fields and returns bytes', async () => {
     // 2024 sheet field names: Text1=Character Name, Text13=Armor Class, Check Box11=Heroic Inspiration.
     const template = await tinyTemplate({ text: ['Text1', 'Text13'], checks: ['Check Box11'] });
-    const { bytes, missingFields } = await fillCharacterPdf(template, minimalResolved(), minimalCharacter());
+    const { bytes, missingFields } = await fillCharacterPdf(template, minimalResolved(), minimalCharacter(), tg, NO_FEATS);
 
     expect(bytes).toBeInstanceOf(Uint8Array);
     expect(bytes.length).toBeGreaterThan(0);
@@ -143,7 +148,7 @@ describe('fillCharacterPdf', () => {
 
   it('reports mapped fields the template lacks instead of throwing', async () => {
     const template = await tinyTemplate({ text: ['Text1'], checks: [] });
-    const { missingFields } = await fillCharacterPdf(template, minimalResolved(), minimalCharacter());
+    const { missingFields } = await fillCharacterPdf(template, minimalResolved(), minimalCharacter(), tg, NO_FEATS);
 
     // e.g. Text13 (AC) / Text19 (ProfBonus) are mapped but absent from this stub template.
     expect(missingFields.length).toBeGreaterThan(0);
@@ -153,7 +158,7 @@ describe('fillCharacterPdf', () => {
 
   it('throws PdfTemplateError when the bytes are not a valid PDF', async () => {
     const garbage = new Uint8Array([1, 2, 3, 4, 5]);
-    await expect(fillCharacterPdf(garbage, minimalResolved(), minimalCharacter())).rejects.toBeInstanceOf(
+    await expect(fillCharacterPdf(garbage, minimalResolved(), minimalCharacter(), tg, NO_FEATS)).rejects.toBeInstanceOf(
       PdfTemplateError
     );
   });
@@ -161,7 +166,7 @@ describe('fillCharacterPdf', () => {
   it('reports a present-but-wrong-type field as missing instead of throwing', async () => {
     // Text13 (armorClass) is a text-mapped key but here it exists as a CHECKBOX.
     const template = await tinyTemplate({ text: ['Text1'], checks: ['Text13'] });
-    const { missingFields } = await fillCharacterPdf(template, minimalResolved(), minimalCharacter());
+    const { missingFields } = await fillCharacterPdf(template, minimalResolved(), minimalCharacter(), tg, NO_FEATS);
     expect(missingFields).toContain('Text13');
     expect(missingFields).not.toContain('Text1');
   });
@@ -181,7 +186,7 @@ describe('exportCharacterPdf', () => {
     vi.spyOn(URL, 'revokeObjectURL').mockImplementation(() => {});
     const click = vi.spyOn(HTMLAnchorElement.prototype, 'click').mockImplementation(() => {});
 
-    const { missingFields } = await exportCharacterPdf(minimalResolved(), minimalCharacter());
+    const { missingFields } = await exportCharacterPdf(minimalResolved(), minimalCharacter(), tg, NO_FEATS);
 
     expect(createUrl).toHaveBeenCalledOnce();
     expect(click).toHaveBeenCalledOnce();
@@ -192,11 +197,11 @@ describe('exportCharacterPdf', () => {
 
   it('throws PdfTemplateError on a non-ok response (the default 404 first-run path)', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 404 }));
-    await expect(exportCharacterPdf(minimalResolved(), minimalCharacter())).rejects.toBeInstanceOf(PdfTemplateError);
+    await expect(exportCharacterPdf(minimalResolved(), minimalCharacter(), tg, NO_FEATS)).rejects.toBeInstanceOf(PdfTemplateError);
   });
 
   it('wraps a fetch rejection in PdfTemplateError (so the handler can discriminate it)', async () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('network down'));
-    await expect(exportCharacterPdf(minimalResolved(), minimalCharacter())).rejects.toBeInstanceOf(PdfTemplateError);
+    await expect(exportCharacterPdf(minimalResolved(), minimalCharacter(), tg, NO_FEATS)).rejects.toBeInstanceOf(PdfTemplateError);
   });
 });

--- a/src/lib/pdf-export.test.ts
+++ b/src/lib/pdf-export.test.ts
@@ -4,10 +4,10 @@ import { exportCharacterPdf, fillCharacterPdf, PdfTemplateError } from '@/lib/pd
 import i18n from '@/lib/i18n';
 import type { Character } from '@/types/database';
 import type { ResolvedAbility, ResolvedCharacter } from '@/types/resolved';
-import type { SourceTag } from '@/types/sources';
+import type { FeatGrantInfo } from '@/lib/pdf-field-map';
 
 const tg = i18n.getFixedT('en', 'gamedata');
-const NO_FEATS: ReadonlyMap<string, SourceTag> = new Map();
+const NO_FEATS: ReadonlyMap<string, FeatGrantInfo> = new Map();
 
 function ability(score: number): ResolvedAbility {
   return { base: score, bonuses: [], total: score, modifier: Math.floor((score - 10) / 2) };
@@ -129,7 +129,13 @@ describe('fillCharacterPdf', () => {
   it('fills matching fields and returns bytes', async () => {
     // 2024 sheet field names: Text1=Character Name, Text13=Armor Class, Check Box11=Heroic Inspiration.
     const template = await tinyTemplate({ text: ['Text1', 'Text13'], checks: ['Check Box11'] });
-    const { bytes, missingFields } = await fillCharacterPdf(template, minimalResolved(), minimalCharacter(), tg, NO_FEATS);
+    const { bytes, missingFields } = await fillCharacterPdf(
+      template,
+      minimalResolved(),
+      minimalCharacter(),
+      tg,
+      NO_FEATS
+    );
 
     expect(bytes).toBeInstanceOf(Uint8Array);
     expect(bytes.length).toBeGreaterThan(0);
@@ -197,11 +203,15 @@ describe('exportCharacterPdf', () => {
 
   it('throws PdfTemplateError on a non-ok response (the default 404 first-run path)', async () => {
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(new Response('', { status: 404 }));
-    await expect(exportCharacterPdf(minimalResolved(), minimalCharacter(), tg, NO_FEATS)).rejects.toBeInstanceOf(PdfTemplateError);
+    await expect(exportCharacterPdf(minimalResolved(), minimalCharacter(), tg, NO_FEATS)).rejects.toBeInstanceOf(
+      PdfTemplateError
+    );
   });
 
   it('wraps a fetch rejection in PdfTemplateError (so the handler can discriminate it)', async () => {
     vi.spyOn(globalThis, 'fetch').mockRejectedValue(new TypeError('network down'));
-    await expect(exportCharacterPdf(minimalResolved(), minimalCharacter(), tg, NO_FEATS)).rejects.toBeInstanceOf(PdfTemplateError);
+    await expect(exportCharacterPdf(minimalResolved(), minimalCharacter(), tg, NO_FEATS)).rejects.toBeInstanceOf(
+      PdfTemplateError
+    );
   });
 });

--- a/src/lib/pdf-export.test.ts
+++ b/src/lib/pdf-export.test.ts
@@ -122,32 +122,33 @@ async function tinyTemplate(fieldNames: { text: string[]; checks: string[] }): P
 
 describe('fillCharacterPdf', () => {
   it('fills matching fields and returns bytes', async () => {
-    const template = await tinyTemplate({ text: ['CharacterName', 'AC'], checks: ['Inspiration'] });
+    // 2024 sheet field names: Text1=Character Name, Text13=Armor Class, Check Box11=Heroic Inspiration.
+    const template = await tinyTemplate({ text: ['Text1', 'Text13'], checks: ['Check Box11'] });
     const { bytes, missingFields } = await fillCharacterPdf(template, minimalResolved(), minimalCharacter());
 
     expect(bytes).toBeInstanceOf(Uint8Array);
     expect(bytes.length).toBeGreaterThan(0);
-    // CharacterName / AC / Inspiration are present, so not reported missing.
-    expect(missingFields).not.toContain('CharacterName');
-    expect(missingFields).not.toContain('AC');
-    expect(missingFields).not.toContain('Inspiration');
+    // Name / AC / Inspiration fields are present, so not reported missing.
+    expect(missingFields).not.toContain('Text1');
+    expect(missingFields).not.toContain('Text13');
+    expect(missingFields).not.toContain('Check Box11');
 
     // The written values round-trip through the saved PDF.
     const reloaded = await PDFDocument.load(bytes);
     const rf = reloaded.getForm();
-    expect(rf.getTextField('CharacterName').getText()).toBe('Boromir');
-    expect(rf.getTextField('AC').getText()).toBe('17');
-    expect(rf.getCheckBox('Inspiration').isChecked()).toBe(true);
+    expect(rf.getTextField('Text1').getText()).toBe('Boromir');
+    expect(rf.getTextField('Text13').getText()).toBe('17');
+    expect(rf.getCheckBox('Check Box11').isChecked()).toBe(true);
   });
 
   it('reports mapped fields the template lacks instead of throwing', async () => {
-    const template = await tinyTemplate({ text: ['CharacterName'], checks: [] });
+    const template = await tinyTemplate({ text: ['Text1'], checks: [] });
     const { missingFields } = await fillCharacterPdf(template, minimalResolved(), minimalCharacter());
 
-    // e.g. AC / ProfBonus / ST Strength are mapped but absent from this stub template.
+    // e.g. Text13 (AC) / Text19 (ProfBonus) are mapped but absent from this stub template.
     expect(missingFields.length).toBeGreaterThan(0);
-    expect(missingFields).toContain('AC');
-    expect(missingFields).not.toContain('CharacterName');
+    expect(missingFields).toContain('Text13');
+    expect(missingFields).not.toContain('Text1');
   });
 
   it('throws PdfTemplateError when the bytes are not a valid PDF', async () => {
@@ -158,11 +159,11 @@ describe('fillCharacterPdf', () => {
   });
 
   it('reports a present-but-wrong-type field as missing instead of throwing', async () => {
-    // 'AC' is a text-mapped semantic key (armorClass) but here it exists as a CHECKBOX.
-    const template = await tinyTemplate({ text: ['CharacterName'], checks: ['AC'] });
+    // Text13 (armorClass) is a text-mapped key but here it exists as a CHECKBOX.
+    const template = await tinyTemplate({ text: ['Text1'], checks: ['Text13'] });
     const { missingFields } = await fillCharacterPdf(template, minimalResolved(), minimalCharacter());
-    expect(missingFields).toContain('AC');
-    expect(missingFields).not.toContain('CharacterName');
+    expect(missingFields).toContain('Text13');
+    expect(missingFields).not.toContain('Text1');
   });
 });
 
@@ -172,7 +173,7 @@ describe('exportCharacterPdf', () => {
   });
 
   it('fetches the template, fills it, downloads, and returns missing fields', async () => {
-    const template = await tinyTemplate({ text: ['CharacterName', 'AC'], checks: [] });
+    const template = await tinyTemplate({ text: ['Text1', 'Text13'], checks: [] });
     vi.spyOn(globalThis, 'fetch').mockResolvedValue(
       new Response(template as BodyInit, { status: 200, headers: { 'Content-Type': 'application/pdf' } })
     );
@@ -185,8 +186,8 @@ describe('exportCharacterPdf', () => {
     expect(createUrl).toHaveBeenCalledOnce();
     expect(click).toHaveBeenCalledOnce();
     expect(Array.isArray(missingFields)).toBe(true);
-    // ProfBonus/saves etc. are mapped but absent from this 2-field stub → reported.
-    expect(missingFields).toContain('ProfBonus');
+    // Text19 (ProfBonus)/saves etc. are mapped but absent from this 2-field stub → reported.
+    expect(missingFields).toContain('Text19');
   });
 
   it('throws PdfTemplateError on a non-ok response (the default 404 first-run path)', async () => {

--- a/src/lib/pdf-export.ts
+++ b/src/lib/pdf-export.ts
@@ -11,7 +11,7 @@
 import { PDFDocument } from 'pdf-lib';
 import type { Character } from '@/types/database';
 import type { ResolvedCharacter } from '@/types/resolved';
-import { buildFieldValues, CHECK_FIELD_NAMES, TEXT_FIELD_NAMES } from '@/lib/pdf-field-map';
+import { buildFieldValues, characterDisplayName, CHECK_FIELD_NAMES, TEXT_FIELD_NAMES } from '@/lib/pdf-field-map';
 
 export class PdfTemplateError extends Error {
   constructor(
@@ -130,6 +130,6 @@ export async function exportCharacterPdf(
 
   const templateBytes = await response.arrayBuffer();
   const { bytes, missingFields } = await fillCharacterPdf(templateBytes, resolved, character);
-  downloadPdf(bytes, `${opts.filename ?? character.name}.pdf`);
+  downloadPdf(bytes, `${opts.filename ?? characterDisplayName(character)}.pdf`);
   return { missingFields };
 }

--- a/src/lib/pdf-export.ts
+++ b/src/lib/pdf-export.ts
@@ -11,12 +11,12 @@
 import { PDFDocument } from 'pdf-lib';
 import type { Character } from '@/types/database';
 import type { ResolvedCharacter } from '@/types/resolved';
-import type { SourceTag } from '@/types/sources';
 import {
   buildFieldValues,
   characterDisplayName,
   CHECK_FIELD_NAMES,
   TEXT_FIELD_NAMES,
+  type FeatGrantInfo,
   type GamedataT,
 } from '@/lib/pdf-field-map';
 
@@ -45,7 +45,7 @@ export async function fillCharacterPdf(
   resolved: ResolvedCharacter,
   character: Character,
   t: GamedataT,
-  featSources: ReadonlyMap<string, SourceTag>
+  featSources: ReadonlyMap<string, FeatGrantInfo>
 ): Promise<FillResult> {
   let pdfDoc: PDFDocument;
   try {
@@ -124,7 +124,7 @@ export async function exportCharacterPdf(
   resolved: ResolvedCharacter,
   character: Character,
   t: GamedataT,
-  featSources: ReadonlyMap<string, SourceTag>,
+  featSources: ReadonlyMap<string, FeatGrantInfo>,
   opts: ExportOptions = {}
 ): Promise<{ missingFields: readonly string[] }> {
   const templateUrl = opts.templateUrl ?? DEFAULT_TEMPLATE_URL;

--- a/src/lib/pdf-export.ts
+++ b/src/lib/pdf-export.ts
@@ -11,7 +11,14 @@
 import { PDFDocument } from 'pdf-lib';
 import type { Character } from '@/types/database';
 import type { ResolvedCharacter } from '@/types/resolved';
-import { buildFieldValues, characterDisplayName, CHECK_FIELD_NAMES, TEXT_FIELD_NAMES } from '@/lib/pdf-field-map';
+import type { SourceTag } from '@/types/sources';
+import {
+  buildFieldValues,
+  characterDisplayName,
+  CHECK_FIELD_NAMES,
+  TEXT_FIELD_NAMES,
+  type GamedataT,
+} from '@/lib/pdf-field-map';
 
 export class PdfTemplateError extends Error {
   constructor(
@@ -36,7 +43,9 @@ export interface FillResult {
 export async function fillCharacterPdf(
   templateBytes: ArrayBuffer | Uint8Array,
   resolved: ResolvedCharacter,
-  character: Character
+  character: Character,
+  t: GamedataT,
+  featSources: ReadonlyMap<string, SourceTag>
 ): Promise<FillResult> {
   let pdfDoc: PDFDocument;
   try {
@@ -47,7 +56,7 @@ export async function fillCharacterPdf(
 
   const form = pdfDoc.getForm();
   const existing = new Set(form.getFields().map((f) => f.getName()));
-  const values = buildFieldValues(resolved, character);
+  const values = buildFieldValues(resolved, character, t, featSources);
   const missingFields: string[] = [];
 
   for (const [semanticKey, value] of Object.entries(values.text)) {
@@ -114,6 +123,8 @@ const DEFAULT_TEMPLATE_URL = '/assets/character-sheet.pdf';
 export async function exportCharacterPdf(
   resolved: ResolvedCharacter,
   character: Character,
+  t: GamedataT,
+  featSources: ReadonlyMap<string, SourceTag>,
   opts: ExportOptions = {}
 ): Promise<{ missingFields: readonly string[] }> {
   const templateUrl = opts.templateUrl ?? DEFAULT_TEMPLATE_URL;
@@ -129,7 +140,7 @@ export async function exportCharacterPdf(
   }
 
   const templateBytes = await response.arrayBuffer();
-  const { bytes, missingFields } = await fillCharacterPdf(templateBytes, resolved, character);
+  const { bytes, missingFields } = await fillCharacterPdf(templateBytes, resolved, character, t, featSources);
   downloadPdf(bytes, `${opts.filename ?? characterDisplayName(character)}.pdf`);
   return { missingFields };
 }

--- a/src/lib/pdf-field-map.test.ts
+++ b/src/lib/pdf-field-map.test.ts
@@ -159,7 +159,8 @@ describe('signed', () => {
 describe('buildFieldValues — identity', () => {
   it('maps name, separate class/level, species, background, alignment, size (2024 sheet)', () => {
     const { text } = buildFieldValues(makeResolved(), makeCharacter({ size: 'medium' }));
-    expect(text.characterName).toBe('Aragorn');
+    // PC with a player → "Character (Player)" since the 2024 sheet has no player-name field.
+    expect(text.characterName).toBe('Aragorn (Viggo)');
     expect(text.class).toBe('Fighter');
     expect(text.level).toBe('5');
     expect(text.species).toBe('Human');
@@ -174,6 +175,13 @@ describe('buildFieldValues — identity', () => {
   it('emits the subclass in its own field when present', () => {
     const { text } = buildFieldValues(makeResolved(), makeCharacter({ subclass: 'champion' }));
     expect(text.subclass).toBe('Champion');
+  });
+
+  it('shows just the name for an NPC, or a PC with no player', () => {
+    const npc = buildFieldValues(makeResolved(), makeCharacter({ character_type: 'npc', player_name: 'Ignored' }));
+    expect(npc.text.characterName).toBe('Aragorn');
+    const pcNoPlayer = buildFieldValues(makeResolved(), makeCharacter({ player_name: null }));
+    expect(pcNoPlayer.text.characterName).toBe('Aragorn');
   });
 });
 

--- a/src/lib/pdf-field-map.test.ts
+++ b/src/lib/pdf-field-map.test.ts
@@ -165,7 +165,7 @@ describe('buildFieldValues — identity', () => {
     expect(text.species).toBe('Human');
     expect(text.background).toBe('Soldier');
     expect(text.alignment).toBe('Lawful Good');
-    expect(text.size).toBe('Medium');
+    expect(text.size).toBe('M'); // single-letter abbreviation on the 2024 sheet
     // No subclass on the base fixture, and the 2024 sheet has no player-name field.
     expect(text.subclass).toBeUndefined();
     expect(text.playerName).toBeUndefined();
@@ -233,8 +233,14 @@ describe('buildFieldValues — combat', () => {
     expect(text.speed).toBe('30 ft');
     expect(text.maxHp).toBe('44');
     expect(text.currentHp).toBe('44'); // freshly-built character starts at full
+    expect(text.hitDiceMax).toBe('5d10'); // fixture: 5× d10
     expect(text.profBonus).toBe('+3');
     expect(text.passivePerception).toBe('14'); // 10 + 4
+  });
+
+  it('omits hit-dice max when the build has no hit dice', () => {
+    const { text } = buildFieldValues(makeResolved({ hitDie: [] }), makeCharacter());
+    expect(text.hitDiceMax).toBeUndefined();
   });
 });
 

--- a/src/lib/pdf-field-map.test.ts
+++ b/src/lib/pdf-field-map.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest';
-import { buildFieldValues, signed, PDF_SKILLS, PDF_ABILITIES } from '@/lib/pdf-field-map';
+import { buildFieldValues, characterDisplayName, signed, PDF_SKILLS, PDF_ABILITIES } from '@/lib/pdf-field-map';
 import { requireItemDef } from '@/lib/sources/items';
 import type { Character } from '@/types/database';
 import type { AbilityKey } from '@/types/database';
@@ -159,8 +159,8 @@ describe('signed', () => {
 describe('buildFieldValues — identity', () => {
   it('maps name, separate class/level, species, background, alignment, size (2024 sheet)', () => {
     const { text } = buildFieldValues(makeResolved(), makeCharacter({ size: 'medium' }));
-    // PC with a player → "Character (Player)" since the 2024 sheet has no player-name field.
-    expect(text.characterName).toBe('Aragorn (Viggo)');
+    // The in-sheet name field is just the character name (no player-name field on the 2024 sheet).
+    expect(text.characterName).toBe('Aragorn');
     expect(text.class).toBe('Fighter');
     expect(text.level).toBe('5');
     expect(text.species).toBe('Human');
@@ -177,11 +177,23 @@ describe('buildFieldValues — identity', () => {
     expect(text.subclass).toBe('Champion');
   });
 
-  it('shows just the name for an NPC, or a PC with no player', () => {
-    const npc = buildFieldValues(makeResolved(), makeCharacter({ character_type: 'npc', player_name: 'Ignored' }));
-    expect(npc.text.characterName).toBe('Aragorn');
-    const pcNoPlayer = buildFieldValues(makeResolved(), makeCharacter({ player_name: null }));
-    expect(pcNoPlayer.text.characterName).toBe('Aragorn');
+  it('keeps the in-sheet name field as just the character name', () => {
+    const pc = buildFieldValues(makeResolved(), makeCharacter({ player_name: 'Viggo' }));
+    expect(pc.text.characterName).toBe('Aragorn');
+  });
+});
+
+describe('characterDisplayName (download filename)', () => {
+  it('folds player into the name for a PC, e.g. "Sebastian (Sebastian)"', () => {
+    expect(characterDisplayName(makeCharacter({ name: 'Sebastian', player_name: 'Sebastian' }))).toBe(
+      'Sebastian (Sebastian)'
+    );
+    expect(characterDisplayName(makeCharacter({ player_name: 'Viggo' }))).toBe('Aragorn (Viggo)');
+  });
+
+  it('uses just the name for an NPC or a player-less PC', () => {
+    expect(characterDisplayName(makeCharacter({ character_type: 'npc', player_name: 'Ignored' }))).toBe('Aragorn');
+    expect(characterDisplayName(makeCharacter({ player_name: null }))).toBe('Aragorn');
   });
 });
 

--- a/src/lib/pdf-field-map.test.ts
+++ b/src/lib/pdf-field-map.test.ts
@@ -157,24 +157,23 @@ describe('signed', () => {
 });
 
 describe('buildFieldValues — identity', () => {
-  it('maps name, player, class+level, species, background, alignment as display text', () => {
-    const { text } = buildFieldValues(makeResolved(), makeCharacter());
+  it('maps name, separate class/level, species, background, alignment, size (2024 sheet)', () => {
+    const { text } = buildFieldValues(makeResolved(), makeCharacter({ size: 'medium' }));
     expect(text.characterName).toBe('Aragorn');
-    expect(text.playerName).toBe('Viggo');
-    expect(text.classLevel).toBe('Fighter 5');
+    expect(text.class).toBe('Fighter');
+    expect(text.level).toBe('5');
     expect(text.species).toBe('Human');
     expect(text.background).toBe('Soldier');
     expect(text.alignment).toBe('Lawful Good');
+    expect(text.size).toBe('Medium');
+    // No subclass on the base fixture, and the 2024 sheet has no player-name field.
+    expect(text.subclass).toBeUndefined();
+    expect(text.playerName).toBeUndefined();
   });
 
-  it('appends subclass to class+level when present', () => {
+  it('emits the subclass in its own field when present', () => {
     const { text } = buildFieldValues(makeResolved(), makeCharacter({ subclass: 'champion' }));
-    expect(text.classLevel).toBe('Fighter 5 (Champion)');
-  });
-
-  it('leaves player name blank for an NPC with no player', () => {
-    const { text } = buildFieldValues(makeResolved(), makeCharacter({ player_name: null }));
-    expect(text.playerName).toBe('');
+    expect(text.subclass).toBe('Champion');
   });
 });
 
@@ -233,6 +232,7 @@ describe('buildFieldValues — combat', () => {
     expect(text.initiative).toBe('+2');
     expect(text.speed).toBe('30 ft');
     expect(text.maxHp).toBe('44');
+    expect(text.currentHp).toBe('44'); // freshly-built character starts at full
     expect(text.profBonus).toBe('+3');
     expect(text.passivePerception).toBe('14'); // 10 + 4
   });
@@ -282,48 +282,79 @@ describe('buildFieldValues — attacks', () => {
   });
 });
 
-describe('buildFieldValues — features block (2024 extras)', () => {
-  it('folds Heroic Inspiration, Exhaustion and Weapon Mastery into the features text', () => {
+describe('buildFieldValues — features split (2024 sections)', () => {
+  it('splits features into class features, species traits and feats by grant origin', () => {
     const resolved = makeResolved({
       features: [
         { feature: { id: 'second-wind', name: 'Second Wind' }, source: { origin: 'class', id: 'fighter', level: 1 } },
-      ],
+        { feature: { id: 'darkvision', name: 'Darkvision' }, source: { origin: 'species', id: 'elf', level: 0 } },
+        { feature: { id: 'alert', name: 'Alert' }, source: { origin: 'feat', id: 'alert', level: 0 } },
+      ] as ResolvedCharacter['features'],
       weaponMasteries: [{ weaponId: 'longsword', masteryId: 'sap' }],
     });
     const character = makeCharacter({ heroic_inspiration: true, exhaustion_level: 2 });
     const { text, checks } = buildFieldValues(resolved, character);
-    expect(text.featuresTraits).toContain('Second Wind');
-    expect(text.featuresTraits).toContain('Heroic Inspiration: yes');
-    expect(text.featuresTraits).toContain('Exhaustion: level 2');
-    expect(text.featuresTraits).toContain('Weapon Mastery: Longsword (Sap)');
+    // Class section gets class/subclass features plus the no-dedicated-field extras.
+    expect(text.classFeatures).toContain('Second Wind');
+    expect(text.classFeatures).toContain('Exhaustion: level 2');
+    expect(text.classFeatures).toContain('Weapon Mastery: Longsword (Sap)');
+    expect(text.speciesTraits).toContain('Darkvision');
+    expect(text.feats).toContain('Alert');
     expect(checks.inspiration).toBe(true);
   });
 
-  it('omits the 2024 extras when they are inactive', () => {
+  it('omits the exhaustion / mastery extras from class features when inactive', () => {
     const { text } = buildFieldValues(makeResolved(), makeCharacter());
-    expect(text.featuresTraits).not.toContain('Heroic Inspiration');
-    expect(text.featuresTraits).not.toContain('Exhaustion');
+    expect(text.classFeatures).not.toContain('Exhaustion');
+    expect(text.classFeatures).not.toContain('Weapon Mastery');
   });
 });
 
-describe('buildFieldValues — equipment & personality', () => {
-  it('lists equipment with quantity multipliers and copies personality fields', () => {
+describe('buildFieldValues — equipment & backstory', () => {
+  it('lists equipment with quantity multipliers and merges personality + backstory', () => {
     const resolved = makeResolved({
       equipment: [equippedWeapon('longsword'), equippedWeapon('dagger', 2)],
     });
     const { text } = buildFieldValues(resolved, makeCharacter());
     expect(text.equipment).toContain('Longsword');
     expect(text.equipment).toContain('Dagger ×2');
-    expect(text.personalityTraits).toBe('Stoic');
-    expect(text.ideals).toBe('Honor');
-    expect(text.bonds).toBe('My people');
-    expect(text.flaws).toBe('Reluctant');
-    expect(text.backstory).toBe('Heir of Isildur');
+    // The 2024 sheet has a single combined Backstory & Personality block.
+    expect(text.backstory).toContain('Heir of Isildur');
+    expect(text.backstory).toContain('Personality Traits: Stoic');
+    expect(text.backstory).toContain('Ideals: Honor');
+    expect(text.backstory).toContain('Bonds: My people');
+    expect(text.backstory).toContain('Flaws: Reluctant');
+  });
+});
+
+describe('buildFieldValues — 2024 proficiencies & languages', () => {
+  it('renders weapon/tool/language text and armor-training checkboxes', () => {
+    const sourced = <T>(value: T) => ({ value, sources: [] });
+    const resolved = makeResolved({
+      weaponProficiencies: [sourced('simple'), sourced('martial')] as ResolvedCharacter['weaponProficiencies'],
+      toolProficiencies: [sourced('thievestools')] as ResolvedCharacter['toolProficiencies'],
+      languages: [sourced('common'), sourced('elvish')] as ResolvedCharacter['languages'],
+      armorProficiencies: [
+        sourced('light'),
+        sourced('medium'),
+        sourced('shields'),
+      ] as ResolvedCharacter['armorProficiencies'],
+    });
+    const { text, checks } = buildFieldValues(resolved, makeCharacter());
+    expect(text.weaponProficienciesText).toBe('Simple, Martial');
+    // Tool ids are concatenated (no separators) and this layer is i18n-free, so titleCase
+    // can't reinsert spaces — display names proper come from the i18n layer elsewhere.
+    expect(text.toolProficienciesText).toBe('Thievestools');
+    expect(text.languages).toBe('Common, Elvish');
+    expect(checks.armorLight).toBe(true);
+    expect(checks.armorMedium).toBe(true);
+    expect(checks.armorHeavy).toBe(false);
+    expect(checks.armorShields).toBe(true);
   });
 });
 
 describe('buildFieldValues — spellcasting', () => {
-  it('maps spell save DC, attack bonus and ability when the character casts', () => {
+  it('maps save DC, attack bonus, ability and modifier when the character casts', () => {
     const resolved = makeResolved({
       spellcasting: {
         ability: 'int',
@@ -341,7 +372,9 @@ describe('buildFieldValues — spellcasting', () => {
     expect(text.spellSaveDc).toBe('15');
     expect(text.spellAttackBonus).toBe('+7');
     expect(text.spellcastingAbility).toBe('Intelligence');
-    expect(text.spellcastingClass).toBe('Wizard');
+    expect(text.spellcastingModifier).toBe('+0'); // int 10 → +0
+    // The 2024 sheet has no spellcasting-class field.
+    expect(text.spellcastingClass).toBeUndefined();
   });
 
   it('omits spell fields entirely for a non-caster', () => {

--- a/src/lib/pdf-field-map.test.ts
+++ b/src/lib/pdf-field-map.test.ts
@@ -6,24 +6,24 @@ import {
   signed,
   PDF_SKILLS,
   PDF_ABILITIES,
+  type FeatGrantInfo,
 } from '@/lib/pdf-field-map';
 import { requireItemDef } from '@/lib/sources/items';
 import i18n from '@/lib/i18n';
 import type { Character } from '@/types/database';
 import type { AbilityKey } from '@/types/database';
 import type { ResolvedAbility, ResolvedCharacter, ResolvedEquipmentItem, ResolvedSkill } from '@/types/resolved';
-import type { SourceTag } from '@/types/sources';
 
 // Real bundled gamedata translator — the export uses i18n for all user-facing text,
 // so tests assert against the actual translations (which also verifies the keys exist).
 const tg = i18n.getFixedT('en', 'gamedata');
-const NO_FEATS: ReadonlyMap<string, SourceTag> = new Map();
+const NO_FEATS: ReadonlyMap<string, FeatGrantInfo> = new Map();
 
 /** buildFieldValues bound to the real gamedata translator; featSources defaults to none. */
 function bfv(
   resolved: ResolvedCharacter,
   character: Character,
-  featSources: ReadonlyMap<string, SourceTag> = NO_FEATS
+  featSources: ReadonlyMap<string, FeatGrantInfo> = NO_FEATS
 ) {
   return buildFieldValues(resolved, character, tg, featSources);
 }
@@ -358,34 +358,58 @@ describe('buildFieldValues — features split (2024 sections)', () => {
     expect(text.classFeatures).not.toContain('Weapon Mastery');
   });
 
-  it('lists feats as "Name (Source)" from the granted-feat map', () => {
-    const featSources = new Map<string, SourceTag>([
-      ['savage-attacker', { origin: 'background', id: 'soldier' }],
-      ['tough', { origin: 'species', id: 'human' }],
+  it('lists feats as "Name (Source)" with the feat description appended', () => {
+    const featSources = new Map<string, FeatGrantInfo>([
+      ['savage-attacker', { source: { origin: 'background', id: 'soldier' }, decisions: [] }],
+      ['tough', { source: { origin: 'species', id: 'human' }, decisions: [] }],
     ]);
     const { text } = bfv(makeResolved(), makeCharacter(), featSources);
     expect(text.feats).toContain('Savage Attacker (Soldier)');
     expect(text.feats).toContain('Tough (Human)');
+    // Feat descriptions are appended after an em dash.
+    expect(text.feats).toContain('Savage Attacker (Soldier) — Once per turn');
+  });
+
+  it('lists a feat\'s chosen options, e.g. "Skilled (Human): Nature, Athletics"', () => {
+    const featSources = new Map<string, FeatGrantInfo>([
+      [
+        'skilled',
+        {
+          source: { origin: 'species', id: 'human' },
+          decisions: [{ type: 'skill-choice', skills: ['nature', 'athletics'] }],
+        },
+      ],
+    ]);
+    const { text } = bfv(makeResolved(), makeCharacter(), featSources);
+    expect(text.feats).toContain('Skilled (Human): Nature, Athletics');
+    expect(text.feats).toContain('Gain proficiency'); // description still appended
   });
 });
 
 describe('collectFeatSources', () => {
-  it('attributes a background origin feat and a species feat-choice to their granters', () => {
+  it("attributes feats to their granters and gathers a feat's own choices", () => {
     const featChoiceKey = 'feat-choice:species:human:0';
+    const skilledChoiceKey = 'skill-choice:feat:skilled:0';
     const bundles = [
+      // Soldier grants Savage Attacker directly.
       { source: { origin: 'background', id: 'soldier' }, grants: [{ type: 'feat', featId: 'savage-attacker' }] },
+      // Human's Versatile feat-choice (resolved below to Skilled).
       {
         source: { origin: 'species', id: 'human' },
         grants: [{ type: 'feat-choice', key: featChoiceKey, from: null, category: 'origin' }],
       },
     ] as unknown as Parameters<typeof collectFeatSources>[0];
-    const choices = { [featChoiceKey]: { type: 'feat-choice', featId: 'tough' } } as unknown as Parameters<
-      typeof collectFeatSources
-    >[1];
+    const choices = {
+      [featChoiceKey]: { type: 'feat-choice', featId: 'skilled' },
+      [skilledChoiceKey]: { type: 'skill-choice', skills: ['nature', 'athletics'] },
+    } as unknown as Parameters<typeof collectFeatSources>[1];
 
     const map = collectFeatSources(bundles, choices);
-    expect(map.get('savage-attacker')).toEqual({ origin: 'background', id: 'soldier' });
-    expect(map.get('tough')).toEqual({ origin: 'species', id: 'human' });
+    // Savage Attacker came from the background.
+    expect(map.get('savage-attacker')?.source).toEqual({ origin: 'background', id: 'soldier' });
+    // Skilled came from the species feat-choice, and its own skill-choice was gathered.
+    expect(map.get('skilled')?.source).toEqual({ origin: 'species', id: 'human' });
+    expect(map.get('skilled')?.decisions).toContainEqual({ type: 'skill-choice', skills: ['nature', 'athletics'] });
   });
 });
 

--- a/src/lib/pdf-field-map.test.ts
+++ b/src/lib/pdf-field-map.test.ts
@@ -1,9 +1,32 @@
 import { describe, it, expect } from 'vitest';
-import { buildFieldValues, characterDisplayName, signed, PDF_SKILLS, PDF_ABILITIES } from '@/lib/pdf-field-map';
+import {
+  buildFieldValues,
+  characterDisplayName,
+  collectFeatSources,
+  signed,
+  PDF_SKILLS,
+  PDF_ABILITIES,
+} from '@/lib/pdf-field-map';
 import { requireItemDef } from '@/lib/sources/items';
+import i18n from '@/lib/i18n';
 import type { Character } from '@/types/database';
 import type { AbilityKey } from '@/types/database';
 import type { ResolvedAbility, ResolvedCharacter, ResolvedEquipmentItem, ResolvedSkill } from '@/types/resolved';
+import type { SourceTag } from '@/types/sources';
+
+// Real bundled gamedata translator — the export uses i18n for all user-facing text,
+// so tests assert against the actual translations (which also verifies the keys exist).
+const tg = i18n.getFixedT('en', 'gamedata');
+const NO_FEATS: ReadonlyMap<string, SourceTag> = new Map();
+
+/** buildFieldValues bound to the real gamedata translator; featSources defaults to none. */
+function bfv(
+  resolved: ResolvedCharacter,
+  character: Character,
+  featSources: ReadonlyMap<string, SourceTag> = NO_FEATS
+) {
+  return buildFieldValues(resolved, character, tg, featSources);
+}
 
 // --- minimal typed fixtures -------------------------------------------------
 
@@ -158,7 +181,7 @@ describe('signed', () => {
 
 describe('buildFieldValues — identity', () => {
   it('maps name, separate class/level, species, background, alignment, size (2024 sheet)', () => {
-    const { text } = buildFieldValues(makeResolved(), makeCharacter({ size: 'medium' }));
+    const { text } = bfv(makeResolved(), makeCharacter({ size: 'medium' }));
     // The in-sheet name field is just the character name (no player-name field on the 2024 sheet).
     expect(text.characterName).toBe('Aragorn');
     expect(text.class).toBe('Fighter');
@@ -173,12 +196,12 @@ describe('buildFieldValues — identity', () => {
   });
 
   it('emits the subclass in its own field when present', () => {
-    const { text } = buildFieldValues(makeResolved(), makeCharacter({ subclass: 'champion' }));
+    const { text } = bfv(makeResolved(), makeCharacter({ subclass: 'champion' }));
     expect(text.subclass).toBe('Champion');
   });
 
   it('keeps the in-sheet name field as just the character name', () => {
-    const pc = buildFieldValues(makeResolved(), makeCharacter({ player_name: 'Viggo' }));
+    const pc = bfv(makeResolved(), makeCharacter({ player_name: 'Viggo' }));
     expect(pc.text.characterName).toBe('Aragorn');
   });
 });
@@ -199,7 +222,7 @@ describe('characterDisplayName (download filename)', () => {
 
 describe('buildFieldValues — abilities & saves', () => {
   it('maps each ability score and signed modifier', () => {
-    const { text } = buildFieldValues(makeResolved(), makeCharacter());
+    const { text } = bfv(makeResolved(), makeCharacter());
     expect(text.strScore).toBe('16');
     expect(text.strMod).toBe('+3');
     expect(text.dexMod).toBe('+2');
@@ -208,7 +231,7 @@ describe('buildFieldValues — abilities & saves', () => {
   });
 
   it('maps saving-throw bonuses (signed) and proficiency checkboxes', () => {
-    const { text, checks } = buildFieldValues(makeResolved(), makeCharacter());
+    const { text, checks } = bfv(makeResolved(), makeCharacter());
     expect(text.strSave).toBe('+6');
     expect(text.chaSave).toBe('-1');
     expect(checks.strSaveProf).toBe(true);
@@ -217,7 +240,7 @@ describe('buildFieldValues — abilities & saves', () => {
   });
 
   it('emits a save entry for all six abilities', () => {
-    const { text } = buildFieldValues(makeResolved(), makeCharacter());
+    const { text } = bfv(makeResolved(), makeCharacter());
     for (const a of PDF_ABILITIES) {
       expect(text[`${a}Save`]).toMatch(/^[+-]\d+$/);
     }
@@ -233,7 +256,7 @@ describe('buildFieldValues — skills', () => {
         stealth: skill('dex', 5, true),
       },
     });
-    const { text, checks } = buildFieldValues(resolved, makeCharacter());
+    const { text, checks } = bfv(resolved, makeCharacter());
     expect(text.athletics).toBe('+6');
     expect(checks.athleticsProf).toBe(true);
     expect(text.stealth).toBe('+5');
@@ -247,7 +270,7 @@ describe('buildFieldValues — combat', () => {
     const resolved = makeResolved({
       skills: { ...makeResolved().skills, perception: skill('wis', 4, true) },
     });
-    const { text } = buildFieldValues(resolved, makeCharacter());
+    const { text } = bfv(resolved, makeCharacter());
     expect(text.armorClass).toBe('18');
     expect(text.initiative).toBe('+2');
     expect(text.speed).toBe('30 ft');
@@ -259,7 +282,7 @@ describe('buildFieldValues — combat', () => {
   });
 
   it('omits hit-dice max when the build has no hit dice', () => {
-    const { text } = buildFieldValues(makeResolved({ hitDie: [] }), makeCharacter());
+    const { text } = bfv(makeResolved({ hitDie: [] }), makeCharacter());
     expect(text.hitDiceMax).toBeUndefined();
   });
 });
@@ -281,10 +304,10 @@ describe('buildFieldValues — attacks', () => {
         },
       ],
     });
-    const { text } = buildFieldValues(resolved, makeCharacter());
+    const { text } = bfv(resolved, makeCharacter());
     expect(text.atk1Name).toBe('Longsword');
     expect(text.atk1Bonus).toBe('+6');
-    expect(text.atk1Damage).toBe('1d8+3 slashing');
+    expect(text.atk1Damage).toBe('1d8+3 Slashing'); // damage type localized via i18n
   });
 
   it('omits the damage bonus segment when it is zero', () => {
@@ -303,36 +326,66 @@ describe('buildFieldValues — attacks', () => {
         },
       ],
     });
-    const { text } = buildFieldValues(resolved, makeCharacter());
-    expect(text.atk1Damage).toBe('1d4 bludgeoning');
+    const { text } = bfv(resolved, makeCharacter());
+    expect(text.atk1Damage).toBe('1d4 Bludgeoning');
   });
 });
 
 describe('buildFieldValues — features split (2024 sections)', () => {
-  it('splits features into class features, species traits and feats by grant origin', () => {
+  it('splits class features and species traits by grant origin, using i18n names', () => {
     const resolved = makeResolved({
+      // Real ids so the i18n names resolve (barbarian-rage → "Rage", human-resourceful → "Resourceful").
       features: [
-        { feature: { id: 'second-wind', name: 'Second Wind' }, source: { origin: 'class', id: 'fighter', level: 1 } },
-        { feature: { id: 'darkvision', name: 'Darkvision' }, source: { origin: 'species', id: 'elf', level: 0 } },
-        { feature: { id: 'alert', name: 'Alert' }, source: { origin: 'feat', id: 'alert', level: 0 } },
+        { feature: { id: 'barbarian-rage' }, source: { origin: 'class', id: 'barbarian', level: 1 } },
+        { feature: { id: 'human-resourceful' }, source: { origin: 'species', id: 'human', level: 0 } },
       ] as ResolvedCharacter['features'],
       weaponMasteries: [{ weaponId: 'longsword', masteryId: 'sap' }],
     });
     const character = makeCharacter({ heroic_inspiration: true, exhaustion_level: 2 });
-    const { text, checks } = buildFieldValues(resolved, character);
-    // Class section gets class/subclass features plus the no-dedicated-field extras.
-    expect(text.classFeatures).toContain('Second Wind');
+    const { text, checks } = bfv(resolved, character);
+    // i18n display name, NOT the id, and no "Barbarian" class prefix.
+    expect(text.classFeatures).toContain('Rage');
+    expect(text.classFeatures).not.toContain('barbarian-rage');
     expect(text.classFeatures).toContain('Exhaustion: level 2');
     expect(text.classFeatures).toContain('Weapon Mastery: Longsword (Sap)');
-    expect(text.speciesTraits).toContain('Darkvision');
-    expect(text.feats).toContain('Alert');
+    expect(text.speciesTraits).toContain('Resourceful');
     expect(checks.inspiration).toBe(true);
   });
 
   it('omits the exhaustion / mastery extras from class features when inactive', () => {
-    const { text } = buildFieldValues(makeResolved(), makeCharacter());
+    const { text } = bfv(makeResolved(), makeCharacter());
     expect(text.classFeatures).not.toContain('Exhaustion');
     expect(text.classFeatures).not.toContain('Weapon Mastery');
+  });
+
+  it('lists feats as "Name (Source)" from the granted-feat map', () => {
+    const featSources = new Map<string, SourceTag>([
+      ['savage-attacker', { origin: 'background', id: 'soldier' }],
+      ['tough', { origin: 'species', id: 'human' }],
+    ]);
+    const { text } = bfv(makeResolved(), makeCharacter(), featSources);
+    expect(text.feats).toContain('Savage Attacker (Soldier)');
+    expect(text.feats).toContain('Tough (Human)');
+  });
+});
+
+describe('collectFeatSources', () => {
+  it('attributes a background origin feat and a species feat-choice to their granters', () => {
+    const featChoiceKey = 'feat-choice:species:human:0';
+    const bundles = [
+      { source: { origin: 'background', id: 'soldier' }, grants: [{ type: 'feat', featId: 'savage-attacker' }] },
+      {
+        source: { origin: 'species', id: 'human' },
+        grants: [{ type: 'feat-choice', key: featChoiceKey, from: null, category: 'origin' }],
+      },
+    ] as unknown as Parameters<typeof collectFeatSources>[0];
+    const choices = { [featChoiceKey]: { type: 'feat-choice', featId: 'tough' } } as unknown as Parameters<
+      typeof collectFeatSources
+    >[1];
+
+    const map = collectFeatSources(bundles, choices);
+    expect(map.get('savage-attacker')).toEqual({ origin: 'background', id: 'soldier' });
+    expect(map.get('tough')).toEqual({ origin: 'species', id: 'human' });
   });
 });
 
@@ -341,7 +394,7 @@ describe('buildFieldValues — equipment & backstory', () => {
     const resolved = makeResolved({
       equipment: [equippedWeapon('longsword'), equippedWeapon('dagger', 2)],
     });
-    const { text } = buildFieldValues(resolved, makeCharacter());
+    const { text } = bfv(resolved, makeCharacter());
     expect(text.equipment).toContain('Longsword');
     expect(text.equipment).toContain('Dagger ×2');
     // The 2024 sheet has a single combined Backstory & Personality block.
@@ -366,11 +419,10 @@ describe('buildFieldValues — 2024 proficiencies & languages', () => {
         sourced('shields'),
       ] as ResolvedCharacter['armorProficiencies'],
     });
-    const { text, checks } = buildFieldValues(resolved, makeCharacter());
+    const { text, checks } = bfv(resolved, makeCharacter());
     expect(text.weaponProficienciesText).toBe('Simple, Martial');
-    // Tool ids are concatenated (no separators) and this layer is i18n-free, so titleCase
-    // can't reinsert spaces — display names proper come from the i18n layer elsewhere.
-    expect(text.toolProficienciesText).toBe('Thievestools');
+    // Proper localized name from i18n (not a title-cased id).
+    expect(text.toolProficienciesText).toBe("Thieves' Tools");
     expect(text.languages).toBe('Common, Elvish');
     expect(checks.armorLight).toBe(true);
     expect(checks.armorMedium).toBe(true);
@@ -394,7 +446,7 @@ describe('buildFieldValues — spellcasting', () => {
         pactMagic: null,
       },
     });
-    const { text } = buildFieldValues(resolved, makeCharacter({ class: 'wizard' }));
+    const { text } = bfv(resolved, makeCharacter({ class: 'wizard' }));
     expect(text.spellSaveDc).toBe('15');
     expect(text.spellAttackBonus).toBe('+7');
     expect(text.spellcastingAbility).toBe('Intelligence');
@@ -404,7 +456,7 @@ describe('buildFieldValues — spellcasting', () => {
   });
 
   it('omits spell fields entirely for a non-caster', () => {
-    const { text } = buildFieldValues(makeResolved(), makeCharacter());
+    const { text } = bfv(makeResolved(), makeCharacter());
     expect(text.spellSaveDc).toBeUndefined();
     expect(text.spellAttackBonus).toBeUndefined();
   });

--- a/src/lib/pdf-field-map.test.ts
+++ b/src/lib/pdf-field-map.test.ts
@@ -352,6 +352,20 @@ describe('buildFieldValues — features split (2024 sections)', () => {
     expect(checks.inspiration).toBe(true);
   });
 
+  it('folds background-granted features into class features rather than dropping them', () => {
+    // Backgrounds grant features directly (e.g. Acolyte → feat-magic-initiate-cleric, origin
+    // 'background'). These belong to no dedicated 2024 field and are NOT in featSources, so they
+    // must land in the catch-all Class Features block — never silently dropped from the sheet.
+    const resolved = makeResolved({
+      features: [
+        { feature: { id: 'feat-magic-initiate-cleric' }, source: { origin: 'background', id: 'acolyte' } },
+      ] as ResolvedCharacter['features'],
+    });
+    const { text } = bfv(resolved, makeCharacter());
+    expect(text.classFeatures).toContain('Magic Initiate');
+    expect(text.classFeatures).not.toContain('feat-magic-initiate-cleric');
+  });
+
   it('omits the exhaustion / mastery extras from class features when inactive', () => {
     const { text } = bfv(makeResolved(), makeCharacter());
     expect(text.classFeatures).not.toContain('Exhaustion');

--- a/src/lib/pdf-field-map.test.ts
+++ b/src/lib/pdf-field-map.test.ts
@@ -372,6 +372,39 @@ describe('buildFieldValues — features split (2024 sections)', () => {
     expect(text.classFeatures).not.toContain('Weapon Mastery');
   });
 
+  it('flows overflowing class features into the second column', () => {
+    // Rage (~10 lines) + Unarmored Defense (~4) fit the first column; Weapon Mastery (~9 more)
+    // would overflow, so it and anything after it move to the second column (Text55).
+    const resolved = makeResolved({
+      features: [
+        { feature: { id: 'barbarian-rage' }, source: { origin: 'class', id: 'barbarian', level: 1 } },
+        { feature: { id: 'barbarian-unarmored-defense' }, source: { origin: 'class', id: 'barbarian', level: 1 } },
+        { feature: { id: 'barbarian-weapon-mastery' }, source: { origin: 'class', id: 'barbarian', level: 1 } },
+        { feature: { id: 'barbarian-reckless-attack' }, source: { origin: 'class', id: 'barbarian', level: 2 } },
+      ] as ResolvedCharacter['features'],
+    });
+    const { text } = bfv(resolved, makeCharacter());
+    // Column one: Rage + Unarmored Defense, and NOT the overflow features.
+    expect(text.classFeatures).toContain('Rage');
+    expect(text.classFeatures).toContain('Unarmored Defense');
+    expect(text.classFeatures).not.toContain('Weapon Mastery');
+    expect(text.classFeatures).not.toContain('Reckless Attack');
+    // Column two: the overflow.
+    expect(text.classFeatures2).toContain('Weapon Mastery');
+    expect(text.classFeatures2).toContain('Reckless Attack');
+  });
+
+  it('leaves the second column empty when the features fit in one column', () => {
+    const resolved = makeResolved({
+      features: [
+        { feature: { id: 'barbarian-rage' }, source: { origin: 'class', id: 'barbarian', level: 1 } },
+      ] as ResolvedCharacter['features'],
+    });
+    const { text } = bfv(resolved, makeCharacter());
+    expect(text.classFeatures).toContain('Rage');
+    expect(text.classFeatures2).toBe('');
+  });
+
   it('lists feats as "Name (Source)" with the feat description appended', () => {
     const featSources = new Map<string, FeatGrantInfo>([
       ['savage-attacker', { source: { origin: 'background', id: 'soldier' }, decisions: [] }],

--- a/src/lib/pdf-field-map.ts
+++ b/src/lib/pdf-field-map.ts
@@ -24,7 +24,7 @@ import type { TFunction } from 'i18next';
 import type { Character } from '@/types/database';
 import type { AbilityKey } from '@/types/database';
 import type { ResolvedCharacter, ResolvedFeature } from '@/types/resolved';
-import type { ChoiceDecision } from '@/types/choices';
+import { parseChoiceKey, type ChoiceDecision } from '@/types/choices';
 import type { GrantBundle, SourceTag } from '@/types/sources';
 import { getItemNameKey } from '@/lib/sources/items';
 
@@ -98,6 +98,13 @@ function featureLabel(f: ResolvedFeature, t: GamedataT): string {
   return t(`features.${f.feature.id}.name` as `features.${string}.name`, { defaultValue: f.feature.id });
 }
 
+/** "Name — description" line for a feature, with the i18n description appended when present. */
+function featureLine(f: ResolvedFeature, t: GamedataT): string {
+  const name = featureLabel(f, t);
+  const desc = t(`features.${f.feature.id}.description` as `features.${string}.description`, { defaultValue: '' });
+  return desc ? `${name} — ${desc}` : name;
+}
+
 /** i18n display name for a grant source — used to attribute a feat to its granter (e.g. "Soldier"). */
 function sourceLabel(tag: SourceTag, t: GamedataT): string {
   switch (tag.origin) {
@@ -118,31 +125,83 @@ function sourceLabel(tag: SourceTag, t: GamedataT): string {
   }
 }
 
+/** What granted a feat, plus the feat's own in-feat choices (e.g. Skilled's chosen skills). */
+export interface FeatGrantInfo {
+  /** The source that granted the feat (background origin feat, species feat-choice, class/subclass ASI). */
+  readonly source: SourceTag;
+  /** Decisions made for the feat's own choices (keyed `…:feat:<featId>:…` in the build). */
+  readonly decisions: readonly ChoiceDecision[];
+}
+
 /**
- * Map each feat the character has to the source that granted it (background origin
- * feat, a species feat-choice like Human's Versatile, or a class/subclass ASI feat).
- * Scans the grant bundles: a `feat` grant's granter is its bundle's source; a resolved
- * `feat-choice` decision's granter is the bundle that offered the choice. Drives the
- * "Savage Attacker (Soldier)" rendering. First writer wins (a feat is granted once).
+ * Map each feat the character has to {@link FeatGrantInfo}. The granter comes from the
+ * grant bundles: a `feat` grant's granter is its bundle's source; a resolved `feat-choice`
+ * decision's granter is the bundle that offered the choice. The feat's own choices (a
+ * feat-origin choice key, e.g. Skilled's `skill-choice:feat:skilled:0`) are gathered from
+ * `choices`. Drives the "Skilled (Human): Nature" rendering. First writer wins.
  */
 export function collectFeatSources(
   bundles: readonly GrantBundle[],
   choices: Readonly<Record<string, ChoiceDecision>>
-): ReadonlyMap<string, SourceTag> {
-  const map = new Map<string, SourceTag>();
+): ReadonlyMap<string, FeatGrantInfo> {
+  const sources = new Map<string, SourceTag>();
   for (const bundle of bundles) {
     for (const grant of bundle.grants) {
       if (grant.type === 'feat') {
-        if (!map.has(grant.featId)) map.set(grant.featId, bundle.source);
+        if (!sources.has(grant.featId)) sources.set(grant.featId, bundle.source);
       } else if (grant.type === 'feat-choice') {
         const decision = choices[grant.key];
-        if (decision?.type === 'feat-choice' && !map.has(decision.featId)) {
-          map.set(decision.featId, bundle.source);
+        if (decision?.type === 'feat-choice' && !sources.has(decision.featId)) {
+          sources.set(decision.featId, bundle.source);
         }
       }
     }
   }
-  return map;
+
+  // Gather each feat's own choice decisions (feat-origin choice keys) for granted feats.
+  const decisions = new Map<string, ChoiceDecision[]>();
+  for (const [key, decision] of Object.entries(choices)) {
+    let parsed: ReturnType<typeof parseChoiceKey>;
+    try {
+      parsed = parseChoiceKey(key);
+    } catch {
+      continue;
+    }
+    if (parsed.origin !== 'feat' || !sources.has(parsed.id)) continue;
+    const list = decisions.get(parsed.id) ?? [];
+    list.push(decision);
+    decisions.set(parsed.id, list);
+  }
+
+  const result = new Map<string, FeatGrantInfo>();
+  for (const [featId, source] of sources) {
+    result.set(featId, { source, decisions: decisions.get(featId) ?? [] });
+  }
+  return result;
+}
+
+/** Format a choice decision's chosen values as localized display strings (for feat choice summaries). */
+function formatDecisionValues(d: ChoiceDecision, t: GamedataT): readonly string[] {
+  switch (d.type) {
+    case 'skill-choice':
+      return d.skills.map((s) => t(`skills.${s}` as `skills.${string}`, { defaultValue: s }));
+    case 'tool-choice':
+      return d.tools.map((x) => t(`tools.${x}` as `tools.${string}`, { defaultValue: x }));
+    case 'language-choice':
+      return d.languages.map((x) => t(`languages.${x}` as `languages.${string}`, { defaultValue: x }));
+    case 'spell-choice':
+      return d.spellIds.map((x) => t(`spells.${x}.name` as `spells.${string}.name`, { defaultValue: x }));
+    case 'ability-choice':
+      return d.abilities.map((a) => t(`abilities.${a}`, { defaultValue: a }));
+    case 'damage-choice':
+      return d.damageTypes.map((x) => t(`damageTypes.${x}` as `damageTypes.${string}`, { defaultValue: x }));
+    case 'feature-choice':
+      return [t(`features.${d.optionId}.name` as `features.${string}.name`, { defaultValue: d.optionId })];
+    case 'feat-choice':
+      return [t(`feats.${d.featId}.name` as `feats.${string}.name`, { defaultValue: d.featId })];
+    default:
+      return [];
+  }
 }
 
 /**
@@ -158,7 +217,7 @@ export function buildFieldValues(
   resolved: ResolvedCharacter,
   character: Character,
   t: GamedataT,
-  featSources: ReadonlyMap<string, SourceTag>
+  featSources: ReadonlyMap<string, FeatGrantInfo>
 ): PdfFieldValues {
   const text: Record<string, string> = {};
   const checks: Record<string, boolean> = {};
@@ -237,9 +296,11 @@ export function buildFieldValues(
 
   // Features — the 2024 sheet has dedicated Class Features, Species Traits and
   // Feats sections, so we split by grant origin rather than lumping them together.
+  // Each line carries the feature's i18n description (where one exists), so the sheet
+  // shows what a feature does — including reset/usage wording when the text has it.
   const classFeatureLines: string[] = resolved.features
     .filter((f) => f.source.origin === 'class' || f.source.origin === 'subclass')
-    .map((f) => featureLabel(f, t));
+    .map((f) => featureLine(f, t));
   // 2024 concepts with no dedicated field are folded into the class-features block.
   if (character.exhaustion_level > 0) classFeatureLines.push(`Exhaustion: level ${character.exhaustion_level}`);
   const masteries = resolved.weaponMasteries.length > 0 ? resolved.weaponMasteries : (character.weapon_masteries ?? []);
@@ -256,15 +317,19 @@ export function buildFieldValues(
   text.classFeatures = classFeatureLines.join('\n');
   text.speciesTraits = resolved.features
     .filter((f) => f.source.origin === 'species')
-    .map((f) => featureLabel(f, t))
+    .map((f) => featureLine(f, t))
     .join('\n');
   // Feats: listed from the granted-feat map (not resolved.features, since some feats
-  // grant no feature) as "Name (Source)", e.g. "Savage Attacker (Soldier)".
+  // grant no feature). Format: "Name (Source): chosen options — description", e.g.
+  // "Skilled (Human): Nature, Athletics — Gain proficiency in any combination of …".
   text.feats = Array.from(featSources.entries())
-    .map(([featId, granter]) => {
+    .map(([featId, info]) => {
       const name = t(`feats.${featId}.name` as `feats.${string}.name`, { defaultValue: featId });
-      const granterLabel = sourceLabel(granter, t);
-      return granterLabel ? `${name} (${granterLabel})` : name;
+      const granterLabel = sourceLabel(info.source, t);
+      const head = granterLabel ? `${name} (${granterLabel})` : name;
+      const choiceStr = info.decisions.flatMap((d) => formatDecisionValues(d, t)).join(', ');
+      const desc = t(`feats.${featId}.description` as `feats.${string}.description`, { defaultValue: '' });
+      return `${head}${choiceStr ? `: ${choiceStr}` : ''}${desc ? ` — ${desc}` : ''}`;
     })
     .join('\n');
 

--- a/src/lib/pdf-field-map.ts
+++ b/src/lib/pdf-field-map.ts
@@ -8,19 +8,21 @@
  *
  *  2. {@link TEXT_FIELD_NAMES} / {@link CHECK_FIELD_NAMES} — the *binding* layer.
  *     A thin map from those semantic keys to the form-field names of a specific
- *     fillable PDF. The names below target the widely-circulated **2014 WotC
- *     form-fillable character sheet** (the de-facto community standard; no stable
- *     2024 fillable form with documented field names is publicly distributed).
+ *     fillable PDF. The names below target the **official 2024 WotC fillable
+ *     character sheet** (© 2024 Wizards of the Coast). That sheet ships with
+ *     auto-generated, semantically-opaque field names (`Text1`, `Check Box37`,
+ *     `Text105.0`, …), so the binding values look meaningless on their own — the
+ *     `// → label` comment on each line records what cell the field actually is.
  *
- *     ⚠️ These strings are TEMPLATE-DEPENDENT. Different PDFs (official WotC, MPMB,
- *     community forms) use different field-name schemes. If your supplied template
- *     fills blank, run `form.getFields().map(f => f.getName())` on it and adjust
- *     these maps. The fill pipeline ({@link import('./pdf-export').fillCharacterPdf})
+ *     ⚠️ These strings are TEMPLATE-DEPENDENT. A different PDF (2014 WotC, MPMB,
+ *     other community forms) uses a different field-name scheme. If your supplied
+ *     template fills blank, run `form.getFields().map(f => f.getName())` on it and
+ *     adjust these maps. The fill pipeline ({@link import('./pdf-export').fillCharacterPdf})
  *     reports any mapped name absent from the template rather than failing silently.
  */
 import type { Character } from '@/types/database';
 import type { AbilityKey } from '@/types/database';
-import type { ResolvedCharacter } from '@/types/resolved';
+import type { ResolvedCharacter, ResolvedFeature } from '@/types/resolved';
 
 export const PDF_ABILITIES: readonly AbilityKey[] = ['str', 'dex', 'con', 'int', 'wis', 'cha'] as const;
 
@@ -47,6 +49,9 @@ export const PDF_SKILLS = [
 ] as const;
 
 export type PdfSkillId = (typeof PDF_SKILLS)[number];
+
+/** The 2024 sheet's "Weapons & Damage Cantrips" table has six rows. */
+const PDF_ATTACK_ROWS = 6;
 
 export interface PdfFieldValues {
   /** Text fields keyed by semantic name. */
@@ -88,6 +93,8 @@ function abilityLabel(a: AbilityKey): string {
   }[a];
 }
 
+const featureName = (f: ResolvedFeature): string => f.feature.name ?? titleCase(f.feature.id);
+
 /**
  * Alignment is stored as a short code (`lg`, `ne`, …) rather than an English word,
  * so `titleCase` can't recover the display name — map the closed 9-value set here.
@@ -108,22 +115,25 @@ const ALIGNMENT_NAMES: Readonly<Record<string, string>> = {
 /**
  * Build the semantic field values for a (resolved) character. Pure — no i18n, no
  * DOM, no PDF. Every value here is verifiable against the resolver in tests.
+ *
+ * Shaped for the 2024 WotC sheet: Class / Subclass / Level are distinct fields,
+ * features are split into Class Features / Species Traits / Feats, and personality
+ * + backstory are merged into one block (the sheet has a single combined section).
  */
 export function buildFieldValues(resolved: ResolvedCharacter, character: Character): PdfFieldValues {
   const text: Record<string, string> = {};
   const checks: Record<string, boolean> = {};
 
-  // Identity
+  // Identity — the 2024 sheet has separate Class, Subclass and Level fields and
+  // no Player Name field.
   text.characterName = character.name;
-  text.classLevel = [character.class ? titleCase(character.class) : '', character.level]
-    .filter(Boolean)
-    .join(' ')
-    .trim();
-  if (character.subclass) text.classLevel += ` (${titleCase(character.subclass)})`;
-  text.background = character.background ? titleCase(character.background) : '';
+  if (character.class) text.class = titleCase(character.class);
+  if (character.subclass) text.subclass = titleCase(character.subclass);
+  text.level = String(character.level);
   text.species = character.species ? titleCase(character.species) : '';
+  text.background = character.background ? titleCase(character.background) : '';
   text.alignment = character.alignment ? (ALIGNMENT_NAMES[character.alignment] ?? titleCase(character.alignment)) : '';
-  text.playerName = character.player_name ?? '';
+  if (character.size) text.size = titleCase(character.size);
 
   // Abilities + saving throws
   for (const a of PDF_ABILITIES) {
@@ -149,12 +159,14 @@ export function buildFieldValues(resolved: ResolvedCharacter, character: Charact
   text.initiative = signed(resolved.initiative);
   text.speed = resolved.speed.walk ? `${resolved.speed.walk.value} ft` : '';
   text.maxHp = String(resolved.hitPoints.max);
+  // No current-HP concept in the build model; a freshly-built character starts at full.
+  text.currentHp = String(resolved.hitPoints.max);
   // Passive perception = 10 + Perception skill bonus.
   const perception = resolved.skills.perception;
   if (perception) text.passivePerception = String(10 + perception.bonus);
 
-  // Attacks (the 2014 form has three weapon rows).
-  resolved.attacks.slice(0, 3).forEach((atk, i) => {
+  // Attacks (the 2024 sheet has six weapon rows).
+  resolved.attacks.slice(0, PDF_ATTACK_ROWS).forEach((atk, i) => {
     const n = i + 1;
     text[`atk${n}Name`] = titleCase(atk.weaponId);
     text[`atk${n}Bonus`] = signed(atk.attackBonus);
@@ -162,127 +174,227 @@ export function buildFieldValues(resolved: ResolvedCharacter, character: Charact
     text[`atk${n}Damage`] = `${atk.damageDice}${dmgBonus} ${atk.damageType}`.trim();
   });
 
-  // Features & Traits — the 2014 form has no dedicated fields for several 2024
-  // concepts (Heroic Inspiration, Exhaustion, weapon mastery, Origin Feat), so we
-  // fold them into the features text block.
-  const featureLines: string[] = resolved.features.map((f) => f.feature.name ?? titleCase(f.feature.id));
-  if (character.heroic_inspiration) featureLines.push('Heroic Inspiration: yes');
-  if (character.exhaustion_level > 0) featureLines.push(`Exhaustion: level ${character.exhaustion_level}`);
+  // Features — the 2024 sheet has dedicated Class Features, Species Traits and
+  // Feats sections, so we split by grant origin rather than lumping them together.
+  const classFeatureLines: string[] = resolved.features
+    .filter((f) => f.source.origin === 'class' || f.source.origin === 'subclass')
+    .map(featureName);
+  // 2024 concepts with no dedicated field are folded into the class-features block.
+  if (character.exhaustion_level > 0) classFeatureLines.push(`Exhaustion: level ${character.exhaustion_level}`);
   const masteries = resolved.weaponMasteries.length > 0 ? resolved.weaponMasteries : (character.weapon_masteries ?? []);
   if (masteries.length > 0) {
-    featureLines.push(
+    classFeatureLines.push(
       `Weapon Mastery: ${masteries.map((m) => `${titleCase(m.weaponId)} (${titleCase(m.masteryId)})`).join(', ')}`
     );
   }
-  text.featuresTraits = featureLines.join('\n');
+  text.classFeatures = classFeatureLines.join('\n');
+  text.speciesTraits = resolved.features
+    .filter((f) => f.source.origin === 'species')
+    .map(featureName)
+    .join('\n');
+  text.feats = resolved.features
+    .filter((f) => f.source.origin === 'feat')
+    .map(featureName)
+    .join('\n');
+
+  // Proficiency text blocks (the sheet has free-text Weapons / Tools lines + a
+  // Languages box). Heroic Inspiration also maps to the sheet's checkbox.
+  text.weaponProficienciesText = resolved.weaponProficiencies.map((p) => titleCase(p.value)).join(', ');
+  text.toolProficienciesText = resolved.toolProficiencies.map((p) => titleCase(p.value)).join(', ');
+  text.languages = resolved.languages.map((l) => titleCase(l.value)).join(', ');
+
+  // Armor Training checkboxes. The sheet distinguishes only Light/Medium/Heavy/Shields,
+  // so the "-nonmetal" variants collapse onto their base category.
+  const armorIds = new Set(resolved.armorProficiencies.map((p) => p.value));
+  checks.armorLight = armorIds.has('light');
+  checks.armorMedium = armorIds.has('medium') || armorIds.has('medium-nonmetal');
+  checks.armorHeavy = armorIds.has('heavy');
+  checks.armorShields = armorIds.has('shields') || armorIds.has('shields-nonmetal');
 
   // Equipment
   text.equipment = resolved.equipment
     .map((it) => (it.quantity > 1 ? `${titleCase(it.itemId)} ×${it.quantity}` : titleCase(it.itemId)))
     .join('\n');
 
-  // Personality
-  text.personalityTraits = character.personality_traits ?? '';
-  text.ideals = character.ideals ?? '';
-  text.bonds = character.bonds ?? '';
-  text.flaws = character.flaws ?? '';
-  text.backstory = character.backstory ?? '';
+  // Appearance + the combined Backstory & Personality block.
   text.appearance = character.appearance ?? '';
+  text.backstory = [
+    character.backstory,
+    character.personality_traits ? `Personality Traits: ${character.personality_traits}` : '',
+    character.ideals ? `Ideals: ${character.ideals}` : '',
+    character.bonds ? `Bonds: ${character.bonds}` : '',
+    character.flaws ? `Flaws: ${character.flaws}` : '',
+  ]
+    .filter(Boolean)
+    .join('\n');
 
   // Spellcasting
   const sc = resolved.spellcasting;
   if (sc) {
-    if (sc.ability) text.spellcastingAbility = abilityLabel(sc.ability);
+    if (sc.ability) {
+      text.spellcastingAbility = abilityLabel(sc.ability);
+      text.spellcastingModifier = signed(resolved.abilities[sc.ability].modifier);
+    }
     if (sc.spellSaveDC != null) text.spellSaveDc = String(sc.spellSaveDC);
     if (sc.spellAttackBonus != null) text.spellAttackBonus = signed(sc.spellAttackBonus);
-    if (character.class) text.spellcastingClass = titleCase(character.class);
   }
 
-  // Heroic Inspiration also maps to the 2024 sheet's inspiration checkbox.
+  // Heroic Inspiration → the 2024 sheet's inspiration checkbox.
   checks.inspiration = character.heroic_inspiration;
 
   return { text, checks };
 }
 
-// --- binding layer: semantic key → 2014 WotC fillable-form field name (TEMPLATE-DEPENDENT) ---
+// --- binding layer: semantic key → 2024 WotC field name (TEMPLATE-DEPENDENT) ---
+//
+// The official 2024 sheet uses opaque auto-generated names. Per-ability and per-skill
+// fields don't follow a derivable pattern, so they're enumerated explicitly. Each
+// `// → …` comment names the cell the field occupies on the sheet.
+
+const ABILITY_MOD_FIELD: Readonly<Record<AbilityKey, string>> = {
+  str: 'Text21',
+  dex: 'Text22',
+  con: 'Text24',
+  int: 'Text20',
+  wis: 'Text23',
+  cha: 'Text25',
+};
+const ABILITY_SCORE_FIELD: Readonly<Record<AbilityKey, string>> = {
+  str: 'Text64',
+  dex: 'Text66',
+  con: 'Text67',
+  int: 'Text63',
+  wis: 'Text65',
+  cha: 'Text68',
+};
+const ABILITY_SAVE_FIELD: Readonly<Record<AbilityKey, string>> = {
+  str: 'Text91',
+  dex: 'Text87',
+  con: 'Text86',
+  int: 'Text69',
+  wis: 'Text75',
+  cha: 'Text81',
+};
+const ABILITY_SAVE_PROF_FIELD: Readonly<Record<AbilityKey, string>> = {
+  str: 'Check Box37',
+  dex: 'Check Box33',
+  con: 'Check Box32',
+  int: 'Check Box4',
+  wis: 'Check Box21',
+  cha: 'Check Box26',
+};
+
+const SKILL_FIELD: Readonly<Record<PdfSkillId, string>> = {
+  acrobatics: 'Text88',
+  animalhandling: 'Text76',
+  arcana: 'Text70',
+  athletics: 'Text92',
+  deception: 'Text82',
+  history: 'Text71',
+  insight: 'Text77',
+  intimidation: 'Text83',
+  investigation: 'Text72',
+  medicine: 'Text78',
+  nature: 'Text73',
+  perception: 'Text79',
+  performance: 'Text84',
+  persuasion: 'Text85',
+  religion: 'Text74',
+  sleightofhand: 'Text89',
+  stealth: 'Text90',
+  survival: 'Text80',
+};
+const SKILL_PROF_FIELD: Readonly<Record<PdfSkillId, string>> = {
+  acrobatics: 'Check Box34',
+  animalhandling: 'Check Box22',
+  arcana: 'Check Box16',
+  athletics: 'Check Box38',
+  deception: 'Check Box27',
+  history: 'Check Box17',
+  insight: 'Check Box23',
+  intimidation: 'Check Box28',
+  investigation: 'Check Box19',
+  medicine: 'Check Box25',
+  nature: 'Check Box20',
+  perception: 'Check Box31',
+  performance: 'Check Box30',
+  persuasion: 'Check Box29',
+  religion: 'Check Box18',
+  sleightofhand: 'Check Box35',
+  stealth: 'Check Box36',
+  survival: 'Check Box24',
+};
+
+// Weapons & Damage Cantrips table — six rows of [Name, Atk/DC, Damage&Type].
+const ATTACK_NAME_FIELDS = ['Text30', 'Text34', 'Text38', 'Text42', 'Text46', 'Text50'] as const;
+const ATTACK_BONUS_FIELDS = ['Text31', 'Text35', 'Text39', 'Text43', 'Text47', 'Text51'] as const;
+const ATTACK_DAMAGE_FIELDS = ['Text32', 'Text36', 'Text40', 'Text44', 'Text48', 'Text52'] as const;
 
 /**
- * Maps semantic text keys to 2014 WotC form field names. Adjust to your template
+ * Maps semantic text keys to 2024 WotC form field names. Adjust to your template
  * (see module header). Keys absent here are simply not written.
  */
 export const TEXT_FIELD_NAMES: Readonly<Record<string, string>> = {
-  characterName: 'CharacterName',
-  classLevel: 'ClassLevel',
-  background: 'Background',
-  species: 'Race ',
-  alignment: 'Alignment',
-  playerName: 'PlayerName',
+  characterName: 'Text1', // → Character Name
+  background: 'Text6', // → Background
+  class: 'Text7', // → Class
+  species: 'Text8', // → Species
+  subclass: 'Text9', // → Subclass
+  level: 'Text11', // → Level
+  alignment: 'Text100', // → Alignment (page 2)
+  size: 'Text28', // → Size
 
   ...Object.fromEntries(
     PDF_ABILITIES.flatMap((a) => [
-      [scoreKey(a), a.toUpperCase()],
-      [modKey(a), `${a.toUpperCase()}mod`],
+      [scoreKey(a), ABILITY_SCORE_FIELD[a]],
+      [modKey(a), ABILITY_MOD_FIELD[a]],
+      [saveKey(a), ABILITY_SAVE_FIELD[a]],
     ])
   ),
-  ...Object.fromEntries(PDF_ABILITIES.map((a) => [saveKey(a), `ST ${abilityLabel(a)}`])),
+  ...Object.fromEntries(PDF_SKILLS.map((s) => [skillKey(s), SKILL_FIELD[s]])),
 
-  acrobatics: 'Acrobatics',
-  animalhandling: 'Animal',
-  arcana: 'Arcana',
-  athletics: 'Athletics',
-  deception: 'Deception ',
-  history: 'History ',
-  insight: 'Insight',
-  intimidation: 'Intimidation',
-  investigation: 'Investigation ',
-  medicine: 'Medicine',
-  nature: 'Nature',
-  perception: 'Perception ',
-  performance: 'Performance',
-  persuasion: 'Persuasion',
-  religion: 'Religion',
-  sleightofhand: 'SleightofHand',
-  stealth: 'Stealth ',
-  survival: 'Survival',
+  profBonus: 'Text19', // → Proficiency Bonus
+  armorClass: 'Text13', // → Armor Class
+  initiative: 'Text26', // → Initiative
+  speed: 'Text27', // → Speed
+  maxHp: 'Text16', // → Hit Points Max
+  currentHp: 'Text14', // → Hit Points Current
+  passivePerception: 'Text29', // → Passive Perception
 
-  profBonus: 'ProfBonus',
-  armorClass: 'AC',
-  initiative: 'Initiative',
-  speed: 'Speed',
-  maxHp: 'HPMax',
-  passivePerception: 'Passive',
+  ...Object.fromEntries(
+    Array.from({ length: PDF_ATTACK_ROWS }, (_unused, i) => [
+      [`atk${i + 1}Name`, ATTACK_NAME_FIELDS[i]],
+      [`atk${i + 1}Bonus`, ATTACK_BONUS_FIELDS[i]],
+      [`atk${i + 1}Damage`, ATTACK_DAMAGE_FIELDS[i]],
+    ]).flat()
+  ),
 
-  atk1Name: 'Wpn Name',
-  atk1Bonus: 'Wpn1 AtkBonus',
-  atk1Damage: 'Wpn1 Damage',
-  atk2Name: 'Wpn Name 2',
-  atk2Bonus: 'Wpn2 AtkBonus ',
-  atk2Damage: 'Wpn2 Damage ',
-  atk3Name: 'Wpn Name 3',
-  atk3Bonus: 'Wpn3 AtkBonus  ',
-  atk3Damage: 'Wpn3 Damage ',
+  classFeatures: 'Text54', // → Class Features
+  speciesTraits: 'Text57', // → Species Traits
+  feats: 'Text58', // → Feats
+  weaponProficienciesText: 'Text59', // → Equipment Training & Proficiencies: Weapons
+  toolProficienciesText: 'Text60', // → Equipment Training & Proficiencies: Tools
+  languages: 'Text98', // → Languages (page 2)
+  equipment: 'Text99', // → Equipment (page 2)
+  appearance: 'Text96', // → Appearance (page 2)
+  backstory: 'Text97', // → Backstory & Personality (page 2)
 
-  featuresTraits: 'Features and Traits',
-  equipment: 'Equipment',
-  personalityTraits: 'PersonalityTraits ',
-  ideals: 'Ideals',
-  bonds: 'Bonds',
-  flaws: 'Flaws',
-  backstory: 'Backstory',
-  appearance: 'CharacterAppearance',
-  spellcastingAbility: 'Spellcasting Ability 2',
-  spellSaveDc: 'SpellSaveDC  2',
-  spellAttackBonus: 'SpellAtkBonus 2',
-  spellcastingClass: 'Spellcasting Class 2',
+  spellcastingAbility: 'Text111', // → Spellcasting Ability (page 2)
+  spellcastingModifier: 'Text93', // → Spellcasting Modifier (page 2)
+  spellSaveDc: 'Text94', // → Spell Save DC (page 2)
+  spellAttackBonus: 'Text95', // → Spell Attack Bonus (page 2)
 };
 
 /**
- * Maps semantic checkbox keys to 2014 WotC form checkbox field names. The classic
- * form names proficiency checkboxes as opaque "Check Box NN" — adjust to your
- * template. Keys absent here are not written.
+ * Maps semantic checkbox keys to 2024 WotC form checkbox field names. Adjust to
+ * your template (see module header). Keys absent here are not written.
  */
 export const CHECK_FIELD_NAMES: Readonly<Record<string, string>> = {
-  ...Object.fromEntries(PDF_ABILITIES.map((a, i) => [saveProfKey(a), `Check Box ${11 + i}`])),
-  ...Object.fromEntries(PDF_SKILLS.map((s, i) => [skillProfKey(s), `Check Box ${23 + i}`])),
-  inspiration: 'Inspiration',
+  ...Object.fromEntries(PDF_ABILITIES.map((a) => [saveProfKey(a), ABILITY_SAVE_PROF_FIELD[a]])),
+  ...Object.fromEntries(PDF_SKILLS.map((s) => [skillProfKey(s), SKILL_PROF_FIELD[s]])),
+  inspiration: 'Check Box11', // → Heroic Inspiration
+  armorLight: 'Check Box13', // → Armor Training: Light
+  armorMedium: 'Check Box14', // → Armor Training: Medium
+  armorHeavy: 'Check Box15', // → Armor Training: Heavy
+  armorShields: 'Check Box12', // → Armor Training: Shields
 };

--- a/src/lib/pdf-field-map.ts
+++ b/src/lib/pdf-field-map.ts
@@ -74,6 +74,18 @@ export function signed(value: number): string {
   return value >= 0 ? `+${value}` : `${value}`;
 }
 
+/**
+ * Display name for the exported PDF's filename. A PC with a player reads as
+ * "Character (Player)" so files are easy to tell apart; NPCs (and PCs without a
+ * player) use just the character name. The in-sheet name field uses the bare
+ * character name — the 2024 sheet has no player-name field.
+ */
+export function characterDisplayName(character: Character): string {
+  return character.character_type === 'pc' && character.player_name
+    ? `${character.name} (${character.player_name})`
+    : character.name;
+}
+
 /** Humanize a kebab/lower id into a display label: "magic-initiate" → "Magic Initiate". */
 function titleCase(id: string): string {
   return id
@@ -124,13 +136,9 @@ export function buildFieldValues(resolved: ResolvedCharacter, character: Charact
   const text: Record<string, string> = {};
   const checks: Record<string, boolean> = {};
 
-  // Identity — the 2024 sheet has separate Class, Subclass and Level fields but no
-  // dedicated Player Name field, so a PC folds its player into the name as
-  // "Character (Player)". NPCs (and PCs without a player) show just the name.
-  text.characterName =
-    character.character_type === 'pc' && character.player_name
-      ? `${character.name} (${character.player_name})`
-      : character.name;
+  // Identity — the 2024 sheet has separate Class, Subclass and Level fields and no
+  // Player Name field, so the name field is just the character name.
+  text.characterName = character.name;
   if (character.class) text.class = titleCase(character.class);
   if (character.subclass) text.subclass = titleCase(character.subclass);
   text.level = String(character.level);

--- a/src/lib/pdf-field-map.ts
+++ b/src/lib/pdf-field-map.ts
@@ -133,7 +133,8 @@ export function buildFieldValues(resolved: ResolvedCharacter, character: Charact
   text.species = character.species ? titleCase(character.species) : '';
   text.background = character.background ? titleCase(character.background) : '';
   text.alignment = character.alignment ? (ALIGNMENT_NAMES[character.alignment] ?? titleCase(character.alignment)) : '';
-  if (character.size) text.size = titleCase(character.size);
+  // The 2024 sheet's Size box wants a single-letter abbreviation (S / M / L / …).
+  if (character.size) text.size = character.size.charAt(0).toUpperCase();
 
   // Abilities + saving throws
   for (const a of PDF_ABILITIES) {
@@ -161,6 +162,11 @@ export function buildFieldValues(resolved: ResolvedCharacter, character: Charact
   text.maxHp = String(resolved.hitPoints.max);
   // No current-HP concept in the build model; a freshly-built character starts at full.
   text.currentHp = String(resolved.hitPoints.max);
+  // Hit Dice maximum is fixed by level (one die per class level): "5d10", or
+  // "3d10 + 2d6" when multiclassed. Spent hit dice aren't tracked in the build model.
+  if (resolved.hitDie.length > 0) {
+    text.hitDiceMax = resolved.hitDie.map((hd) => `${hd.count}d${hd.die}`).join(' + ');
+  }
   // Passive perception = 10 + Perception skill bonus.
   const perception = resolved.skills.perception;
   if (perception) text.passivePerception = String(10 + perception.bonus);
@@ -359,6 +365,7 @@ export const TEXT_FIELD_NAMES: Readonly<Record<string, string>> = {
   speed: 'Text27', // → Speed
   maxHp: 'Text16', // → Hit Points Max
   currentHp: 'Text14', // → Hit Points Current
+  hitDiceMax: 'Text17', // → Hit Dice Max
   passivePerception: 'Text29', // → Passive Perception
 
   ...Object.fromEntries(

--- a/src/lib/pdf-field-map.ts
+++ b/src/lib/pdf-field-map.ts
@@ -106,6 +106,63 @@ function featureLine(f: ResolvedFeature, t: GamedataT): string {
   return desc ? `${name} — ${desc}` : name;
 }
 
+// The 2024 sheet's Class Features box is split into two side-by-side columns
+// (Text54 / Text55), each a fixed Helvetica-10 multiline field roughly 175×202pt
+// that clips rather than shrinks. These are the empirically-calibrated capacities:
+// at ~40 chars/line a column holds ~17 wrapped lines before clipping.
+const CLASS_FEATURES_CHARS_PER_LINE = 40;
+const CLASS_FEATURES_LINES_PER_COLUMN = 17;
+
+/** Estimate how many wrapped lines `text` occupies at `charsPerLine`, word-wrapping like the PDF field. */
+function estimateWrappedLines(text: string, charsPerLine: number): number {
+  let lines = 0;
+  for (const paragraph of text.split('\n')) {
+    if (paragraph.length === 0) {
+      lines += 1;
+      continue;
+    }
+    let lineLen = 0;
+    let linesInParagraph = 1;
+    for (const word of paragraph.split(' ')) {
+      if (lineLen === 0) {
+        lineLen = word.length;
+      } else if (lineLen + 1 + word.length <= charsPerLine) {
+        lineLen += 1 + word.length;
+      } else {
+        linesInParagraph += 1;
+        lineLen = word.length;
+      }
+      // A single word longer than the column wraps onto extra lines.
+      while (lineLen > charsPerLine) {
+        linesInParagraph += 1;
+        lineLen -= charsPerLine;
+      }
+    }
+    lines += linesInParagraph;
+  }
+  return lines;
+}
+
+/**
+ * Split feature lines across the two Class Features columns: fill the first column
+ * until the next whole feature would overflow it, then put that feature and all the
+ * rest in the second column. Features are never split mid-text. With only two columns
+ * available, overflow beyond the second column clips (no third column exists).
+ */
+function splitClassFeatureColumns(lines: readonly string[]): readonly [string, string] {
+  let usedLines = 0;
+  let splitIndex = lines.length; // default: everything fits in column one
+  for (let i = 0; i < lines.length; i++) {
+    const needed = estimateWrappedLines(lines[i], CLASS_FEATURES_CHARS_PER_LINE);
+    if (usedLines > 0 && usedLines + needed > CLASS_FEATURES_LINES_PER_COLUMN) {
+      splitIndex = i;
+      break;
+    }
+    usedLines += needed;
+  }
+  return [lines.slice(0, splitIndex).join('\n'), lines.slice(splitIndex).join('\n')];
+}
+
 /** What granted a feat, plus the feat's own in-feat choices (e.g. Skilled's chosen skills). */
 export interface FeatGrantInfo {
   /** The source that granted the feat (background origin feat, species feat-choice, class/subclass ASI). */
@@ -299,7 +356,11 @@ export function buildFieldValues(
       .join(', ');
     classFeatureLines.push(`Weapon Mastery: ${masteryList}`);
   }
-  text.classFeatures = classFeatureLines.join('\n');
+  // Flow the features across the sheet's two Class Features columns so a long list
+  // (e.g. a Barbarian's descriptive Rage + Unarmored Defense) doesn't clip in column one.
+  const [classFeaturesCol1, classFeaturesCol2] = splitClassFeatureColumns(classFeatureLines);
+  text.classFeatures = classFeaturesCol1;
+  text.classFeatures2 = classFeaturesCol2;
   text.speciesTraits = resolved.features
     .filter((f) => f.source.origin === 'species')
     .map((f) => featureLine(f, t))
@@ -500,7 +561,8 @@ export const TEXT_FIELD_NAMES: Readonly<Record<string, string>> = {
     ]).flat()
   ),
 
-  classFeatures: 'Text54', // → Class Features
+  classFeatures: 'Text54', // → Class Features (left column)
+  classFeatures2: 'Text55', // → Class Features (right column — overflow from Text54)
   speciesTraits: 'Text57', // → Species Traits
   feats: 'Text58', // → Feats
   weaponProficienciesText: 'Text59', // → Equipment Training & Proficiencies: Weapons

--- a/src/lib/pdf-field-map.ts
+++ b/src/lib/pdf-field-map.ts
@@ -20,9 +20,16 @@
  *     adjust these maps. The fill pipeline ({@link import('./pdf-export').fillCharacterPdf})
  *     reports any mapped name absent from the template rather than failing silently.
  */
+import type { TFunction } from 'i18next';
 import type { Character } from '@/types/database';
 import type { AbilityKey } from '@/types/database';
 import type { ResolvedCharacter, ResolvedFeature } from '@/types/resolved';
+import type { ChoiceDecision } from '@/types/choices';
+import type { GrantBundle, SourceTag } from '@/types/sources';
+import { getItemNameKey } from '@/lib/sources/items';
+
+/** Gamedata i18n translator. All user-facing text in the export comes from i18n — ids are never user-facing. */
+export type GamedataT = TFunction<'gamedata'>;
 
 export const PDF_ABILITIES: readonly AbilityKey[] = ['str', 'dex', 'con', 'int', 'wis', 'cha'] as const;
 
@@ -86,67 +93,102 @@ export function characterDisplayName(character: Character): string {
     : character.name;
 }
 
-/** Humanize a kebab/lower id into a display label: "magic-initiate" → "Magic Initiate". */
-function titleCase(id: string): string {
-  return id
-    .replace(/[-_]/g, ' ')
-    .replace(/\b\w/g, (c) => c.toUpperCase())
-    .trim();
+/** i18n display name for a granted feature (class feature or species trait). */
+function featureLabel(f: ResolvedFeature, t: GamedataT): string {
+  return t(`features.${f.feature.id}.name` as `features.${string}.name`, { defaultValue: f.feature.id });
 }
 
-function abilityLabel(a: AbilityKey): string {
-  return {
-    str: 'Strength',
-    dex: 'Dexterity',
-    con: 'Constitution',
-    int: 'Intelligence',
-    wis: 'Wisdom',
-    cha: 'Charisma',
-  }[a];
+/** i18n display name for a grant source — used to attribute a feat to its granter (e.g. "Soldier"). */
+function sourceLabel(tag: SourceTag, t: GamedataT): string {
+  switch (tag.origin) {
+    case 'species':
+      return t(`species.${tag.id}`, { defaultValue: tag.id });
+    case 'class':
+      return t(`classes.${tag.id}`, { defaultValue: tag.id });
+    case 'subclass':
+      return t(`subclasses.${tag.id}.name`, { defaultValue: tag.id });
+    case 'background':
+      return t(`backgrounds.${tag.id}`, { defaultValue: tag.id });
+    case 'feat':
+      return t(`feats.${tag.id}.name`, { defaultValue: tag.id });
+    case 'loot':
+      return tag.description;
+    default:
+      return tag.id;
+  }
 }
-
-const featureName = (f: ResolvedFeature): string => f.feature.name ?? titleCase(f.feature.id);
 
 /**
- * Alignment is stored as a short code (`lg`, `ne`, …) rather than an English word,
- * so `titleCase` can't recover the display name — map the closed 9-value set here.
- * (class/species/background/subclass ids ARE their English words, so titleCase suffices.)
+ * Map each feat the character has to the source that granted it (background origin
+ * feat, a species feat-choice like Human's Versatile, or a class/subclass ASI feat).
+ * Scans the grant bundles: a `feat` grant's granter is its bundle's source; a resolved
+ * `feat-choice` decision's granter is the bundle that offered the choice. Drives the
+ * "Savage Attacker (Soldier)" rendering. First writer wins (a feat is granted once).
  */
-const ALIGNMENT_NAMES: Readonly<Record<string, string>> = {
-  lg: 'Lawful Good',
-  ng: 'Neutral Good',
-  cg: 'Chaotic Good',
-  ln: 'Lawful Neutral',
-  n: 'Neutral',
-  cn: 'Chaotic Neutral',
-  le: 'Lawful Evil',
-  ne: 'Neutral Evil',
-  ce: 'Chaotic Evil',
-};
+export function collectFeatSources(
+  bundles: readonly GrantBundle[],
+  choices: Readonly<Record<string, ChoiceDecision>>
+): ReadonlyMap<string, SourceTag> {
+  const map = new Map<string, SourceTag>();
+  for (const bundle of bundles) {
+    for (const grant of bundle.grants) {
+      if (grant.type === 'feat') {
+        if (!map.has(grant.featId)) map.set(grant.featId, bundle.source);
+      } else if (grant.type === 'feat-choice') {
+        const decision = choices[grant.key];
+        if (decision?.type === 'feat-choice' && !map.has(decision.featId)) {
+          map.set(decision.featId, bundle.source);
+        }
+      }
+    }
+  }
+  return map;
+}
 
 /**
- * Build the semantic field values for a (resolved) character. Pure — no i18n, no
- * DOM, no PDF. Every value here is verifiable against the resolver in tests.
+ * Build the semantic field values for a (resolved) character. All user-facing text
+ * comes from the gamedata i18n translator `t` — ids are never user-facing. `featSources`
+ * (see {@link collectFeatSources}) attributes each feat to its granter. No DOM, no PDF.
  *
  * Shaped for the 2024 WotC sheet: Class / Subclass / Level are distinct fields,
  * features are split into Class Features / Species Traits / Feats, and personality
  * + backstory are merged into one block (the sheet has a single combined section).
  */
-export function buildFieldValues(resolved: ResolvedCharacter, character: Character): PdfFieldValues {
+export function buildFieldValues(
+  resolved: ResolvedCharacter,
+  character: Character,
+  t: GamedataT,
+  featSources: ReadonlyMap<string, SourceTag>
+): PdfFieldValues {
   const text: Record<string, string> = {};
   const checks: Record<string, boolean> = {};
 
   // Identity — the 2024 sheet has separate Class, Subclass and Level fields and no
   // Player Name field, so the name field is just the character name.
   text.characterName = character.name;
-  if (character.class) text.class = titleCase(character.class);
-  if (character.subclass) text.subclass = titleCase(character.subclass);
+  if (character.class)
+    text.class = t(`classes.${character.class}` as `classes.${string}`, { defaultValue: character.class });
+  if (character.subclass)
+    text.subclass = t(`subclasses.${character.subclass}.name` as `subclasses.${string}.name`, {
+      defaultValue: character.subclass,
+    });
   text.level = String(character.level);
-  text.species = character.species ? titleCase(character.species) : '';
-  text.background = character.background ? titleCase(character.background) : '';
-  text.alignment = character.alignment ? (ALIGNMENT_NAMES[character.alignment] ?? titleCase(character.alignment)) : '';
-  // The 2024 sheet's Size box wants a single-letter abbreviation (S / M / L / …).
-  if (character.size) text.size = character.size.charAt(0).toUpperCase();
+  text.species = character.species
+    ? t(`species.${character.species}` as `species.${string}`, { defaultValue: character.species })
+    : '';
+  text.background = character.background
+    ? t(`backgrounds.${character.background}` as `backgrounds.${string}`, { defaultValue: character.background })
+    : '';
+  text.alignment = character.alignment
+    ? t(`alignments.${character.alignment}` as `alignments.${string}`, { defaultValue: character.alignment })
+    : '';
+  // The 2024 sheet's Size box wants a single-letter abbreviation (S / M / L / …), taken
+  // from the first letter of the localized size name.
+  if (character.size) {
+    text.size = t(`sizes.${character.size}` as `sizes.${string}`, { defaultValue: character.size })
+      .charAt(0)
+      .toUpperCase();
+  }
 
   // Abilities + saving throws
   for (const a of PDF_ABILITIES) {
@@ -186,40 +228,57 @@ export function buildFieldValues(resolved: ResolvedCharacter, character: Charact
   // Attacks (the 2024 sheet has six weapon rows).
   resolved.attacks.slice(0, PDF_ATTACK_ROWS).forEach((atk, i) => {
     const n = i + 1;
-    text[`atk${n}Name`] = titleCase(atk.weaponId);
+    text[`atk${n}Name`] = t(getItemNameKey('weapon', atk.weaponId), { defaultValue: atk.weaponId });
     text[`atk${n}Bonus`] = signed(atk.attackBonus);
     const dmgBonus = atk.damageBonus !== 0 ? signed(atk.damageBonus) : '';
-    text[`atk${n}Damage`] = `${atk.damageDice}${dmgBonus} ${atk.damageType}`.trim();
+    const dmgType = t(`damageTypes.${atk.damageType}`, { defaultValue: atk.damageType });
+    text[`atk${n}Damage`] = `${atk.damageDice}${dmgBonus} ${dmgType}`.trim();
   });
 
   // Features — the 2024 sheet has dedicated Class Features, Species Traits and
   // Feats sections, so we split by grant origin rather than lumping them together.
   const classFeatureLines: string[] = resolved.features
     .filter((f) => f.source.origin === 'class' || f.source.origin === 'subclass')
-    .map(featureName);
+    .map((f) => featureLabel(f, t));
   // 2024 concepts with no dedicated field are folded into the class-features block.
   if (character.exhaustion_level > 0) classFeatureLines.push(`Exhaustion: level ${character.exhaustion_level}`);
   const masteries = resolved.weaponMasteries.length > 0 ? resolved.weaponMasteries : (character.weapon_masteries ?? []);
   if (masteries.length > 0) {
-    classFeatureLines.push(
-      `Weapon Mastery: ${masteries.map((m) => `${titleCase(m.weaponId)} (${titleCase(m.masteryId)})`).join(', ')}`
-    );
+    const masteryList = masteries
+      .map(
+        (m) =>
+          `${t(getItemNameKey('weapon', m.weaponId), { defaultValue: m.weaponId })} ` +
+          `(${t(`weaponMasteries.${m.masteryId}.name`, { defaultValue: m.masteryId })})`
+      )
+      .join(', ');
+    classFeatureLines.push(`Weapon Mastery: ${masteryList}`);
   }
   text.classFeatures = classFeatureLines.join('\n');
   text.speciesTraits = resolved.features
     .filter((f) => f.source.origin === 'species')
-    .map(featureName)
+    .map((f) => featureLabel(f, t))
     .join('\n');
-  text.feats = resolved.features
-    .filter((f) => f.source.origin === 'feat')
-    .map(featureName)
+  // Feats: listed from the granted-feat map (not resolved.features, since some feats
+  // grant no feature) as "Name (Source)", e.g. "Savage Attacker (Soldier)".
+  text.feats = Array.from(featSources.entries())
+    .map(([featId, granter]) => {
+      const name = t(`feats.${featId}.name` as `feats.${string}.name`, { defaultValue: featId });
+      const granterLabel = sourceLabel(granter, t);
+      return granterLabel ? `${name} (${granterLabel})` : name;
+    })
     .join('\n');
 
   // Proficiency text blocks (the sheet has free-text Weapons / Tools lines + a
   // Languages box). Heroic Inspiration also maps to the sheet's checkbox.
-  text.weaponProficienciesText = resolved.weaponProficiencies.map((p) => titleCase(p.value)).join(', ');
-  text.toolProficienciesText = resolved.toolProficiencies.map((p) => titleCase(p.value)).join(', ');
-  text.languages = resolved.languages.map((l) => titleCase(l.value)).join(', ');
+  text.weaponProficienciesText = resolved.weaponProficiencies
+    .map((p) => t(`weapons.${p.value}` as `weapons.${string}`, { defaultValue: p.value }))
+    .join(', ');
+  text.toolProficienciesText = resolved.toolProficiencies
+    .map((p) => t(`tools.${p.value}` as `tools.${string}`, { defaultValue: p.value }))
+    .join(', ');
+  text.languages = resolved.languages
+    .map((l) => t(`languages.${l.value}` as `languages.${string}`, { defaultValue: l.value }))
+    .join(', ');
 
   // Armor Training checkboxes. The sheet distinguishes only Light/Medium/Heavy/Shields,
   // so the "-nonmetal" variants collapse onto their base category.
@@ -231,7 +290,10 @@ export function buildFieldValues(resolved: ResolvedCharacter, character: Charact
 
   // Equipment
   text.equipment = resolved.equipment
-    .map((it) => (it.quantity > 1 ? `${titleCase(it.itemId)} ×${it.quantity}` : titleCase(it.itemId)))
+    .map((it) => {
+      const name = t(getItemNameKey(it.itemDef.type, it.itemId), { defaultValue: it.itemId });
+      return it.quantity > 1 ? `${name} ×${it.quantity}` : name;
+    })
     .join('\n');
 
   // Appearance + the combined Backstory & Personality block.
@@ -250,7 +312,7 @@ export function buildFieldValues(resolved: ResolvedCharacter, character: Charact
   const sc = resolved.spellcasting;
   if (sc) {
     if (sc.ability) {
-      text.spellcastingAbility = abilityLabel(sc.ability);
+      text.spellcastingAbility = t(`abilities.${sc.ability}`, { defaultValue: sc.ability });
       text.spellcastingModifier = signed(resolved.abilities[sc.ability].modifier);
     }
     if (sc.spellSaveDC != null) text.spellSaveDc = String(sc.spellSaveDC);

--- a/src/lib/pdf-field-map.ts
+++ b/src/lib/pdf-field-map.ts
@@ -124,9 +124,13 @@ export function buildFieldValues(resolved: ResolvedCharacter, character: Charact
   const text: Record<string, string> = {};
   const checks: Record<string, boolean> = {};
 
-  // Identity — the 2024 sheet has separate Class, Subclass and Level fields and
-  // no Player Name field.
-  text.characterName = character.name;
+  // Identity — the 2024 sheet has separate Class, Subclass and Level fields but no
+  // dedicated Player Name field, so a PC folds its player into the name as
+  // "Character (Player)". NPCs (and PCs without a player) show just the name.
+  text.characterName =
+    character.character_type === 'pc' && character.player_name
+      ? `${character.name} (${character.player_name})`
+      : character.name;
   if (character.class) text.class = titleCase(character.class);
   if (character.subclass) text.subclass = titleCase(character.subclass);
   text.level = String(character.level);

--- a/src/lib/pdf-field-map.ts
+++ b/src/lib/pdf-field-map.ts
@@ -27,6 +27,7 @@ import type { ResolvedCharacter, ResolvedFeature } from '@/types/resolved';
 import { parseChoiceKey, type ChoiceDecision } from '@/types/choices';
 import type { GrantBundle, SourceTag } from '@/types/sources';
 import { getItemNameKey } from '@/lib/sources/items';
+import { getSourceDisplayName } from '@/lib/class-icons';
 
 /** Gamedata i18n translator. All user-facing text in the export comes from i18n — ids are never user-facing. */
 export type GamedataT = TFunction<'gamedata'>;
@@ -103,26 +104,6 @@ function featureLine(f: ResolvedFeature, t: GamedataT): string {
   const name = featureLabel(f, t);
   const desc = t(`features.${f.feature.id}.description` as `features.${string}.description`, { defaultValue: '' });
   return desc ? `${name} — ${desc}` : name;
-}
-
-/** i18n display name for a grant source — used to attribute a feat to its granter (e.g. "Soldier"). */
-function sourceLabel(tag: SourceTag, t: GamedataT): string {
-  switch (tag.origin) {
-    case 'species':
-      return t(`species.${tag.id}`, { defaultValue: tag.id });
-    case 'class':
-      return t(`classes.${tag.id}`, { defaultValue: tag.id });
-    case 'subclass':
-      return t(`subclasses.${tag.id}.name`, { defaultValue: tag.id });
-    case 'background':
-      return t(`backgrounds.${tag.id}`, { defaultValue: tag.id });
-    case 'feat':
-      return t(`feats.${tag.id}.name`, { defaultValue: tag.id });
-    case 'loot':
-      return tag.description;
-    default:
-      return tag.id;
-  }
 }
 
 /** What granted a feat, plus the feat's own in-feat choices (e.g. Skilled's chosen skills). */
@@ -298,8 +279,12 @@ export function buildFieldValues(
   // Feats sections, so we split by grant origin rather than lumping them together.
   // Each line carries the feature's i18n description (where one exists), so the sheet
   // shows what a feature does — including reset/usage wording when the text has it.
+  // Species features go to Species Traits and feat-granted features are listed in the
+  // Feats block (from featSources); everything else — class/subclass plus
+  // background/item/loot-granted features (e.g. a background's Magic Initiate) — folds
+  // into Class Features so no resolved feature is silently dropped from the sheet.
   const classFeatureLines: string[] = resolved.features
-    .filter((f) => f.source.origin === 'class' || f.source.origin === 'subclass')
+    .filter((f) => f.source.origin !== 'species' && f.source.origin !== 'feat')
     .map((f) => featureLine(f, t));
   // 2024 concepts with no dedicated field are folded into the class-features block.
   if (character.exhaustion_level > 0) classFeatureLines.push(`Exhaustion: level ${character.exhaustion_level}`);
@@ -325,7 +310,7 @@ export function buildFieldValues(
   text.feats = Array.from(featSources.entries())
     .map(([featId, info]) => {
       const name = t(`feats.${featId}.name` as `feats.${string}.name`, { defaultValue: featId });
-      const granterLabel = sourceLabel(info.source, t);
+      const granterLabel = getSourceDisplayName(info.source, t);
       const head = granterLabel ? `${name} (${granterLabel})` : name;
       const choiceStr = info.decisions.flatMap((d) => formatDecisionValues(d, t)).join(', ');
       const desc = t(`feats.${featId}.description` as `feats.${string}.description`, { defaultValue: '' });

--- a/src/lib/pdf-field-map.ts
+++ b/src/lib/pdf-field-map.ts
@@ -27,7 +27,7 @@ import type { ResolvedCharacter, ResolvedFeature } from '@/types/resolved';
 import { parseChoiceKey, type ChoiceDecision } from '@/types/choices';
 import type { GrantBundle, SourceTag } from '@/types/sources';
 import { getItemNameKey } from '@/lib/sources/items';
-import { getSourceDisplayName } from '@/lib/class-icons';
+import { getSourceDisplayName } from '@/lib/source-display';
 
 /** Gamedata i18n translator. All user-facing text in the export comes from i18n — ids are never user-facing. */
 export type GamedataT = TFunction<'gamedata'>;

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -1624,6 +1624,82 @@ describe('Weapon mastery resolver', () => {
     expect(pending[0].count).toBe(2);
   });
 
+  it('L3 Barbarian surfaces the Primal Knowledge skill choice and a rage pool (max 3) without crashing', () => {
+    const barbarianL3Build: CharacterBuild = {
+      speciesId: 'human',
+      backgroundId: 'soldier',
+      baseAbilities: { str: 15, dex: 13, con: 14, int: 8, wis: 10, cha: 12 },
+      abilityMethod: 'standard-array',
+      choices: {
+        // L1 barbarian skill choice already made — Primal Knowledge (index 1) is the new one.
+        'skill-choice:class:barbarian:0': { type: 'skill-choice', skills: ['athletics', 'perception'] },
+        'skill-choice:species:human:0': { type: 'skill-choice', skills: ['intimidation'] },
+        'language-choice:species:human:0': { type: 'language-choice', languages: ['elvish'] },
+        'asi:background:soldier:0': { type: 'asi', allocation: { str: 2, con: 1 } },
+        'tool-choice:background:soldier:0': { type: 'tool-choice', tools: ['gaming-set-dice'] },
+        'language-choice:background:soldier:0': { type: 'language-choice', languages: ['dwarvish'] },
+        'subclass:class:barbarian:0': { type: 'subclass', subclassId: 'berserker' as SubclassId },
+      },
+      levels: [
+        { classId: 'barbarian' as ClassId, classLevel: 1, hpRoll: null },
+        { classId: 'barbarian' as ClassId, classLevel: 2, hpRoll: null },
+        { classId: 'barbarian' as ClassId, classLevel: 3, hpRoll: null },
+      ],
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(barbarianL3Build);
+    const result = resolveCharacter({
+      baseAbilities: barbarianL3Build.baseAbilities,
+      level: 3,
+      bundles,
+      choices: barbarianL3Build.choices,
+      levels: barbarianL3Build.levels,
+    });
+
+    // The L3 Primal Knowledge extra skill choice surfaces as its own pending skill-choice.
+    const skillKeys = result.pendingChoices.filter((c) => c.type === 'skill-choice').map((c) => c.choiceKey);
+    expect(skillKeys).toContain('skill-choice:class:barbarian:1');
+
+    // Primal Knowledge feature present; Rage pool scales to 3 at L3.
+    expect(result.features.map((f) => f.feature.id)).toContain('barbarian-primal-knowledge');
+    const ragePool = result.resourcePools.find((p) => p.poolId === 'rage');
+    expect(ragePool).toMatchObject({ max: 3, regen: 'long-rest' });
+  });
+
+  it('L19 Barbarian gains an Epic Boon feature and only four ASIs (no spurious 5th)', () => {
+    const levels = Array.from({ length: 19 }, (_, i) => ({
+      classId: 'barbarian' as ClassId,
+      classLevel: i + 1,
+      hpRoll: null,
+    }));
+    const barbarianL19Build: CharacterBuild = {
+      speciesId: 'human',
+      backgroundId: 'soldier',
+      baseAbilities: { str: 15, dex: 13, con: 14, int: 8, wis: 10, cha: 12 },
+      abilityMethod: 'standard-array',
+      choices: {},
+      levels,
+      feats: [],
+      activeItems: [],
+    };
+    const { bundles } = collectBundles(barbarianL19Build);
+    const result = resolveCharacter({
+      baseAbilities: barbarianL19Build.baseAbilities,
+      level: 19,
+      bundles,
+      choices: barbarianL19Build.choices,
+      levels: barbarianL19Build.levels,
+    });
+    expect(result.features.map((f) => f.feature.id)).toContain('barbarian-epic-boon');
+    const asiKeys = result.pendingChoices.filter((c) => c.type === 'asi').map((c) => c.choiceKey);
+    // Four class ASIs (L4/8/12/16) — the old L19 ASI is now the Epic Boon.
+    expect(asiKeys).toContain('asi:class:barbarian:3');
+    expect(asiKeys).not.toContain('asi:class:barbarian:4');
+    // Rage pool tops out at 6 by level 17+.
+    expect(result.resourcePools.find((p) => p.poolId === 'rage')).toMatchObject({ max: 6 });
+  });
+
   it('L1 Paladin has a weapon-mastery-choice pending choice with count 2', () => {
     const paladinBuild: CharacterBuild = {
       speciesId: 'human',

--- a/src/lib/resolver/resource-pools.test.ts
+++ b/src/lib/resolver/resource-pools.test.ts
@@ -3,7 +3,7 @@ import type { GrantBundle } from '@/types/sources';
 import { resolveResourcePools } from '@/lib/resolver/resource-pools';
 
 function classBundles(
-  classId: 'monk' | 'sorcerer',
+  classId: 'monk' | 'sorcerer' | 'barbarian',
   count: number,
   extraGrants: GrantBundle['grants'] = []
 ): GrantBundle[] {
@@ -80,6 +80,53 @@ describe('resolveResourcePools', () => {
     const pools = resolveResourcePools(bundles);
     expect(pools).toHaveLength(1);
     expect(pools[0]).toMatchObject({ poolId: 'psionic-energy', max: 4, regen: 'long-rest' });
+  });
+
+  describe('level-steps max (Barbarian Rage table)', () => {
+    const RAGE_GRANT: GrantBundle['grants'][number] = {
+      type: 'resource-pool',
+      poolId: 'rage',
+      max: {
+        mode: 'level-steps',
+        classId: 'barbarian',
+        steps: [
+          { minLevel: 1, value: 2 },
+          { minLevel: 3, value: 3 },
+          { minLevel: 6, value: 4 },
+          { minLevel: 12, value: 5 },
+          { minLevel: 17, value: 6 },
+        ],
+      },
+      regen: 'long-rest',
+    };
+
+    function barbarianAtLevel(level: number): GrantBundle[] {
+      const bundles: GrantBundle[] = [];
+      for (let l = 1; l <= level; l++) {
+        bundles.push({
+          source: { origin: 'class', id: 'barbarian', level: l },
+          grants: l === 1 ? [RAGE_GRANT] : [],
+        });
+      }
+      return bundles;
+    }
+
+    it.each([
+      [1, 2],
+      [2, 2],
+      [3, 3],
+      [5, 3],
+      [6, 4],
+      [11, 4],
+      [12, 5],
+      [16, 5],
+      [17, 6],
+      [20, 6],
+    ])('resolves rage max to %i uses at barbarian level %i', (level, expectedMax) => {
+      const pools = resolveResourcePools(barbarianAtLevel(level));
+      expect(pools).toHaveLength(1);
+      expect(pools[0]).toMatchObject({ poolId: 'rage', max: expectedMax, regen: 'long-rest' });
+    });
   });
 
   it('tags pool with its source bundle', () => {

--- a/src/lib/resolver/resource-pools.ts
+++ b/src/lib/resolver/resource-pools.ts
@@ -12,6 +12,23 @@ export function resolveResourcePools(bundles: readonly GrantBundle[]): readonly 
     let max: number;
     if (maxSpec.mode === 'fixed') {
       max = maxSpec.value;
+    } else if (maxSpec.mode === 'level-steps') {
+      const level = getClassLevel(bundles, maxSpec.classId);
+      // Highest-minLevel step that the class level satisfies wins (order-independent).
+      let bestMin = -1;
+      let value = 0;
+      for (const step of maxSpec.steps) {
+        if (level >= step.minLevel && step.minLevel > bestMin) {
+          bestMin = step.minLevel;
+          value = step.value;
+        }
+      }
+      max = value;
+      if (level === 0) {
+        logger.warn(
+          `resource-pool "${grant.poolId}" declares classId "${maxSpec.classId}" but no bundles for that class were found — max will be 0`
+        );
+      }
     } else {
       max = getClassLevel(bundles, maxSpec.classId);
       if (max === 0) {

--- a/src/lib/resolver/resource-pools.ts
+++ b/src/lib/resolver/resource-pools.ts
@@ -5,6 +5,22 @@ import { getLogger } from '@/lib/logger';
 
 const logger = getLogger('resolver');
 
+/** Highest-minLevel step whose threshold `level` satisfies wins (order-independent); 0 if none. */
+function stepValueForLevel(
+  steps: readonly { readonly minLevel: number; readonly value: number }[],
+  level: number
+): number {
+  let bestMin = -1;
+  let value = 0;
+  for (const step of steps) {
+    if (level >= step.minLevel && step.minLevel > bestMin) {
+      bestMin = step.minLevel;
+      value = step.value;
+    }
+  }
+  return value;
+}
+
 export function resolveResourcePools(bundles: readonly GrantBundle[]): readonly ResolvedResourcePool[] {
   const pools: ResolvedResourcePool[] = [];
   for (const { grant, source } of collectGrantsByType(bundles, 'resource-pool')) {
@@ -12,30 +28,15 @@ export function resolveResourcePools(bundles: readonly GrantBundle[]): readonly 
     let max: number;
     if (maxSpec.mode === 'fixed') {
       max = maxSpec.value;
-    } else if (maxSpec.mode === 'level-steps') {
+    } else {
+      // class-level and level-steps both key off the character's level in the named class.
       const level = getClassLevel(bundles, maxSpec.classId);
-      // Highest-minLevel step that the class level satisfies wins (order-independent).
-      let bestMin = -1;
-      let value = 0;
-      for (const step of maxSpec.steps) {
-        if (level >= step.minLevel && step.minLevel > bestMin) {
-          bestMin = step.minLevel;
-          value = step.value;
-        }
-      }
-      max = value;
       if (level === 0) {
         logger.warn(
           `resource-pool "${grant.poolId}" declares classId "${maxSpec.classId}" but no bundles for that class were found — max will be 0`
         );
       }
-    } else {
-      max = getClassLevel(bundles, maxSpec.classId);
-      if (max === 0) {
-        logger.warn(
-          `resource-pool "${grant.poolId}" declares classId "${maxSpec.classId}" but no bundles for that class were found — max will be 0`
-        );
-      }
+      max = maxSpec.mode === 'level-steps' ? stepValueForLevel(maxSpec.steps, level) : level;
     }
     pools.push({
       poolId: grant.poolId,

--- a/src/lib/source-display.ts
+++ b/src/lib/source-display.ts
@@ -1,0 +1,35 @@
+import type { TFunction } from 'i18next';
+import type { SourceTag } from '@/types/sources';
+import { getBundleNameKey } from '@/lib/sources/bundles';
+import { getItemNameKey } from '@/lib/sources/items';
+
+/**
+ * Resolve a user-friendly display name for a grant source (race name, class name,
+ * background name, bundle/item name, etc.) using the gamedata namespace.
+ *
+ * Lives in a React-free module so pure-logic consumers (e.g. the PDF export in
+ * `pdf-field-map.ts`) can attribute a grant to its source without pulling the
+ * React + icon dependencies of `class-icons.tsx` into their module graph.
+ */
+export function getSourceDisplayName(source: SourceTag, tGamedata: TFunction<'gamedata'>): string {
+  switch (source.origin) {
+    case 'species':
+      return tGamedata(`species.${source.id}`, { defaultValue: source.id });
+    case 'class':
+      return tGamedata(`classes.${source.id}`, { defaultValue: source.id });
+    case 'subclass':
+      return tGamedata(`subclasses.${source.id}.name`, { defaultValue: source.id });
+    case 'background':
+      return tGamedata(`backgrounds.${source.id}`, { defaultValue: source.id });
+    case 'feat':
+      return tGamedata(`feats.${source.id}.name`, { defaultValue: source.id });
+    case 'item':
+      return tGamedata(getItemNameKey('gear', source.id), { defaultValue: source.id });
+    case 'bundle':
+      return tGamedata(getBundleNameKey(source.id), { defaultValue: source.id });
+    case 'pack':
+      return tGamedata(getItemNameKey('pack', source.id), { defaultValue: source.id });
+    case 'loot':
+      return source.description;
+  }
+}

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -47,7 +47,24 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
             from: ['athletics', 'animalhandling', 'intimidation', 'nature', 'perception', 'survival'],
           },
           { type: 'feature', feature: { id: 'barbarian-rage' } },
+          {
+            type: 'resource-pool',
+            poolId: 'rage',
+            max: {
+              mode: 'level-steps',
+              classId: 'barbarian',
+              steps: [
+                { minLevel: 1, value: 2 },
+                { minLevel: 3, value: 3 },
+                { minLevel: 6, value: 4 },
+                { minLevel: 12, value: 5 },
+                { minLevel: 17, value: 6 },
+              ],
+            },
+            regen: 'long-rest',
+          },
           { type: 'feature', feature: { id: 'barbarian-unarmored-defense' } },
+          { type: 'feature', feature: { id: 'barbarian-weapon-mastery' } },
           { type: 'armor-class', calculation: { mode: 'unarmored', formula: 'barbarian' } },
           {
             type: 'weapon-mastery-choice',
@@ -63,7 +80,17 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
         ],
       },
       {
-        grants: [{ type: 'subclass', classId: 'barbarian', key: createChoiceKey('subclass', 'class', 'barbarian', 0) }],
+        grants: [
+          { type: 'subclass', classId: 'barbarian', key: createChoiceKey('subclass', 'class', 'barbarian', 0) },
+          { type: 'feature', feature: { id: 'barbarian-primal-knowledge' } },
+          {
+            type: 'proficiency-choice',
+            category: 'skill',
+            key: createChoiceKey('skill-choice', 'class', 'barbarian', 1),
+            count: 1,
+            from: ['athletics', 'animalhandling', 'intimidation', 'nature', 'perception', 'survival'],
+          },
+        ],
       },
       {
         grants: [
@@ -107,7 +134,7 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'barbarian', 3), points: 2, from: null }] },
       { grants: [{ type: 'feature', feature: { id: 'barbarian-improved-brutal-strike-2' } }] },
       { grants: [{ type: 'feature', feature: { id: 'barbarian-indomitable-might' } }] },
-      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'barbarian', 4), points: 2, from: null }] },
+      { grants: [{ type: 'feature', feature: { id: 'barbarian-epic-boon' } }] },
       { grants: [{ type: 'feature', feature: { id: 'barbarian-primal-champion' } }] },
     ],
   },

--- a/src/lib/sources/coverage-matrix.ts
+++ b/src/lib/sources/coverage-matrix.ts
@@ -75,8 +75,16 @@ export const SUBCLASS_MILESTONES_BY_CLASS: Readonly<Record<string, readonly numb
   wizard: [3, 6, 10, 14],
 } as const;
 
-/** 2024 PHB Ability Score Improvement levels common to every class. */
-export const EXPECTED_ASI_LEVELS: readonly number[] = [4, 8, 12, 16, 19] as const;
+/**
+ * 2024 PHB Ability Score Improvement levels common to every class. Level 19 is
+ * NOT here: in the 2024 rules every class gains an Epic Boon at level 19 instead
+ * of a regular ASI ({@link EPIC_BOON_LEVEL}), so that slot is checked separately
+ * and accepts either grant shape.
+ */
+export const EXPECTED_ASI_LEVELS: readonly number[] = [4, 8, 12, 16] as const;
+
+/** 2024 PHB level at which every class gains an Epic Boon feat in place of an ASI. */
+export const EPIC_BOON_LEVEL = 19 as const;
 
 /**
  * Golden-verified registry — the ONLY source of "matches the PHB" confidence.
@@ -129,11 +137,22 @@ export function computeClassCoverage(): ForkCoverage {
     const missingAsi = missingLevels(asiLevels, EXPECTED_ASI_LEVELS);
     if (missingAsi.length > 0) problems.push(`missing ASI at level(s) ${missingAsi.join(', ')}`);
 
+    // Level 19 is the Epic Boon slot in 2024: accept either an ASI grant or an
+    // Epic Boon feature (id ending `-epic-boon`) / epic-boon feat grant.
+    const l19 = src.levels[EPIC_BOON_LEVEL - 1]?.grants ?? [];
+    const hasEpicBoonSlot = l19.some(
+      (g) =>
+        g.type === 'asi' ||
+        (g.type === 'feature' && g.feature.id.endsWith('-epic-boon')) ||
+        (g.type === 'feat' && g.featId.endsWith('-epic-boon'))
+    );
+    if (!hasEpicBoonSlot) problems.push(`missing ASI or Epic Boon at level ${EPIC_BOON_LEVEL}`);
+
     const status: EntryStatus = problems.length === 0 ? 'complete' : 'partial';
     return {
       id: c.id,
       status,
-      detail: problems.length === 0 ? '20 levels, subclass@3, ASI@4/8/12/16/19' : problems.join('; '),
+      detail: problems.length === 0 ? '20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19' : problems.join('; '),
       goldenVerified: GOLDEN_VERIFIED.has(c.id),
     };
   });

--- a/src/lib/sources/coverage-matrix.ts
+++ b/src/lib/sources/coverage-matrix.ts
@@ -138,21 +138,24 @@ export function computeClassCoverage(): ForkCoverage {
     if (missingAsi.length > 0) problems.push(`missing ASI at level(s) ${missingAsi.join(', ')}`);
 
     // Level 19 is the Epic Boon slot in 2024: accept either an ASI grant or an
-    // Epic Boon feature (id ending `-epic-boon`) / epic-boon feat grant.
+    // Epic Boon feature (id ending `-epic-boon`) / epic-boon feat grant. Most class
+    // tables still model it as a plain ASI; only those carrying an actual epic-boon
+    // grant are reported as "Epic Boon@19" so the matrix doesn't overstate coverage.
     const l19 = src.levels[EPIC_BOON_LEVEL - 1]?.grants ?? [];
-    const hasEpicBoonSlot = l19.some(
+    const hasL19EpicBoon = l19.some(
       (g) =>
-        g.type === 'asi' ||
         (g.type === 'feature' && g.feature.id.endsWith('-epic-boon')) ||
         (g.type === 'feat' && g.featId.endsWith('-epic-boon'))
     );
-    if (!hasEpicBoonSlot) problems.push(`missing ASI or Epic Boon at level ${EPIC_BOON_LEVEL}`);
+    const hasL19Asi = l19.some((g) => g.type === 'asi');
+    if (!hasL19EpicBoon && !hasL19Asi) problems.push(`missing ASI or Epic Boon at level ${EPIC_BOON_LEVEL}`);
+    const l19Label = hasL19EpicBoon ? 'Epic Boon@19' : 'ASI@19';
 
     const status: EntryStatus = problems.length === 0 ? 'complete' : 'partial';
     return {
       id: c.id,
       status,
-      detail: problems.length === 0 ? '20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19' : problems.join('; '),
+      detail: problems.length === 0 ? `20 levels, subclass@3, ASI@4/8/12/16, ${l19Label}` : problems.join('; '),
       goldenVerified: GOLDEN_VERIFIED.has(c.id),
     };
   });

--- a/src/lib/sources/coverage-matrix.ts
+++ b/src/lib/sources/coverage-matrix.ts
@@ -141,13 +141,13 @@ export function computeClassCoverage(): ForkCoverage {
     // Epic Boon feature (id ending `-epic-boon`) / epic-boon feat grant. Most class
     // tables still model it as a plain ASI; only those carrying an actual epic-boon
     // grant are reported as "Epic Boon@19" so the matrix doesn't overstate coverage.
-    const l19 = src.levels[EPIC_BOON_LEVEL - 1]?.grants ?? [];
-    const hasL19EpicBoon = l19.some(
+    const hasL19EpicBoon = (src.levels[EPIC_BOON_LEVEL - 1]?.grants ?? []).some(
       (g) =>
         (g.type === 'feature' && g.feature.id.endsWith('-epic-boon')) ||
         (g.type === 'feat' && g.featId.endsWith('-epic-boon'))
     );
-    const hasL19Asi = l19.some((g) => g.type === 'asi');
+    // Reuse the asiLevels scan above rather than re-detecting an ASI grant at level 19.
+    const hasL19Asi = asiLevels.includes(EPIC_BOON_LEVEL);
     if (!hasL19EpicBoon && !hasL19Asi) problems.push(`missing ASI or Epic Boon at level ${EPIC_BOON_LEVEL}`);
     const l19Label = hasL19EpicBoon ? 'Epic Boon@19' : 'ASI@19';
 

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -225,7 +225,8 @@
       "quickNpcAdvanceTimeout": "NPC was created but the step did not advance — please navigate manually",
       "quickNpcOverwriteTitle": "Replace your current work?",
       "quickNpcOverwriteConfirm": "This will overwrite the data you have already entered. Continue?",
-      "disabledSourceBook": "This option is from a source book not enabled for this campaign."
+      "disabledSourceBook": "This option is from a source book not enabled for this campaign.",
+      "alreadyGranted": "Already granted by another source"
     },
     "abilities": {
       "standardArray": "Standard Array",

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1029,11 +1029,19 @@
     },
     "barbarian-rage": {
       "name": "Rage",
-      "description": "In battle, you fight with primal ferocity. On your turn, you can enter a rage as a bonus action."
+      "description": "In battle, you fight with primal ferocity. As a Bonus Action you can enter a Rage: you gain resistance to Bludgeoning, Piercing, and Slashing damage, advantage on Strength checks and Strength saving throws, and a Rage Damage bonus to Strength-based attacks (+2 at level 1, +3 at level 9, +4 at level 16). The number of times you can Rage is tracked as a resource pool."
     },
     "barbarian-unarmored-defense": {
       "name": "Unarmored Defense",
       "description": "While you are not wearing any armor, your Armor Class equals 10 + your Dexterity modifier + your Constitution modifier."
+    },
+    "barbarian-weapon-mastery": {
+      "name": "Weapon Mastery",
+      "description": "You can use the mastery properties of two kinds of weapons of your choice with which you have proficiency (a Simple or Martial weapon). The number of weapons increases as you gain Barbarian levels — three at level 4 and four at level 10 — and you can change your choices when you finish a Long Rest."
+    },
+    "barbarian-primal-knowledge": {
+      "name": "Primal Knowledge",
+      "description": "You gain proficiency in one additional skill of your choice from the Barbarian skill list. In addition, while your Rage is active you can channel it into certain skills: you can make Acrobatics, Intimidation, Perception, Stealth, or Survival checks as Strength checks even if they normally use a different ability."
     },
     "barbarian-reckless-attack": {
       "name": "Reckless Attack",
@@ -1082,6 +1090,10 @@
     "barbarian-indomitable-might": {
       "name": "Indomitable Might",
       "description": "If your total for a Strength check is less than your Strength score, you can use that score in place of the total."
+    },
+    "barbarian-epic-boon": {
+      "name": "Epic Boon",
+      "description": "You gain an Epic Boon feat or another feat of your choice for which you qualify. The Boon of Irresistible Offense is recommended."
     },
     "barbarian-primal-champion": {
       "name": "Primal Champion",
@@ -2411,6 +2423,10 @@
     }
   },
   "resourcePools": {
+    "rage": {
+      "name": "Rage",
+      "description": "The number of times you can enter a Rage (2 at level 1, scaling to 6 at level 17). You regain one expended use when you finish a Short Rest, and you regain all expended uses when you finish a Long Rest."
+    },
     "focus-points": {
       "name": "Focus Points",
       "description": "Fuel Monk techniques. Regain on a Short Rest."

--- a/src/pages/CharacterSheet.tsx
+++ b/src/pages/CharacterSheet.tsx
@@ -24,6 +24,7 @@ import { EditPersonalityDialog } from '@/components/character-sheet/edit-dialogs
 import { EditTextDialog } from '@/components/character-sheet/edit-dialogs/EditTextDialog';
 import { buildRestUpdate } from '@/lib/rest';
 import { exportCharacterPdf, PdfTemplateError } from '@/lib/pdf-export';
+import { collectFeatSources } from '@/lib/pdf-field-map';
 import { useCharacter, useCharacterMutations } from '@/hooks/useCharacters';
 import { useCharacterBuildLevels, useCharacterItems } from '@/hooks/useCharacterBuild';
 import { usePageTitle } from '@/hooks/usePageTitle';
@@ -53,6 +54,7 @@ function CharacterSheetInner({
   characterId: string;
 }) {
   const { t: tc } = useTranslation('common');
+  const { t: tg } = useTranslation('gamedata');
   const [editSection, setEditSection] = useState<EditSection>(null);
 
   const navigate = useNavigate();
@@ -67,6 +69,8 @@ function CharacterSheetInner({
     character: ctxCharacter,
     rows,
     resolved,
+    bundles,
+    build,
     buildError,
     buildWarnings,
     isDirty,
@@ -186,7 +190,8 @@ function CharacterSheetInner({
     }
     setExportingPdf(true);
     try {
-      const { missingFields } = await exportCharacterPdf(resolved, character);
+      const featSources = collectFeatSources(bundles, build?.choices ?? {});
+      const { missingFields } = await exportCharacterPdf(resolved, character, tg, featSources);
       if (missingFields.length > 0) {
         toast.warning(tc('characterSheet.export.successWithMissing', { count: missingFields.length }));
         logger.warn('PDF template missing mapped fields:', missingFields);

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -277,7 +277,17 @@ export interface FeatChoiceGrant {
 
 export type ResourcePoolMax =
   | { readonly mode: 'class-level'; readonly classId: ClassId }
-  | { readonly mode: 'fixed'; readonly value: number };
+  | { readonly mode: 'fixed'; readonly value: number }
+  /**
+   * A stepped table keyed on class level — e.g. the Barbarian's Rages column
+   * (2 at L1, 3 at L3, 4 at L6, 5 at L12, 6 at L17). The max is the `value` of
+   * the step with the highest `minLevel` that is ≤ the character's class level.
+   */
+  | {
+      readonly mode: 'level-steps';
+      readonly classId: ClassId;
+      readonly steps: readonly { readonly minLevel: number; readonly value: number }[];
+    };
 
 export type ResourcePoolRegen = 'short-rest' | 'long-rest';
 


### PR DESCRIPTION
From a UAT pass on a human / barbarian / soldier build, plus repointing the PDF export at the official 2024 WotC sheet.

## Character builder UAT fixes
- **Origin-feat sub-choices no longer crash.** Skill/tool/language picks from feats like *Skilled* were routed to a non-existent class level row, throwing `No active level row found for class "skilled"`. They now route to the creation row (fixed in both `resolveChoiceSequence` and `applyDecisionToRows`).
- **Most-restrictive grant routing.** A chosen skill/language now consumes the smallest eligible pool first (e.g. Athletics → the narrow Barbarian list, not the "any skill" Human grant), via a shared `pickMostRestrictiveChoiceWithRoom` helper used by both Skills and Proficiencies steps.
- **Origin-feat picker stays visible** after selection (sourced from grant bundles, not `pendingChoices`), so a misclick can be changed.
- **Class step soft notice** now shows whenever there are no actionable choices, even when display-only features (Rage, Unarmored Defense) render above it.
- **Tool proficiency de-duplicated** — removed from the Origin step; the Proficiencies (Details) step owns it.

## 2024 WotC PDF export
The binding map targeted the **2014** form, whose field names don't exist on the official **2024** sheet (which uses auto-generated names like `Text1`, `Check Box37`), so every field filled blank.
- Rewrote `TEXT_FIELD_NAMES` / `CHECK_FIELD_NAMES` to the 2024 sheet's actual field names (each annotated with the cell it fills). **All 111 mapped fields verified to exist in the real template.**
- Refactored `buildFieldValues` for the 2024 layout: separate Class/Subclass/Level; dropped Player Name & Spellcasting Class (no such fields); split features into Class Features / Species Traits / Feats by origin; merged personality + backstory; added size, languages, weapon/tool proficiency text, armor-training checkboxes, current HP, spellcasting modifier, and 6 attack rows.
- The copyrighted PDF stays gitignored — the map binds by field name, so no PDF editing is needed.

## Verification
- `npm run lint`, `npm run typecheck`, `npm run test` (2088 passed) all green.
- New tests: `resolveChoiceSequence` feat→creation-row regression, `route-choice` helper unit tests, 2024 field-map coverage; updated tests that asserted prior behavior.
- End-to-end: every mapped field name confirmed present in the real 2024 template.

🤖 Generated with [Claude Code](https://claude.com/claude-code)