### PR TITLE
feat(bdd): export specs to a manual UAT checklist

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -6,3 +6,5 @@ supabase/.temp/
 package-lock.json
 src/types/supabase.ts
 docs/coverage-matrix.md
+docs/uat-checklist.md
+docs/uat-checklist.csv

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,6 +24,7 @@ D&D 5.5e (2024 PHB) Campaign Manager — a React SPA for managing campaigns, cha
 - `npm run test:bdd` — run the Cucumber BDD suite (default profile, stays green). See `docs/bdd.md`.
 - `npm run test:bdd:future` — run spec-ahead BDD scenarios (`@future` profile, expected to fail). See `docs/bdd.md`.
 - `npm run coverage:matrix` — regenerate `docs/coverage-matrix.md` from `src/lib/sources/coverage-matrix.ts`
+- `npm run uat:checklist` — generate a manual UAT checklist (one row per BDD scenario) from `features/` into `docs/uat-checklist.csv`. Add `-- --format md` (or `both`) for a printable Markdown checklist. See `scripts/gen-uat-checklist.ts`.
 
 ### Formatting
 
@@ -108,7 +109,7 @@ Three color themes (Default/gold, Sylvan/green, Arcane/purple) with light and da
 
 #### BDD (Cucumber)
 
-Spec-first acceptance tests live in `features/`, run via `npm run test:bdd` (and `npm run test:bdd:future` for spec-ahead scenarios). The suite **drives** development — never edit `src/` or `supabase/migrations/` to force a scenario green; tag genuinely-missing functionality `@future` instead. Full guide — tag taxonomy, the two binding seams (resolver vs. render-app), and run-time gotchas — is in **`docs/bdd.md`**.
+Spec-first acceptance tests live in `features/`, run via `npm run test:bdd` (and `npm run test:bdd:future` for spec-ahead scenarios). The suite **drives** development — never edit `src/` or `supabase/migrations/` to force a scenario green; tag genuinely-missing functionality `@future` instead. Full guide — tag taxonomy, the two binding seams (resolver vs. render-app), and run-time gotchas — is in **`docs/bdd.md`**. The same specs export to a manual UAT checklist via `npm run uat:checklist` (see Commands).
 
 ## Environment Variables
 

--- a/README.md
+++ b/README.md
@@ -67,18 +67,41 @@ Open [http://localhost:5173](http://localhost:5173) in your browser.
 
 ## Scripts
 
-| Command                 | Description                                       |
-| ----------------------- | ------------------------------------------------- |
-| `npm run start`         | Start Supabase, regenerate types, and launch Vite |
-| `npm run stop`          | Stop the local Supabase instance                  |
-| `npm run dev`           | Start Vite dev server                             |
-| `npm run build`         | Typecheck and build for production                |
-| `npm run preview`       | Preview the production build                      |
-| `npm run typecheck`     | Run TypeScript type checking                      |
-| `npm run lint`          | Lint with ESLint (`--max-warnings 0`)             |
-| `npm run test`          | Run unit tests                                    |
-| `npm run test:watch`    | Run tests in watch mode                           |
-| `npm run test:coverage` | Run tests with coverage report                    |
+| Command                 | Description                                        |
+| ----------------------- | -------------------------------------------------- |
+| `npm run start`         | Start Supabase, regenerate types, and launch Vite  |
+| `npm run stop`          | Stop the local Supabase instance                   |
+| `npm run dev`           | Start Vite dev server                              |
+| `npm run build`         | Typecheck and build for production                 |
+| `npm run preview`       | Preview the production build                       |
+| `npm run typecheck`     | Run TypeScript type checking                       |
+| `npm run lint`          | Lint with ESLint (`--max-warnings 0`)              |
+| `npm run test`          | Run unit tests                                     |
+| `npm run test:watch`    | Run tests in watch mode                            |
+| `npm run test:coverage` | Run tests with coverage report                     |
+| `npm run uat:checklist` | Generate a manual UAT checklist from the BDD specs |
+
+## Acceptance Testing (UAT Checklist)
+
+The Cucumber BDD specs under `features/` double as a manual user-acceptance-testing
+script. `npm run uat:checklist` parses every `.feature` file and writes one row per
+scenario so a human tester can tick each behavior off by hand.
+
+| Command                                  | Output                   | Use for                                                      |
+| ---------------------------------------- | ------------------------ | ------------------------------------------------------------ |
+| `npm run uat:checklist`                  | `docs/uat-checklist.csv` | Open in Excel / Google Sheets (blank Result + Notes columns) |
+| `npm run uat:checklist -- --format md`   | `docs/uat-checklist.md`  | Printable list with `[ ]` checkboxes                         |
+| `npm run uat:checklist -- --format both` | both files               | —                                                            |
+
+Each scenario is labeled with a **status** derived from its tags (see `docs/bdd.md`):
+
+- **Ready** — the app is expected to support this today; validate it now.
+- **Future** — `@future` spec-ahead work order; not built yet, expect it to fail or skip.
+- **Draft** — `@draft`; steps not yet implemented.
+
+Scenario Outlines are expanded into one row per Examples table entry, with placeholders
+substituted, so every concrete case is listed. Re-run the script to refresh after the
+specs change — don't hand-edit the generated files.
 
 ## Tech Stack
 

--- a/docs/bdd.md
+++ b/docs/bdd.md
@@ -9,6 +9,9 @@ functionality the app does not have yet.
 - `npm run test:bdd` — run the default profile (implemented, passing scenarios). Stays green.
 - `npm run test:bdd:future` — run the `future` profile (spec-ahead scenarios, expected to fail
   with meaningful assertions).
+- `npm run uat:checklist` — export the specs to a manual UAT checklist (`docs/uat-checklist.csv`,
+  or `-- --format md` for a printable Markdown version). One row per scenario, labeled with its
+  tag-derived status (Ready / Future / Draft). See `scripts/gen-uat-checklist.ts`.
 
 Always run via the npm scripts, not raw `npx tsx`. The scripts set
 `TSX_TSCONFIG_PATH=tsconfig.app.json` so JSX uses the automatic runtime — the root

--- a/docs/uat-checklist.csv
+++ b/docs/uat-checklist.csv
@@ -1,0 +1,647 @@
+"File","Feature","Rule","Scenario","Status","Tags","Steps","Result (Pass/Fail/Blocked)","Notes"
+"features/campaigns/archive-campaign.feature","Archive a campaign","","A DM archives a finished campaign","Ready","","Given a campaign named ""Lost Mines"" exists
+When the Dungeon Master archives ""Lost Mines""
+Then ""Lost Mines"" does not appear in the active campaigns list","",""
+"features/campaigns/create-campaign.feature","Create a new campaign","","A DM creates a campaign by providing a name","Ready","","Given the Dungeon Master has no campaigns
+When the Dungeon Master creates a campaign named ""Curse of Strahd""
+Then ""Curse of Strahd"" appears in their campaign list","",""
+"features/campaigns/create-campaign.feature","Create a new campaign","","A campaign name is required","Ready","","When the Dungeon Master tries to create a campaign with no name
+Then the campaign is not created
+And the Dungeon Master sees that a name is required","",""
+"features/campaigns/create-campaign.feature","Create a new campaign","","A newly created campaign is ready to manage","Ready","","Given the Dungeon Master has no campaigns
+When the Dungeon Master creates a campaign named ""Tomb of Annihilation""
+Then ""Tomb of Annihilation"" is the active campaign","",""
+"features/campaigns/edit-campaign-details.feature","Edit campaign details","","A DM updates the campaign description","Ready","","Given a campaign named ""Curse of Strahd"" exists with no description
+When the Dungeon Master sets the description to ""Gothic horror in Barovia""
+Then the campaign description shows ""Gothic horror in Barovia""","",""
+"features/campaigns/edit-campaign-details.feature","Edit campaign details","","A DM changes the campaign setting","Ready","","Given a campaign named ""Sandbox"" exists in the ""Forgotten Realms"" setting
+When the Dungeon Master changes the setting to ""Eberron""
+Then the campaign is in the ""Eberron"" setting","",""
+"features/campaigns/edit-campaign-details.feature","Edit campaign details","","A DM renames a campaign","Ready","","Given a campaign named ""Untitled"" exists
+When the Dungeon Master renames it to ""Storm King's Thunder""
+Then the campaign is named ""Storm King's Thunder""","",""
+"features/campaigns/per-campaign-theme.feature","Per-campaign color theme","","A DM sets a theme on a campaign","Ready","","Given a campaign named ""Curse of Strahd"" exists with no theme set
+When the Dungeon Master sets the campaign theme to ""Arcane""
+Then ""Curse of Strahd"" uses the ""Arcane"" theme","",""
+"features/campaigns/per-campaign-theme.feature","Per-campaign color theme","","A campaign without a theme falls back to the DM's global theme","Ready","","Given the Dungeon Master's global theme is ""Sylvan""
+And a campaign named ""Sandbox"" exists with no theme set
+When the Dungeon Master opens ""Sandbox""
+Then the interface uses the ""Sylvan"" theme","",""
+"features/campaigns/per-campaign-theme.feature","Per-campaign color theme","","A campaign theme overrides the global theme while that campaign is active","Ready","","Given the Dungeon Master's global theme is ""Default""
+And a campaign named ""Curse of Strahd"" exists with theme ""Arcane""
+When the Dungeon Master opens ""Curse of Strahd""
+Then the interface uses the ""Arcane"" theme","",""
+"features/campaigns/per-campaign-theme.feature","Per-campaign color theme","","A DM clears a campaign theme to fall back to their global theme","Ready","","Given the Dungeon Master's global theme is ""Default""
+And a campaign named ""Curse of Strahd"" exists with theme ""Arcane""
+When the Dungeon Master clears the theme on ""Curse of Strahd""
+Then ""Curse of Strahd"" uses the ""Default"" theme","",""
+"features/campaigns/search-campaigns.feature","Search campaigns by name","","Typing a query narrows the list to matching campaigns","Ready","","Given a campaign named ""Dragon's Lair"" exists
+And a campaign named ""City of Shadows"" exists
+And a campaign named ""Dragon's Peak"" exists
+When the Dungeon Master searches campaigns for ""Dragon""
+Then ""Dragon's Lair"" appears in the list
+And ""Dragon's Peak"" appears in the list
+And ""City of Shadows"" does not appear in the list","",""
+"features/campaigns/search-campaigns.feature","Search campaigns by name","","Clearing the search restores the full list","Ready","","Given a campaign named ""Dragon's Lair"" exists
+And a campaign named ""City of Shadows"" exists
+When the Dungeon Master searches campaigns for ""Dragon""
+And the Dungeon Master clears the campaign search
+Then ""Dragon's Lair"" appears in the list
+And ""City of Shadows"" appears in the list","",""
+"features/campaigns/view-campaigns.feature","View existing campaigns","","A previously created campaign is visible to the DM","Ready","","Given a campaign named ""Dragon's Lair"" exists
+When the Dungeon Master views their campaigns
+Then ""Dragon's Lair"" appears in the list","",""
+"features/campaigns/view-campaigns.feature","View existing campaigns","","A first-time DM sees an empty campaign list","Ready","","Given the Dungeon Master has no campaigns
+When the Dungeon Master views their campaigns
+Then the list is empty
+And the Dungeon Master is prompted to create their first campaign","",""
+"features/campaigns/view-campaigns.feature","View existing campaigns","","Archived campaigns are hidden by default","Ready","","Given a campaign named ""Lost Mines"" exists
+And a campaign named ""Forgotten Realms"" exists but has been archived
+When the Dungeon Master views their campaigns
+Then ""Lost Mines"" appears in the list
+And ""Forgotten Realms"" does not appear in the list","",""
+"features/campaigns/view-campaigns.feature","View existing campaigns","","Campaigns are ordered by most recent activity","Ready","","Given a campaign named ""Older Game"" exists and was last played 2 weeks ago
+And a campaign named ""Current Game"" exists and was last played yesterday
+When the Dungeon Master views their campaigns
+Then ""Current Game"" appears before ""Older Game"" in the list","",""
+"features/characters/ability-modifiers.feature","Ability score modifiers","","A score of 14 gives a +2 modifier","Ready","","Given an ability score of 14
+Then the ability modifier is 2","",""
+"features/characters/ability-modifiers.feature","Ability score modifiers","","A score of 8 gives a -1 modifier","Ready","","Given an ability score of 8
+Then the ability modifier is -1","",""
+"features/characters/archive-character.feature","Archive a character","","Active characters appear in the campaign's character list","Ready","","Given a campaign with an active character named ""Valeros""
+When the Dungeon Master views the character list
+Then ""Valeros"" appears in the character list","",""
+"features/characters/builder-autosave.feature","Autosave character builder draft","","A saved draft is reloaded when returning to the builder","Ready","","Given a saved character draft named ""Aldara""
+When the player opens the character builder for that draft
+Then the builder resumes with the name ""Aldara""
+And the builder shows the species ""Human""","",""
+"features/characters/choose-ability-scores.feature","Choose ability scores during character creation","Each method produces a valid base score set","The standard array assigns the fixed set of scores","Ready","","Given a new character using the standard-array ability method
+Then the available base scores are 15, 14, 13, 12, 10, and 8","",""
+"features/characters/choose-ability-scores.feature","Choose ability scores during character creation","Each method produces a valid base score set","Point buy spends a fixed pool of points","Ready","","Given a new character using the point-buy ability method
+Then the character has 27 points to spend on ability scores","",""
+"features/characters/choose-ability-scores.feature","Choose ability scores during character creation","Each method produces a valid base score set","Point buy rejects a base score above 15","Ready","","Given a new character using the point-buy ability method
+When the character tries to set a base ability score of 16
+Then the score is not allowed","",""
+"features/characters/choose-ability-scores.feature","Choose ability scores during character creation","Background increases apply on top of base scores","A background's ability increases are added to the base scores","Ready","","Given a new character with the soldier background
+And base ability scores of 15, 14, 13, 12, 10, and 8
+When the soldier ability increases are applied to Strength and Constitution
+Then the final Strength score includes the background increase
+And the final ability modifiers reflect the increased scores","",""
+"features/characters/choose-background.feature","Choose a background during character creation","A background grants fixed proficiencies","A background grants two skill proficiencies","Ready","","Given a new character with the soldier background
+Then the character is proficient in the Athletics skill
+And the character is proficient in the Intimidation skill","",""
+"features/characters/choose-background.feature","Choose a background during character creation","A background grants fixed proficiencies","A background grants a tool proficiency or tool choice","Ready","","Given a new character with the soldier background
+Then the character has a tool proficiency from the background","",""
+"features/characters/choose-background.feature","Choose a background during character creation","A background grants 2024-style ability increases","A background grants three points of ability score increases","Ready","","Given a new character with the soldier background
+Then the background grants 3 points of ability score increases","",""
+"features/characters/choose-background.feature","Choose a background during character creation","A background grants an origin feat","A background grants its origin feat","Ready","","Given a new character with the soldier background
+Then the character gains an origin feat","",""
+"features/characters/choose-class.feature","Choose a class during character creation","A class grants its core proficiencies at level 1","A class grants its saving throw proficiencies","Ready","","Given a new character with the fighter class at level 1
+Then the character is proficient in Strength saving throws
+And the character is proficient in Constitution saving throws","",""
+"features/characters/choose-class.feature","Choose a class during character creation","A class grants its core proficiencies at level 1","A class grants its saving throw proficiencies","Ready","","Given a new character with the wizard class at level 1
+Then the character is proficient in Intelligence saving throws
+And the character is proficient in Wisdom saving throws","",""
+"features/characters/choose-class.feature","Choose a class during character creation","A class grants its core proficiencies at level 1","A class grants its saving throw proficiencies","Ready","","Given a new character with the cleric class at level 1
+Then the character is proficient in Wisdom saving throws
+And the character is proficient in Charisma saving throws","",""
+"features/characters/choose-class.feature","Choose a class during character creation","A class grants its core proficiencies at level 1","A class offers skill proficiency choices from its own list","Ready","","Given a new character with the cleric class at level 1
+Then the character must choose 2 skills from the cleric skill list","",""
+"features/characters/choose-class.feature","Choose a class during character creation","A class introduces its signature level-1 mechanics","A martial class grants a weapon mastery choice","Ready","","Given a new character with the fighter class at level 1
+Then the character must choose weapon masteries","",""
+"features/characters/choose-class.feature","Choose a class during character creation","A class introduces its signature level-1 mechanics","A spellcasting class gains spellcasting at level 1","Ready","","Given a new character with the wizard class at level 1
+Then the character has spellcasting from its class","",""
+"features/characters/choose-class.feature","Choose a class during character creation","Every class selects a subclass at level 3","A class must choose a subclass when it reaches level 3","Ready","","Given a new character with the fighter class at level 3
+Then the character must choose a subclass","",""
+"features/characters/choose-class.feature","Choose a class during character creation","Every class selects a subclass at level 3","A class must choose a subclass when it reaches level 3","Ready","","Given a new character with the cleric class at level 3
+Then the character must choose a subclass","",""
+"features/characters/choose-class.feature","Choose a class during character creation","Every class selects a subclass at level 3","A class must choose a subclass when it reaches level 3","Ready","","Given a new character with the wizard class at level 3
+Then the character must choose a subclass","",""
+"features/characters/choose-equipment.feature","Choose starting equipment during character creation","A class offers a starting equipment choice","A class presents its starting equipment options","Ready","","Given a new character with the fighter class at level 1
+Then the character must choose a starting equipment option","",""
+"features/characters/choose-equipment.feature","Choose starting equipment during character creation","Choosing an option populates the inventory","Choosing a starting equipment option adds its items","Ready","","Given a new character with the fighter class at level 1
+When the character chooses the first starting equipment option
+Then the chosen items appear in the character's inventory","",""
+"features/characters/choose-skills.feature","Choose skills during character creation","Skill proficiencies combine across sources","A character's skills come from both class and background","Ready","","Given a new character with the cleric class and the soldier background
+Then the character's skill proficiencies include the soldier background skills
+And the character may choose additional skills from the cleric","",""
+"features/characters/choose-skills.feature","Choose skills during character creation","Skill proficiencies combine across sources","A class skill choice offers the correct count from its list","Ready","","Given a new character with the cleric class at level 1
+Then the character must choose 2 skills from the cleric skill list","",""
+"features/characters/choose-skills.feature","Choose skills during character creation","Overlapping skill grants are not double-counted","A skill granted by two sources is only counted once","Ready","","Given a new character whose class and background both grant the Athletics skill
+Then the character is proficient in the Athletics skill exactly once","",""
+"features/characters/choose-skills.feature","Choose skills during character creation","Expertise improves a chosen skill","Expertise doubles the proficiency bonus for a chosen skill","Ready","","Given a new character with the rogue class at level 1
+When the character chooses Expertise in the Stealth skill
+Then the Stealth skill applies double the proficiency bonus","",""
+"features/characters/choose-species.feature","Choose a species during character creation","A species grants its racial traits","A species grants its level-1 traits","Ready","","Given a new character with the dwarf species
+Then the character has the Darkvision trait
+And the character has the Dwarven Resilience trait","",""
+"features/characters/choose-species.feature","Choose a species during character creation","Species with a lineage require a lineage choice","A species with lineages must choose one","Ready","","Given a new character with the elf species
+Then the character must choose a lineage","",""
+"features/characters/choose-species.feature","Choose a species during character creation","Species with a lineage require a lineage choice","A species with lineages must choose one","Ready","","Given a new character with the gnome species
+Then the character must choose a lineage","",""
+"features/characters/choose-species.feature","Choose a species during character creation","Species with a lineage require a lineage choice","A species with lineages must choose one","Ready","","Given a new character with the dragonborn species
+Then the character must choose a draconic ancestry","",""
+"features/characters/choose-species.feature","Choose a species during character creation","Species with a lineage require a lineage choice","A chosen lineage grants its sub-traits","Ready","","Given a new character with the elf species
+When the character chooses the Wood Elf lineage
+Then the character gains the traits of the Wood Elf lineage","",""
+"features/characters/choose-species.feature","Choose a species during character creation","Species without a lineage require no lineage choice","A species without lineages has no lineage choice","Ready","","Given a new character with the dwarf species
+Then the character has no lineage choice to make","",""
+"features/characters/edit-character-backstory.feature","Edit character backstory and personality","","Editing the backstory saves the new text","Ready","","Given a Fighter character sheet with an existing backstory and personality
+When the Dungeon Master edits the backstory to ""Born in the ashlands, sworn to the flame.""
+Then the character's backstory reads ""Born in the ashlands, sworn to the flame.""","",""
+"features/characters/edit-character-backstory.feature","Edit character backstory and personality","","Editing the personality traits saves them","Ready","","Given a Fighter character sheet with an existing backstory and personality
+When the Dungeon Master edits the personality traits to ""Quick to laugh, slow to trust.""
+Then the character's personality traits read ""Quick to laugh, slow to trust.""","",""
+"features/characters/finalize-character.feature","Finalize a character draft into a playable character","A build must be complete before it can be finalized","A complete build can be finalized","Ready","","Given a complete character build with a name, class, species, background, and ability scores
+When the player finalizes the build
+Then the character is created as an active character","",""
+"features/characters/finalize-character.feature","Finalize a character draft into a playable character","Finalizing resolves the character's derived stats","A finalized character has its derived stats computed","Ready","","Given a complete character build at level 1
+When the player finalizes the build
+Then the finalized character has a proficiency bonus
+And the finalized character has maximum hit points","",""
+"features/characters/finalize-character.feature","Finalize a character draft into a playable character","A finalized character belongs to the active campaign","A finalized character appears in the campaign","Ready","","Given a complete character build in the active campaign
+When the player finalizes the build
+Then the character appears among the campaign's characters","",""
+"features/characters/level-down.feature","Level down a character","","Reverting a Fighter from level 4 to level 3 removes the ASI choice","Ready","","Given a Fighter at level 4 with no background chosen
+Then the character has a pending ability score increase
+When the most recent level is removed
+Then the character is level 3
+And the character has no pending ability score increase
+And their proficiency bonus is 2","",""
+"features/characters/level-down.feature","Level down a character","","A first-level character cannot be leveled down","Ready","","Given a level 1 Fighter is shown on the character sheet
+Then the Level Down action is unavailable","",""
+"features/characters/level-down.feature","Level down a character","","A higher-level character offers the Level Down control","Ready","","Given a level 3 Fighter is shown on the character sheet
+Then the Level Down action is available","",""
+"features/characters/level-up-character.feature","Level up a character","","A Fighter advancing to level 4 is offered an ability score increase","Ready","","Given a Fighter at level 3
+When the Fighter advances to level 4
+Then they must choose an ability score increase
+And their proficiency bonus is 2","",""
+"features/characters/level-up-character.feature","Level up a character","","Reaching level 3 prompts a subclass choice","Ready","","Given a new character with the fighter class at level 3
+Then the character must choose a subclass","",""
+"features/characters/resolve-asi.feature","Resolve a pending ability score increase","","A Fighter reaching level 4 is prompted for an ability score increase","Ready","","Given a Fighter at level 4 with no background chosen
+Then the character has a pending ability score increase","",""
+"features/characters/resolve-asi.feature","Resolve a pending ability score increase","","Allocating the full increase resolves the choice and raises the ability","Ready","","Given a Fighter at level 4 with no background chosen
+When the player allocates 2 points of ability score increase to Strength
+Then the ability score increase is no longer pending
+And the character's Strength score is increased by 2","",""
+"features/characters/resolve-asi.feature","Resolve a pending ability score increase","","Splitting the increase across two abilities also resolves it","Ready","","Given a Fighter at level 4 with no background chosen
+When the player allocates 1 point of ability score increase to Strength and 1 to Constitution
+Then the ability score increase is no longer pending","",""
+"features/characters/resolve-asi.feature","Resolve a pending ability score increase","","Over-allocating beyond the granted points leaves the choice unresolved","Ready","","Given a Fighter at level 4 with no background chosen
+When the player allocates 3 points of ability score increase to Strength
+Then the ability score increase is still pending","",""
+"features/characters/view-character-sheet.feature","View character sheet","","The sheet shows the resolved core statistics","Ready","","Given a level 5 Fighter character sheet
+Then the sheet shows a proficiency bonus of 3
+And the sheet shows the Saving Throws section
+And the sheet shows the Skills section","",""
+"features/characters/view-character-sheet.feature","View character sheet","","Unresolved choices surface a Pending Choices panel","Ready","","Given a level 5 Fighter character sheet
+Then the sheet prompts the player to resolve pending choices","",""
+"features/characters/view-character-sheet.feature","View character sheet","","The sheet lists the character's equipment","Ready","","Given a finalized Fighter character sheet holding a longsword
+Then the equipment list shows the longsword","",""
+"features/export/export-campaigns.feature","Export selected campaigns as a SQL seed file","","Exporting a campaign produces SQL with its related data","Ready","","Given a campaign named ""Dragon's Lair"" exists with 2 characters and 2 sessions
+And the Dungeon Master is on the export page
+When the Dungeon Master selects ""Dragon's Lair"" for export
+And the Dungeon Master exports the selected campaigns
+Then the generated SQL contains INSERT statements for the campaigns table
+And the generated SQL contains INSERT statements for the characters table
+And the generated SQL contains INSERT statements for the sessions table","",""
+"features/export/export-campaigns.feature","Export selected campaigns as a SQL seed file","","The export button is disabled when nothing is selected","Ready","","Given a campaign named ""Dragon's Lair"" exists
+And the Dungeon Master is on the export page
+Then the export button is disabled","",""
+"features/export/export-error-handling.feature","Show an export error when the data fetch fails","","A failed fetch shows an error instead of a download","Ready","","Given a campaign named ""Dragon's Lair"" exists
+And the export data fetch will fail
+And the Dungeon Master is on the export page
+When the Dungeon Master selects ""Dragon's Lair"" for export
+And the Dungeon Master exports the selected campaigns
+Then an export error is shown","",""
+"features/export/export-error-handling.feature","Show an export error when the data fetch fails","","A successful retry clears a previous export error","Ready","","Given a campaign named ""Dragon's Lair"" exists
+And the export data fetch will fail
+And the Dungeon Master is on the export page
+When the Dungeon Master selects ""Dragon's Lair"" for export
+And the Dungeon Master exports the selected campaigns
+Then an export error is shown
+When the export data fetch recovers
+And the Dungeon Master exports the selected campaigns
+Then no export error is shown","",""
+"features/export/export-select-all.feature","Select all or deselect all campaigns for export","","Select All checks every campaign","Ready","","Given a campaign named ""Dragon's Lair"" exists
+And a campaign named ""City of Shadows"" exists
+And a campaign named ""Dragon's Peak"" exists
+And the Dungeon Master is on the export page
+When the Dungeon Master clicks Select All
+Then 3 of 3 campaigns are selected for export","",""
+"features/export/export-select-all.feature","Select all or deselect all campaigns for export","","Deselect All clears the selection","Ready","","Given a campaign named ""Dragon's Lair"" exists
+And a campaign named ""City of Shadows"" exists
+And a campaign named ""Dragon's Peak"" exists
+And the Dungeon Master is on the export page
+When the Dungeon Master clicks Select All
+And the Dungeon Master clicks Deselect All
+Then 0 of 3 campaigns are selected for export","",""
+"features/settings/color-mode.feature","Switch light and dark mode","","Switching to Dark mode darkens the interface","Ready","","Given the Dungeon Master is on the theme settings page
+When the Dungeon Master selects the ""Dark"" color mode
+Then the interface is in dark mode","",""
+"features/settings/color-mode.feature","Switch light and dark mode","","Switching back to Light mode lightens the interface","Ready","","Given the Dungeon Master is on the theme settings page
+When the Dungeon Master selects the ""Dark"" color mode
+And the Dungeon Master selects the ""Light"" color mode
+Then the interface is in light mode","",""
+"features/settings/color-mode.feature","Switch light and dark mode","","System mode follows the operating system preference","Ready","","Given the operating system prefers dark mode
+And the Dungeon Master is on the theme settings page
+When the Dungeon Master selects the ""Light"" color mode
+Then the interface is in light mode
+When the Dungeon Master selects the ""System"" color mode
+Then the interface is in dark mode","",""
+"features/settings/global-theme.feature","Switch the global color theme","","Selecting Sylvan applies it immediately","Ready","","Given the Dungeon Master is on the theme settings page
+When the Dungeon Master selects the ""Sylvan"" global theme
+Then the interface uses the ""Sylvan"" theme","",""
+"features/settings/global-theme.feature","Switch the global color theme","","The chosen global theme persists for the next visit","Ready","","Given the Dungeon Master is on the theme settings page
+When the Dungeon Master selects the ""Arcane"" global theme
+Then the saved global theme is ""Arcane""","",""
+"features/settings/per-campaign-theme-override.feature","Override per-campaign theme from Settings","","Setting an override for a campaign from Settings","Ready","","Given a campaign named ""Curse of Strahd"" exists with no theme set
+And the Dungeon Master is on the theme settings page
+When the Dungeon Master sets the ""Arcane"" theme for ""Curse of Strahd"" in Settings
+Then ""Curse of Strahd"" uses the ""Arcane"" theme","",""
+"features/settings/per-campaign-theme-override.feature","Override per-campaign theme from Settings","","Resetting a campaign override back to inherit the global theme","Ready","","Given a campaign named ""Curse of Strahd"" exists with theme ""Sylvan""
+And the Dungeon Master is on the theme settings page
+When the Dungeon Master resets ""Curse of Strahd"" to inherit in Settings
+Then ""Curse of Strahd"" uses the ""Default"" theme","",""
+"features/campaigns/archive-campaign.feature","Archive a campaign","","An archived campaign can be restored","Future (not built yet)","@future","Given a campaign named ""Forgotten Realms"" exists but has been archived
+When the Dungeon Master restores ""Forgotten Realms""
+Then ""Forgotten Realms"" appears in the active campaigns list","",""
+"features/campaigns/archive-campaign.feature","Archive a campaign","","Archived campaigns are browsable separately","Future (not built yet)","@future","Given a campaign named ""Old Game"" exists but has been archived
+When the Dungeon Master views their archived campaigns
+Then ""Old Game"" appears in the archived list","",""
+"features/campaigns/archive-campaign.feature","Archive a campaign","","Archiving preserves the campaign's characters and sessions","Future (not built yet)","@future","Given a campaign named ""Lost Mines"" exists with 3 characters and 5 sessions
+When the Dungeon Master archives ""Lost Mines""
+And the Dungeon Master restores ""Lost Mines""
+Then the campaign still has 3 characters and 5 sessions","",""
+"features/campaigns/create-campaign.feature","Create a new campaign","","Two campaigns cannot share the same name","Future (not built yet)","@future","Given a campaign named ""Lost Mines"" exists
+When the Dungeon Master tries to create another campaign named ""Lost Mines""
+Then the campaign is not created
+And the Dungeon Master sees that the name is already in use","",""
+"features/campaigns/edit-campaign-details.feature","Edit campaign details","","A rename cannot collide with an existing campaign name","Future (not built yet)","@future","Given a campaign named ""Lost Mines"" exists
+And another campaign named ""Untitled"" exists
+When the Dungeon Master tries to rename ""Untitled"" to ""Lost Mines""
+Then the campaign is not renamed
+And the Dungeon Master sees that the name is already in use","",""
+"features/characters/archive-character.feature","Archive a character","","An archived character is hidden from the character list","Future (not built yet)","@future","Given a campaign with an archived character named ""Old Hero""
+When the Dungeon Master views the character list
+Then ""Old Hero"" does not appear in the character list","",""
+"features/characters/choose-background.feature","Choose a background during character creation","A background grants an origin feat","A background grants its origin feat","Future (not built yet)","@future","Given a new character with the acolyte background
+Then the character gains an origin feat","",""
+"features/characters/choose-background.feature","Choose a background during character creation","A background grants an origin feat","A background grants its origin feat","Future (not built yet)","@future","Given a new character with the sage background
+Then the character gains an origin feat","",""
+"features/characters/choose-equipment.feature","Choose starting equipment during character creation","Choosing an option populates the inventory","A character can take starting gold instead of an equipment package","Future (not built yet)","@future","Given a new character with the fighter class at level 1
+When the character chooses to start with gold instead of equipment
+Then the character's inventory reflects the gold option","",""
+"features/characters/finalize-character.feature","Finalize a character draft into a playable character","A build must be complete before it can be finalized","An incomplete build cannot be finalized","Future (not built yet)","@future","Given a character build that is missing a class
+When the player attempts to finalize the build
+Then the character is not finalized
+And the player is shown what is still required","",""
+"features/admin/initiate-password-reset.feature","Admin-initiated password reset","","An admin sends a reset link to a user","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given an account exists for ""lockedout@example.com""
+When the admin initiates a password reset for ""lockedout@example.com""
+Then a password reset link is sent to ""lockedout@example.com""","",""
+"features/admin/initiate-password-reset.feature","Admin-initiated password reset","","The admin never sets the user's password directly","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given an account exists for ""lockedout@example.com""
+When the admin initiates a password reset for ""lockedout@example.com""
+Then the admin is not shown a field to type a new password
+And the user must complete the reset using their own link","",""
+"features/admin/initiate-password-reset.feature","Admin-initiated password reset","","An admin can reset a disabled user's password","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given the account ""lockedout@example.com"" has been disabled
+When the admin initiates a password reset for ""lockedout@example.com""
+Then a password reset link is sent to ""lockedout@example.com""
+And ""lockedout@example.com"" still cannot sign in while disabled","",""
+"features/admin/initiate-password-reset.feature","Admin-initiated password reset","","A non-admin cannot initiate a reset for someone else","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given the user is signed in as ""player@example.com"" with the ""user"" role
+And an account exists for ""victim@example.com""
+When the user tries to initiate a password reset for ""victim@example.com""
+Then no password reset link is sent
+And the user sees that they are not authorized","",""
+"features/admin/manage-accounts.feature","Disable and re-enable accounts","","An admin disables an account","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given an account exists for ""noisy@example.com"" with the ""user"" role
+When the admin disables ""noisy@example.com""
+Then ""noisy@example.com"" is marked as disabled
+And ""noisy@example.com"" can no longer sign in","",""
+"features/admin/manage-accounts.feature","Disable and re-enable accounts","","An admin re-enables a disabled account","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given the account ""noisy@example.com"" has been disabled
+When the admin re-enables ""noisy@example.com""
+Then ""noisy@example.com"" is marked as active
+And ""noisy@example.com"" can sign in again","",""
+"features/admin/manage-accounts.feature","Disable and re-enable accounts","","Disabling an owner retains their campaigns","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given an account exists for ""departing@example.com"" with the ""user"" role
+And ""departing@example.com"" owns a campaign named ""Their Game""
+When the admin disables ""departing@example.com""
+Then the campaign ""Their Game"" still exists
+And ""Their Game"" is still owned by ""departing@example.com""","",""
+"features/admin/manage-accounts.feature","Disable and re-enable accounts","","Re-enabling an owner restores access to their retained campaigns","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given an account exists for ""departing@example.com"" with the ""user"" role
+And ""departing@example.com"" owns a campaign named ""Their Game""
+And the account ""departing@example.com"" has been disabled
+When the admin re-enables ""departing@example.com""
+Then ""departing@example.com"" can sign in again
+And ""departing@example.com"" still owns the campaign ""Their Game""","",""
+"features/admin/manage-accounts.feature","Disable and re-enable accounts","","Disabling a player keeps their character assignments intact","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given an account exists for ""departing@example.com"" with the ""user"" role
+And ""departing@example.com"" is the assigned player of the character ""Borrowed Hero"" in someone else's campaign
+When the admin disables ""departing@example.com""
+Then the character ""Borrowed Hero"" still exists
+And the character ""Borrowed Hero"" is still assigned to ""departing@example.com""","",""
+"features/admin/manage-accounts.feature","Disable and re-enable accounts","","The last active admin cannot be disabled","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given ""boss@example.com"" is the only active admin
+When the admin tries to disable ""boss@example.com""
+Then the account is not disabled
+And the admin sees that at least one active admin must remain","",""
+"features/admin/manage-accounts.feature","Disable and re-enable accounts","","Disabling the second-to-last admin is allowed","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given an account exists for ""cofounder@example.com"" with the ""admin"" role
+When the admin disables ""cofounder@example.com""
+Then ""cofounder@example.com"" is marked as disabled","",""
+"features/admin/manage-accounts.feature","Disable and re-enable accounts","","A non-admin cannot disable accounts","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given the user is signed in as ""player@example.com"" with the ""user"" role
+And an account exists for ""victim@example.com"" with the ""user"" role
+When the user tries to disable ""victim@example.com""
+Then the account is not disabled
+And the user sees that they are not authorized","",""
+"features/admin/manage-roles.feature","Promote and demote account roles","","An admin promotes a user to admin","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given an account exists for ""trusted@example.com"" with the ""user"" role
+When the admin promotes ""trusted@example.com"" to admin
+Then ""trusted@example.com"" has the ""admin"" role","",""
+"features/admin/manage-roles.feature","Promote and demote account roles","","An admin demotes another admin to user","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given an account exists for ""trusted@example.com"" with the ""admin"" role
+When the admin demotes ""trusted@example.com"" to user
+Then ""trusted@example.com"" has the ""user"" role","",""
+"features/admin/manage-roles.feature","Promote and demote account roles","","The last active admin cannot be demoted","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given ""boss@example.com"" is the only active admin
+When the admin tries to demote ""boss@example.com"" to user
+Then the role is not changed
+And the admin sees that at least one active admin must remain
+And ""boss@example.com"" still has the ""admin"" role","",""
+"features/admin/manage-roles.feature","Promote and demote account roles","","The last active admin cannot be demoted even if a disabled admin exists","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given an account exists for ""cofounder@example.com"" with the ""admin"" role
+And the account ""cofounder@example.com"" has been disabled
+When the admin tries to demote ""boss@example.com"" to user
+Then the role is not changed
+And the admin sees that at least one active admin must remain","",""
+"features/admin/manage-roles.feature","Promote and demote account roles","","An admin can demote themselves while another active admin remains","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given an account exists for ""cofounder@example.com"" with the ""admin"" role
+When the admin demotes ""boss@example.com"" to user
+Then ""boss@example.com"" has the ""user"" role","",""
+"features/admin/manage-roles.feature","Promote and demote account roles","","A non-admin cannot change roles","Draft","@draft","Given the user is signed in as ""boss@example.com"" with the ""admin"" role
+Given the user is signed in as ""player@example.com"" with the ""user"" role
+And an account exists for ""victim@example.com"" with the ""user"" role
+When the user tries to promote ""victim@example.com"" to admin
+Then the role is not changed
+And the user sees that they are not authorized","",""
+"features/auth/authentication.feature","Sign in and sign out","","A user signs in with valid credentials","Draft","@draft","Given a confirmed account exists for ""player@example.com"" with password ""Correct-Horse-1""
+When the user signs in with email ""player@example.com"" and password ""Correct-Horse-1""
+Then the user is signed in as ""player@example.com""","",""
+"features/auth/authentication.feature","Sign in and sign out","","Signing in with a wrong password is rejected","Draft","@draft","Given a confirmed account exists for ""player@example.com"" with password ""Correct-Horse-1""
+When the user signs in with email ""player@example.com"" and password ""wrong-password""
+Then the user is not signed in
+And the user sees that the credentials are invalid","",""
+"features/auth/authentication.feature","Sign in and sign out","","Signing in with an unknown email is rejected","Draft","@draft","Given no account exists for ""ghost@example.com""
+When the user signs in with email ""ghost@example.com"" and password ""anything""
+Then the user is not signed in
+And the user sees that the credentials are invalid","",""
+"features/auth/authentication.feature","Sign in and sign out","","A disabled account cannot sign in and is not distinguishable from a bad login","Draft","@draft","Given a confirmed account exists for ""banned@example.com"" with password ""Correct-Horse-1""
+And the account ""banned@example.com"" has been disabled by an admin
+When the user signs in with email ""banned@example.com"" and password ""Correct-Horse-1""
+Then the user is not signed in
+And the user sees that the credentials are invalid","",""
+"features/auth/authentication.feature","Sign in and sign out","","An unconfirmed account cannot sign in and is not distinguishable from a bad login","Draft","@draft","Given an account for ""pending@example.com"" is pending email confirmation
+When the user signs in with email ""pending@example.com"" and the correct password
+Then the user is not signed in
+And the user sees that the credentials are invalid","",""
+"features/auth/authentication.feature","Sign in and sign out","","A signed-in user signs out","Draft","@draft","Given the user is signed in as ""player@example.com""
+When the user signs out
+Then the user is no longer signed in
+And visiting a campaign page redirects to the sign-in screen","",""
+"features/auth/authentication.feature","Sign in and sign out","","Protected pages require a signed-in user","Draft","@draft","Given no user is signed in
+When the visitor opens a campaign page directly
+Then the visitor is redirected to the sign-in screen","",""
+"features/auth/password-reset.feature","Reset a forgotten password","","A user requests a password reset","Draft","@draft","Given an account exists for ""forgetful@example.com""
+When the user requests a password reset for ""forgetful@example.com""
+Then a password reset link is sent to ""forgetful@example.com""","",""
+"features/auth/password-reset.feature","Reset a forgotten password","","Requesting a reset for an unknown email reveals nothing","Draft","@draft","Given no account exists for ""stranger@example.com""
+When the user requests a password reset for ""stranger@example.com""
+Then the user sees the same generic confirmation message
+And no password reset link is sent","",""
+"features/auth/password-reset.feature","Reset a forgotten password","","A user sets a new password with a valid reset token","Draft","@draft","Given a valid password reset token was issued for ""forgetful@example.com""
+When the user sets a new password ""Brand-New-Pw-2"" using that token
+Then the password for ""forgetful@example.com"" is updated
+And the user can sign in with ""Brand-New-Pw-2""
+And the user cannot sign in with their old password","",""
+"features/auth/password-reset.feature","Reset a forgotten password","","An expired reset token is rejected","Draft","@draft","Given an expired password reset token was issued for ""forgetful@example.com""
+When the user tries to set a new password using that token
+Then the password is not changed
+And the user sees that the reset link has expired","",""
+"features/auth/password-reset.feature","Reset a forgotten password","","A reset token can only be used once","Draft","@draft","Given a valid password reset token was issued for ""forgetful@example.com""
+And the token has already been used to set a new password
+When the user tries to set another password using the same token
+Then the password is not changed
+And the user sees that the reset link is no longer valid","",""
+"features/auth/password-reset.feature","Reset a forgotten password","","The new password must meet the requirements","Draft","@draft","Given a valid password reset token was issued for ""forgetful@example.com""
+When the user tries to set a new password that is too weak using that token
+Then the password is not changed
+And the user sees that the password does not meet the requirements","",""
+"features/auth/sign-up.feature","Sign up for an account","","A visitor registers with email and password","Draft","@draft","Given no account exists for ""dm@example.com""
+When the visitor signs up with email ""dm@example.com"" and a valid password
+Then an account for ""dm@example.com"" is created
+And the new account has the ""user"" role
+And the new account is pending email confirmation
+And the visitor is not yet signed in
+And the visitor sees a generic ""check your email to confirm your account"" message","",""
+"features/auth/sign-up.feature","Sign up for an account","","A confirmed account can sign in","Draft","@draft","Given an account for ""dm@example.com"" is pending email confirmation
+When the visitor confirms their email using the confirmation link
+Then the account for ""dm@example.com"" is confirmed
+And the user can sign in as ""dm@example.com""","",""
+"features/auth/sign-up.feature","Sign up for an account","","Signing up with an already-registered email does not reveal the account exists","Draft","@draft","Given an account exists for ""dm@example.com""
+When a visitor tries to sign up with email ""dm@example.com""
+Then no second account is created for ""dm@example.com""
+And the visitor sees the same generic ""check your email to confirm your account"" message
+And an account-already-exists notice is emailed to ""dm@example.com""","",""
+"features/auth/sign-up.feature","Sign up for an account","","A weak password is rejected","Draft","@draft","When the visitor tries to sign up with email ""new@example.com"" and a password that is too weak
+Then the account is not created
+And the visitor sees that the password does not meet the requirements","",""
+"features/auth/sign-up.feature","Sign up for an account","","Email format is validated","Draft","@draft","When the visitor tries to sign up with email ""not-an-email""
+Then the account is not created
+And the visitor sees that the email is invalid","",""
+"features/collaboration/accept-invite.feature","Respond to a campaign invite","","A player accepts an invite","Draft","@draft","Given the user is signed in as ""alice@example.com""
+And ""alice@example.com"" has a pending invite to ""Sunless Citadel""
+When ""alice@example.com"" accepts the invite to ""Sunless Citadel""
+Then ""alice@example.com"" is a player in ""Sunless Citadel""
+And ""alice@example.com"" can view ""Sunless Citadel""
+And the invite is no longer pending","",""
+"features/collaboration/accept-invite.feature","Respond to a campaign invite","","A player declines an invite","Draft","@draft","Given the user is signed in as ""alice@example.com""
+And ""alice@example.com"" has a pending invite to ""Sunless Citadel""
+When ""alice@example.com"" declines the invite to ""Sunless Citadel""
+Then ""alice@example.com"" is not a member of ""Sunless Citadel""
+And the invite is no longer pending
+And ""alice@example.com"" cannot view ""Sunless Citadel""","",""
+"features/collaboration/accept-invite.feature","Respond to a campaign invite","","A user can only respond to their own invite","Draft","@draft","Given the user is signed in as ""alice@example.com""
+And ""alice@example.com"" has a pending invite to ""Sunless Citadel""
+Given the user is signed in as ""mallory@example.com""
+When ""mallory@example.com"" tries to accept the invite addressed to ""alice@example.com""
+Then ""mallory@example.com"" is not a member of ""Sunless Citadel""
+And ""mallory@example.com"" sees that they are not authorized","",""
+"features/collaboration/accept-invite.feature","Respond to a campaign invite","","An invite revoked by the owner can no longer be accepted","Draft","@draft","Given the user is signed in as ""alice@example.com""
+And ""alice@example.com"" has a pending invite to ""Sunless Citadel""
+Given the owner has revoked the invite to ""alice@example.com""
+When ""alice@example.com"" tries to accept the invite to ""Sunless Citadel""
+Then ""alice@example.com"" is not a member of ""Sunless Citadel""
+And ""alice@example.com"" sees that the invite is no longer available","",""
+"features/collaboration/accept-invite.feature","Respond to a campaign invite","","A player can leave a campaign they joined","Draft","@draft","Given the user is signed in as ""alice@example.com""
+And ""alice@example.com"" has a pending invite to ""Sunless Citadel""
+Given ""alice@example.com"" accepted the invite and is a player in ""Sunless Citadel""
+When ""alice@example.com"" leaves ""Sunless Citadel""
+Then ""alice@example.com"" is not a member of ""Sunless Citadel""
+And any characters assigned to ""alice@example.com"" in ""Sunless Citadel"" have no assigned player","",""
+"features/collaboration/assign-characters.feature","Assign characters to players","","An owner assigns a character to a player in the campaign","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+And ""alice@example.com"" is a player in ""Sunless Citadel""
+And a character named ""Thorin"" exists in ""Sunless Citadel"" with no assigned player
+When the owner assigns ""Thorin"" to ""alice@example.com""
+Then ""Thorin"" is assigned to ""alice@example.com""","",""
+"features/collaboration/assign-characters.feature","Assign characters to players","","A character cannot be assigned to a non-member","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+And ""alice@example.com"" is a player in ""Sunless Citadel""
+And a character named ""Thorin"" exists in ""Sunless Citadel"" with no assigned player
+Given ""bob@example.com"" is not a member of ""Sunless Citadel""
+When the owner tries to assign ""Thorin"" to ""bob@example.com""
+Then ""Thorin"" has no assigned player
+And the owner sees that the player must be a member of the campaign","",""
+"features/collaboration/assign-characters.feature","Assign characters to players","","Assigning a character to a new player replaces the previous assignee","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+And ""alice@example.com"" is a player in ""Sunless Citadel""
+And a character named ""Thorin"" exists in ""Sunless Citadel"" with no assigned player
+Given ""Thorin"" is assigned to ""alice@example.com""
+And ""carol@example.com"" is a player in ""Sunless Citadel""
+When the owner assigns ""Thorin"" to ""carol@example.com""
+Then ""Thorin"" is assigned to ""carol@example.com""
+And ""Thorin"" is not assigned to ""alice@example.com""","",""
+"features/collaboration/assign-characters.feature","Assign characters to players","","An owner unassigns a character","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+And ""alice@example.com"" is a player in ""Sunless Citadel""
+And a character named ""Thorin"" exists in ""Sunless Citadel"" with no assigned player
+Given ""Thorin"" is assigned to ""alice@example.com""
+When the owner unassigns ""Thorin""
+Then ""Thorin"" has no assigned player","",""
+"features/collaboration/assign-characters.feature","Assign characters to players","","A character belongs to exactly one campaign","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+And ""alice@example.com"" is a player in ""Sunless Citadel""
+And a character named ""Thorin"" exists in ""Sunless Citadel"" with no assigned player
+Given ""owner@example.com"" also owns a campaign named ""Dragon Heist""
+When the owner views the character ""Thorin""
+Then ""Thorin"" belongs only to ""Sunless Citadel""
+And there is no way to also place ""Thorin"" in ""Dragon Heist""","",""
+"features/collaboration/assign-characters.feature","Assign characters to players","","A non-owner cannot assign characters","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+And ""alice@example.com"" is a player in ""Sunless Citadel""
+And a character named ""Thorin"" exists in ""Sunless Citadel"" with no assigned player
+Given the user is signed in as ""alice@example.com""
+When the player tries to assign ""Thorin"" to ""alice@example.com""
+Then ""Thorin"" has no assigned player
+And the player sees that they are not authorized","",""
+"features/collaboration/data-ownership-isolation.feature","Each user owns their own campaigns and characters","","Pre-auth data is assigned to the seeded admin when auth is introduced","Draft","@draft","Given a campaign named ""Legacy Game"" existed before authentication was introduced
+And ""admin@example.com"" is the seeded admin account
+When the ownership migration runs
+Then ""Legacy Game"" is owned by ""admin@example.com""
+And every character in ""Legacy Game"" belongs to ""Legacy Game""","",""
+"features/collaboration/data-ownership-isolation.feature","Each user owns their own campaigns and characters","","A new user starts with no campaigns","Draft","@draft","Given the user is signed in as ""newbie@example.com""
+And ""newbie@example.com"" owns no campaigns and has joined none
+When ""newbie@example.com"" views their campaign list
+Then the campaign list is empty","",""
+"features/collaboration/data-ownership-isolation.feature","Each user owns their own campaigns and characters","","A user sees campaigns they own","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+When ""owner@example.com"" views their campaign list
+Then ""Sunless Citadel"" appears in their campaign list","",""
+"features/collaboration/data-ownership-isolation.feature","Each user owns their own campaigns and characters","","A user does not see another user's campaigns","Draft","@draft","Given an account exists for ""stranger@example.com"" who owns a campaign named ""Private Game""
+And the user is signed in as ""owner@example.com""
+When ""owner@example.com"" views their campaign list
+Then ""Private Game"" does not appear in their campaign list","",""
+"features/collaboration/data-ownership-isolation.feature","Each user owns their own campaigns and characters","","A user cannot open another user's campaign by direct link","Draft","@draft","Given an account exists for ""stranger@example.com"" who owns a campaign named ""Private Game""
+And the user is signed in as ""owner@example.com""
+And ""owner@example.com"" is not a member of ""Private Game""
+When ""owner@example.com"" opens the ""Private Game"" campaign page directly
+Then access is denied with a 403 Forbidden","",""
+"features/collaboration/data-ownership-isolation.feature","Each user owns their own campaigns and characters","","A joined player sees the campaign but not the owner's other campaigns","Draft","@draft","Given the user is signed in as ""alice@example.com""
+And ""alice@example.com"" is a player in ""Sunless Citadel"" owned by ""owner@example.com""
+And ""owner@example.com"" also owns a campaign named ""Secret Game"" that ""alice@example.com"" has not joined
+When ""alice@example.com"" views their campaign list
+Then ""Sunless Citadel"" appears in their campaign list
+And ""Secret Game"" does not appear in their campaign list","",""
+"features/collaboration/data-ownership-isolation.feature","Each user owns their own campaigns and characters","","A user cannot see characters in a campaign they have not joined","Draft","@draft","Given an account exists for ""stranger@example.com"" who owns a campaign named ""Private Game"" with a character named ""Hidden Hero""
+And the user is signed in as ""owner@example.com""
+When ""owner@example.com"" tries to view the characters in ""Private Game""
+Then access is denied with a 403 Forbidden
+And ""Hidden Hero"" is not shown","",""
+"features/collaboration/invite-players.feature","Invite players to a campaign","","An owner invites a registered user as a player","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+Given an account exists for ""alice@example.com""
+When the owner invites ""alice@example.com"" to ""Sunless Citadel""
+Then ""alice@example.com"" has a pending invite to ""Sunless Citadel""","",""
+"features/collaboration/invite-players.feature","Invite players to a campaign","","An unregistered email cannot be invited","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+Given no account exists for ""nobody@example.com""
+When the owner tries to invite ""nobody@example.com"" to ""Sunless Citadel""
+Then no invite is created
+And the owner sees that only registered users can be invited","",""
+"features/collaboration/invite-players.feature","Invite players to a campaign","","A pending invite does not yet grant access","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+Given the owner has invited ""alice@example.com"" to ""Sunless Citadel""
+And the invite is still pending
+When ""alice@example.com"" tries to view ""Sunless Citadel""
+Then ""alice@example.com"" cannot view the campaign","",""
+"features/collaboration/invite-players.feature","Invite players to a campaign","","The same user cannot be invited twice while a pending invite exists","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+Given the owner has invited ""alice@example.com"" to ""Sunless Citadel""
+When the owner tries to invite ""alice@example.com"" to ""Sunless Citadel"" again
+Then no second invite is created
+And the owner sees that an invite is already pending","",""
+"features/collaboration/invite-players.feature","Invite players to a campaign","","A current member cannot be re-invited","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+Given ""alice@example.com"" is already a player in ""Sunless Citadel""
+When the owner tries to invite ""alice@example.com"" to ""Sunless Citadel""
+Then no invite is created
+And the owner sees that the user is already a member","",""
+"features/collaboration/invite-players.feature","Invite players to a campaign","","A non-owner cannot invite players","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+Given ""alice@example.com"" is already a player in ""Sunless Citadel""
+And the user is signed in as ""alice@example.com""
+When the player tries to invite ""bob@example.com"" to ""Sunless Citadel""
+Then no invite is created
+And the player sees that they are not authorized","",""
+"features/collaboration/invite-players.feature","Invite players to a campaign","","An owner removes a player from the campaign","Draft","@draft","Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns a campaign named ""Sunless Citadel""
+Given ""alice@example.com"" is already a player in ""Sunless Citadel""
+When the owner removes ""alice@example.com"" from ""Sunless Citadel""
+Then ""alice@example.com"" is no longer a member of ""Sunless Citadel""
+And ""alice@example.com"" can no longer view the campaign","",""
+"features/collaboration/manage-own-characters.feature","Players manage their own characters","","A player creates a character in a campaign they joined and is auto-assigned","Draft","@draft","Given the user is signed in as ""alice@example.com""
+And ""alice@example.com"" is a player in ""Sunless Citadel""
+When ""alice@example.com"" creates a character named ""Lyra"" in ""Sunless Citadel""
+Then ""Lyra"" exists in ""Sunless Citadel""
+And ""Lyra"" is assigned to ""alice@example.com""","",""
+"features/collaboration/manage-own-characters.feature","Players manage their own characters","","A player edits a character assigned to them","Draft","@draft","Given the user is signed in as ""alice@example.com""
+And ""alice@example.com"" is a player in ""Sunless Citadel""
+Given a character named ""Lyra"" in ""Sunless Citadel"" is assigned to ""alice@example.com""
+When ""alice@example.com"" levels up ""Lyra""
+Then the change is saved without any approval step","",""
+"features/collaboration/manage-own-characters.feature","Players manage their own characters","","A player cannot edit another player's character","Draft","@draft","Given the user is signed in as ""alice@example.com""
+And ""alice@example.com"" is a player in ""Sunless Citadel""
+Given ""bob@example.com"" is a player in ""Sunless Citadel""
+And a character named ""Grog"" in ""Sunless Citadel"" is assigned to ""bob@example.com""
+When ""alice@example.com"" tries to edit ""Grog""
+Then the change is not saved
+And ""alice@example.com"" sees that they are not authorized","",""
+"features/collaboration/manage-own-characters.feature","Players manage their own characters","","A player cannot create a character in a campaign they have not joined","Draft","@draft","Given the user is signed in as ""alice@example.com""
+And ""alice@example.com"" is a player in ""Sunless Citadel""
+Given ""alice@example.com"" is not a member of ""Waterdeep""
+When ""alice@example.com"" tries to create a character in ""Waterdeep""
+Then no character is created
+And ""alice@example.com"" sees that they are not a member of the campaign","",""
+"features/collaboration/manage-own-characters.feature","Players manage their own characters","","The campaign owner can edit any character in their campaign","Draft","@draft","Given the user is signed in as ""alice@example.com""
+And ""alice@example.com"" is a player in ""Sunless Citadel""
+Given the user is signed in as ""owner@example.com""
+And ""owner@example.com"" owns ""Sunless Citadel""
+And a character named ""Lyra"" in ""Sunless Citadel"" is assigned to ""alice@example.com""
+When the owner edits ""Lyra""
+Then the change is saved","",""

--- a/docs/uat-checklist.md
+++ b/docs/uat-checklist.md
@@ -1,0 +1,1085 @@
+# UAT Checklist
+
+> Generated from the Gherkin specs under `features/` by `npm run uat:checklist`.
+> Do not edit by hand — re-run the script to refresh.
+
+**156 scenarios** — 80 ready · 10 future (not built yet) · 66 draft
+
+Status legend: **Ready** = expected to work today, validate it · **Future** = spec-ahead, expect it to fail/skip · **Draft** = no steps yet.
+
+## Ready (80)
+
+### `features/campaigns/archive-campaign.feature`
+
+#### Archive a campaign
+
+- [ ] **A DM archives a finished campaign**
+  - Given a campaign named "Lost Mines" exists
+  - When the Dungeon Master archives "Lost Mines"
+  - Then "Lost Mines" does not appear in the active campaigns list
+
+### `features/campaigns/create-campaign.feature`
+
+#### Create a new campaign
+
+- [ ] **A DM creates a campaign by providing a name**
+  - Given the Dungeon Master has no campaigns
+  - When the Dungeon Master creates a campaign named "Curse of Strahd"
+  - Then "Curse of Strahd" appears in their campaign list
+- [ ] **A campaign name is required**
+  - When the Dungeon Master tries to create a campaign with no name
+  - Then the campaign is not created
+  - And the Dungeon Master sees that a name is required
+- [ ] **A newly created campaign is ready to manage**
+  - Given the Dungeon Master has no campaigns
+  - When the Dungeon Master creates a campaign named "Tomb of Annihilation"
+  - Then "Tomb of Annihilation" is the active campaign
+
+### `features/campaigns/edit-campaign-details.feature`
+
+#### Edit campaign details
+
+- [ ] **A DM updates the campaign description**
+  - Given a campaign named "Curse of Strahd" exists with no description
+  - When the Dungeon Master sets the description to "Gothic horror in Barovia"
+  - Then the campaign description shows "Gothic horror in Barovia"
+- [ ] **A DM changes the campaign setting**
+  - Given a campaign named "Sandbox" exists in the "Forgotten Realms" setting
+  - When the Dungeon Master changes the setting to "Eberron"
+  - Then the campaign is in the "Eberron" setting
+- [ ] **A DM renames a campaign**
+  - Given a campaign named "Untitled" exists
+  - When the Dungeon Master renames it to "Storm King's Thunder"
+  - Then the campaign is named "Storm King's Thunder"
+
+### `features/campaigns/per-campaign-theme.feature`
+
+#### Per-campaign color theme
+
+- [ ] **A DM sets a theme on a campaign**
+  - Given a campaign named "Curse of Strahd" exists with no theme set
+  - When the Dungeon Master sets the campaign theme to "Arcane"
+  - Then "Curse of Strahd" uses the "Arcane" theme
+- [ ] **A campaign without a theme falls back to the DM's global theme**
+  - Given the Dungeon Master's global theme is "Sylvan"
+  - And a campaign named "Sandbox" exists with no theme set
+  - When the Dungeon Master opens "Sandbox"
+  - Then the interface uses the "Sylvan" theme
+- [ ] **A campaign theme overrides the global theme while that campaign is active**
+  - Given the Dungeon Master's global theme is "Default"
+  - And a campaign named "Curse of Strahd" exists with theme "Arcane"
+  - When the Dungeon Master opens "Curse of Strahd"
+  - Then the interface uses the "Arcane" theme
+- [ ] **A DM clears a campaign theme to fall back to their global theme**
+  - Given the Dungeon Master's global theme is "Default"
+  - And a campaign named "Curse of Strahd" exists with theme "Arcane"
+  - When the Dungeon Master clears the theme on "Curse of Strahd"
+  - Then "Curse of Strahd" uses the "Default" theme
+
+### `features/campaigns/search-campaigns.feature`
+
+#### Search campaigns by name
+
+- [ ] **Typing a query narrows the list to matching campaigns**
+  - Given a campaign named "Dragon's Lair" exists
+  - And a campaign named "City of Shadows" exists
+  - And a campaign named "Dragon's Peak" exists
+  - When the Dungeon Master searches campaigns for "Dragon"
+  - Then "Dragon's Lair" appears in the list
+  - And "Dragon's Peak" appears in the list
+  - And "City of Shadows" does not appear in the list
+- [ ] **Clearing the search restores the full list**
+  - Given a campaign named "Dragon's Lair" exists
+  - And a campaign named "City of Shadows" exists
+  - When the Dungeon Master searches campaigns for "Dragon"
+  - And the Dungeon Master clears the campaign search
+  - Then "Dragon's Lair" appears in the list
+  - And "City of Shadows" appears in the list
+
+### `features/campaigns/view-campaigns.feature`
+
+#### View existing campaigns
+
+- [ ] **A previously created campaign is visible to the DM**
+  - Given a campaign named "Dragon's Lair" exists
+  - When the Dungeon Master views their campaigns
+  - Then "Dragon's Lair" appears in the list
+- [ ] **A first-time DM sees an empty campaign list**
+  - Given the Dungeon Master has no campaigns
+  - When the Dungeon Master views their campaigns
+  - Then the list is empty
+  - And the Dungeon Master is prompted to create their first campaign
+- [ ] **Archived campaigns are hidden by default**
+  - Given a campaign named "Lost Mines" exists
+  - And a campaign named "Forgotten Realms" exists but has been archived
+  - When the Dungeon Master views their campaigns
+  - Then "Lost Mines" appears in the list
+  - And "Forgotten Realms" does not appear in the list
+- [ ] **Campaigns are ordered by most recent activity**
+  - Given a campaign named "Older Game" exists and was last played 2 weeks ago
+  - And a campaign named "Current Game" exists and was last played yesterday
+  - When the Dungeon Master views their campaigns
+  - Then "Current Game" appears before "Older Game" in the list
+
+### `features/characters/ability-modifiers.feature`
+
+#### Ability score modifiers
+
+- [ ] **A score of 14 gives a +2 modifier**
+  - Given an ability score of 14
+  - Then the ability modifier is 2
+- [ ] **A score of 8 gives a -1 modifier**
+  - Given an ability score of 8
+  - Then the ability modifier is -1
+
+### `features/characters/archive-character.feature`
+
+#### Archive a character
+
+- [ ] **Active characters appear in the campaign's character list**
+  - Given a campaign with an active character named "Valeros"
+  - When the Dungeon Master views the character list
+  - Then "Valeros" appears in the character list
+
+### `features/characters/builder-autosave.feature`
+
+#### Autosave character builder draft
+
+- [ ] **A saved draft is reloaded when returning to the builder**
+  - Given a saved character draft named "Aldara"
+  - When the player opens the character builder for that draft
+  - Then the builder resumes with the name "Aldara"
+  - And the builder shows the species "Human"
+
+### `features/characters/choose-ability-scores.feature`
+
+#### Choose ability scores during character creation
+
+##### Rule: Each method produces a valid base score set
+
+- [ ] **The standard array assigns the fixed set of scores**
+  - Given a new character using the standard-array ability method
+  - Then the available base scores are 15, 14, 13, 12, 10, and 8
+- [ ] **Point buy spends a fixed pool of points**
+  - Given a new character using the point-buy ability method
+  - Then the character has 27 points to spend on ability scores
+- [ ] **Point buy rejects a base score above 15**
+  - Given a new character using the point-buy ability method
+  - When the character tries to set a base ability score of 16
+  - Then the score is not allowed
+##### Rule: Background increases apply on top of base scores
+
+- [ ] **A background's ability increases are added to the base scores**
+  - Given a new character with the soldier background
+  - And base ability scores of 15, 14, 13, 12, 10, and 8
+  - When the soldier ability increases are applied to Strength and Constitution
+  - Then the final Strength score includes the background increase
+  - And the final ability modifiers reflect the increased scores
+
+### `features/characters/choose-background.feature`
+
+#### Choose a background during character creation
+
+##### Rule: A background grants fixed proficiencies
+
+- [ ] **A background grants two skill proficiencies**
+  - Given a new character with the soldier background
+  - Then the character is proficient in the Athletics skill
+  - And the character is proficient in the Intimidation skill
+- [ ] **A background grants a tool proficiency or tool choice**
+  - Given a new character with the soldier background
+  - Then the character has a tool proficiency from the background
+##### Rule: A background grants 2024-style ability increases
+
+- [ ] **A background grants three points of ability score increases**
+  - Given a new character with the soldier background
+  - Then the background grants 3 points of ability score increases
+##### Rule: A background grants an origin feat
+
+- [ ] **A background grants its origin feat**
+  - Given a new character with the soldier background
+  - Then the character gains an origin feat
+
+### `features/characters/choose-class.feature`
+
+#### Choose a class during character creation
+
+##### Rule: A class grants its core proficiencies at level 1
+
+- [ ] **A class grants its saving throw proficiencies**
+  - Given a new character with the fighter class at level 1
+  - Then the character is proficient in Strength saving throws
+  - And the character is proficient in Constitution saving throws
+- [ ] **A class grants its saving throw proficiencies**
+  - Given a new character with the wizard class at level 1
+  - Then the character is proficient in Intelligence saving throws
+  - And the character is proficient in Wisdom saving throws
+- [ ] **A class grants its saving throw proficiencies**
+  - Given a new character with the cleric class at level 1
+  - Then the character is proficient in Wisdom saving throws
+  - And the character is proficient in Charisma saving throws
+- [ ] **A class offers skill proficiency choices from its own list**
+  - Given a new character with the cleric class at level 1
+  - Then the character must choose 2 skills from the cleric skill list
+##### Rule: A class introduces its signature level-1 mechanics
+
+- [ ] **A martial class grants a weapon mastery choice**
+  - Given a new character with the fighter class at level 1
+  - Then the character must choose weapon masteries
+- [ ] **A spellcasting class gains spellcasting at level 1**
+  - Given a new character with the wizard class at level 1
+  - Then the character has spellcasting from its class
+##### Rule: Every class selects a subclass at level 3
+
+- [ ] **A class must choose a subclass when it reaches level 3**
+  - Given a new character with the fighter class at level 3
+  - Then the character must choose a subclass
+- [ ] **A class must choose a subclass when it reaches level 3**
+  - Given a new character with the cleric class at level 3
+  - Then the character must choose a subclass
+- [ ] **A class must choose a subclass when it reaches level 3**
+  - Given a new character with the wizard class at level 3
+  - Then the character must choose a subclass
+
+### `features/characters/choose-equipment.feature`
+
+#### Choose starting equipment during character creation
+
+##### Rule: A class offers a starting equipment choice
+
+- [ ] **A class presents its starting equipment options**
+  - Given a new character with the fighter class at level 1
+  - Then the character must choose a starting equipment option
+##### Rule: Choosing an option populates the inventory
+
+- [ ] **Choosing a starting equipment option adds its items**
+  - Given a new character with the fighter class at level 1
+  - When the character chooses the first starting equipment option
+  - Then the chosen items appear in the character's inventory
+
+### `features/characters/choose-skills.feature`
+
+#### Choose skills during character creation
+
+##### Rule: Skill proficiencies combine across sources
+
+- [ ] **A character's skills come from both class and background**
+  - Given a new character with the cleric class and the soldier background
+  - Then the character's skill proficiencies include the soldier background skills
+  - And the character may choose additional skills from the cleric
+- [ ] **A class skill choice offers the correct count from its list**
+  - Given a new character with the cleric class at level 1
+  - Then the character must choose 2 skills from the cleric skill list
+##### Rule: Overlapping skill grants are not double-counted
+
+- [ ] **A skill granted by two sources is only counted once**
+  - Given a new character whose class and background both grant the Athletics skill
+  - Then the character is proficient in the Athletics skill exactly once
+##### Rule: Expertise improves a chosen skill
+
+- [ ] **Expertise doubles the proficiency bonus for a chosen skill**
+  - Given a new character with the rogue class at level 1
+  - When the character chooses Expertise in the Stealth skill
+  - Then the Stealth skill applies double the proficiency bonus
+
+### `features/characters/choose-species.feature`
+
+#### Choose a species during character creation
+
+##### Rule: A species grants its racial traits
+
+- [ ] **A species grants its level-1 traits**
+  - Given a new character with the dwarf species
+  - Then the character has the Darkvision trait
+  - And the character has the Dwarven Resilience trait
+##### Rule: Species with a lineage require a lineage choice
+
+- [ ] **A species with lineages must choose one**
+  - Given a new character with the elf species
+  - Then the character must choose a lineage
+- [ ] **A species with lineages must choose one**
+  - Given a new character with the gnome species
+  - Then the character must choose a lineage
+- [ ] **A species with lineages must choose one**
+  - Given a new character with the dragonborn species
+  - Then the character must choose a draconic ancestry
+- [ ] **A chosen lineage grants its sub-traits**
+  - Given a new character with the elf species
+  - When the character chooses the Wood Elf lineage
+  - Then the character gains the traits of the Wood Elf lineage
+##### Rule: Species without a lineage require no lineage choice
+
+- [ ] **A species without lineages has no lineage choice**
+  - Given a new character with the dwarf species
+  - Then the character has no lineage choice to make
+
+### `features/characters/edit-character-backstory.feature`
+
+#### Edit character backstory and personality
+
+- [ ] **Editing the backstory saves the new text**
+  - Given a Fighter character sheet with an existing backstory and personality
+  - When the Dungeon Master edits the backstory to "Born in the ashlands, sworn to the flame."
+  - Then the character's backstory reads "Born in the ashlands, sworn to the flame."
+- [ ] **Editing the personality traits saves them**
+  - Given a Fighter character sheet with an existing backstory and personality
+  - When the Dungeon Master edits the personality traits to "Quick to laugh, slow to trust."
+  - Then the character's personality traits read "Quick to laugh, slow to trust."
+
+### `features/characters/finalize-character.feature`
+
+#### Finalize a character draft into a playable character
+
+##### Rule: A build must be complete before it can be finalized
+
+- [ ] **A complete build can be finalized**
+  - Given a complete character build with a name, class, species, background, and ability scores
+  - When the player finalizes the build
+  - Then the character is created as an active character
+##### Rule: Finalizing resolves the character's derived stats
+
+- [ ] **A finalized character has its derived stats computed**
+  - Given a complete character build at level 1
+  - When the player finalizes the build
+  - Then the finalized character has a proficiency bonus
+  - And the finalized character has maximum hit points
+##### Rule: A finalized character belongs to the active campaign
+
+- [ ] **A finalized character appears in the campaign**
+  - Given a complete character build in the active campaign
+  - When the player finalizes the build
+  - Then the character appears among the campaign's characters
+
+### `features/characters/level-down.feature`
+
+#### Level down a character
+
+- [ ] **Reverting a Fighter from level 4 to level 3 removes the ASI choice**
+  - Given a Fighter at level 4 with no background chosen
+  - Then the character has a pending ability score increase
+  - When the most recent level is removed
+  - Then the character is level 3
+  - And the character has no pending ability score increase
+  - And their proficiency bonus is 2
+- [ ] **A first-level character cannot be leveled down**
+  - Given a level 1 Fighter is shown on the character sheet
+  - Then the Level Down action is unavailable
+- [ ] **A higher-level character offers the Level Down control**
+  - Given a level 3 Fighter is shown on the character sheet
+  - Then the Level Down action is available
+
+### `features/characters/level-up-character.feature`
+
+#### Level up a character
+
+- [ ] **A Fighter advancing to level 4 is offered an ability score increase**
+  - Given a Fighter at level 3
+  - When the Fighter advances to level 4
+  - Then they must choose an ability score increase
+  - And their proficiency bonus is 2
+- [ ] **Reaching level 3 prompts a subclass choice**
+  - Given a new character with the fighter class at level 3
+  - Then the character must choose a subclass
+
+### `features/characters/resolve-asi.feature`
+
+#### Resolve a pending ability score increase
+
+- [ ] **A Fighter reaching level 4 is prompted for an ability score increase**
+  - Given a Fighter at level 4 with no background chosen
+  - Then the character has a pending ability score increase
+- [ ] **Allocating the full increase resolves the choice and raises the ability**
+  - Given a Fighter at level 4 with no background chosen
+  - When the player allocates 2 points of ability score increase to Strength
+  - Then the ability score increase is no longer pending
+  - And the character's Strength score is increased by 2
+- [ ] **Splitting the increase across two abilities also resolves it**
+  - Given a Fighter at level 4 with no background chosen
+  - When the player allocates 1 point of ability score increase to Strength and 1 to Constitution
+  - Then the ability score increase is no longer pending
+- [ ] **Over-allocating beyond the granted points leaves the choice unresolved**
+  - Given a Fighter at level 4 with no background chosen
+  - When the player allocates 3 points of ability score increase to Strength
+  - Then the ability score increase is still pending
+
+### `features/characters/view-character-sheet.feature`
+
+#### View character sheet
+
+- [ ] **The sheet shows the resolved core statistics**
+  - Given a level 5 Fighter character sheet
+  - Then the sheet shows a proficiency bonus of 3
+  - And the sheet shows the Saving Throws section
+  - And the sheet shows the Skills section
+- [ ] **Unresolved choices surface a Pending Choices panel**
+  - Given a level 5 Fighter character sheet
+  - Then the sheet prompts the player to resolve pending choices
+- [ ] **The sheet lists the character's equipment**
+  - Given a finalized Fighter character sheet holding a longsword
+  - Then the equipment list shows the longsword
+
+### `features/export/export-campaigns.feature`
+
+#### Export selected campaigns as a SQL seed file
+
+- [ ] **Exporting a campaign produces SQL with its related data**
+  - Given a campaign named "Dragon's Lair" exists with 2 characters and 2 sessions
+  - And the Dungeon Master is on the export page
+  - When the Dungeon Master selects "Dragon's Lair" for export
+  - And the Dungeon Master exports the selected campaigns
+  - Then the generated SQL contains INSERT statements for the campaigns table
+  - And the generated SQL contains INSERT statements for the characters table
+  - And the generated SQL contains INSERT statements for the sessions table
+- [ ] **The export button is disabled when nothing is selected**
+  - Given a campaign named "Dragon's Lair" exists
+  - And the Dungeon Master is on the export page
+  - Then the export button is disabled
+
+### `features/export/export-error-handling.feature`
+
+#### Show an export error when the data fetch fails
+
+- [ ] **A failed fetch shows an error instead of a download**
+  - Given a campaign named "Dragon's Lair" exists
+  - And the export data fetch will fail
+  - And the Dungeon Master is on the export page
+  - When the Dungeon Master selects "Dragon's Lair" for export
+  - And the Dungeon Master exports the selected campaigns
+  - Then an export error is shown
+- [ ] **A successful retry clears a previous export error**
+  - Given a campaign named "Dragon's Lair" exists
+  - And the export data fetch will fail
+  - And the Dungeon Master is on the export page
+  - When the Dungeon Master selects "Dragon's Lair" for export
+  - And the Dungeon Master exports the selected campaigns
+  - Then an export error is shown
+  - When the export data fetch recovers
+  - And the Dungeon Master exports the selected campaigns
+  - Then no export error is shown
+
+### `features/export/export-select-all.feature`
+
+#### Select all or deselect all campaigns for export
+
+- [ ] **Select All checks every campaign**
+  - Given a campaign named "Dragon's Lair" exists
+  - And a campaign named "City of Shadows" exists
+  - And a campaign named "Dragon's Peak" exists
+  - And the Dungeon Master is on the export page
+  - When the Dungeon Master clicks Select All
+  - Then 3 of 3 campaigns are selected for export
+- [ ] **Deselect All clears the selection**
+  - Given a campaign named "Dragon's Lair" exists
+  - And a campaign named "City of Shadows" exists
+  - And a campaign named "Dragon's Peak" exists
+  - And the Dungeon Master is on the export page
+  - When the Dungeon Master clicks Select All
+  - And the Dungeon Master clicks Deselect All
+  - Then 0 of 3 campaigns are selected for export
+
+### `features/settings/color-mode.feature`
+
+#### Switch light and dark mode
+
+- [ ] **Switching to Dark mode darkens the interface**
+  - Given the Dungeon Master is on the theme settings page
+  - When the Dungeon Master selects the "Dark" color mode
+  - Then the interface is in dark mode
+- [ ] **Switching back to Light mode lightens the interface**
+  - Given the Dungeon Master is on the theme settings page
+  - When the Dungeon Master selects the "Dark" color mode
+  - And the Dungeon Master selects the "Light" color mode
+  - Then the interface is in light mode
+- [ ] **System mode follows the operating system preference**
+  - Given the operating system prefers dark mode
+  - And the Dungeon Master is on the theme settings page
+  - When the Dungeon Master selects the "Light" color mode
+  - Then the interface is in light mode
+  - When the Dungeon Master selects the "System" color mode
+  - Then the interface is in dark mode
+
+### `features/settings/global-theme.feature`
+
+#### Switch the global color theme
+
+- [ ] **Selecting Sylvan applies it immediately**
+  - Given the Dungeon Master is on the theme settings page
+  - When the Dungeon Master selects the "Sylvan" global theme
+  - Then the interface uses the "Sylvan" theme
+- [ ] **The chosen global theme persists for the next visit**
+  - Given the Dungeon Master is on the theme settings page
+  - When the Dungeon Master selects the "Arcane" global theme
+  - Then the saved global theme is "Arcane"
+
+### `features/settings/per-campaign-theme-override.feature`
+
+#### Override per-campaign theme from Settings
+
+- [ ] **Setting an override for a campaign from Settings**
+  - Given a campaign named "Curse of Strahd" exists with no theme set
+  - And the Dungeon Master is on the theme settings page
+  - When the Dungeon Master sets the "Arcane" theme for "Curse of Strahd" in Settings
+  - Then "Curse of Strahd" uses the "Arcane" theme
+- [ ] **Resetting a campaign override back to inherit the global theme**
+  - Given a campaign named "Curse of Strahd" exists with theme "Sylvan"
+  - And the Dungeon Master is on the theme settings page
+  - When the Dungeon Master resets "Curse of Strahd" to inherit in Settings
+  - Then "Curse of Strahd" uses the "Default" theme
+
+## Future (10)
+
+### `features/campaigns/archive-campaign.feature`
+
+#### Archive a campaign
+
+- [ ] **An archived campaign can be restored**
+  - Given a campaign named "Forgotten Realms" exists but has been archived
+  - When the Dungeon Master restores "Forgotten Realms"
+  - Then "Forgotten Realms" appears in the active campaigns list
+- [ ] **Archived campaigns are browsable separately**
+  - Given a campaign named "Old Game" exists but has been archived
+  - When the Dungeon Master views their archived campaigns
+  - Then "Old Game" appears in the archived list
+- [ ] **Archiving preserves the campaign's characters and sessions**
+  - Given a campaign named "Lost Mines" exists with 3 characters and 5 sessions
+  - When the Dungeon Master archives "Lost Mines"
+  - And the Dungeon Master restores "Lost Mines"
+  - Then the campaign still has 3 characters and 5 sessions
+
+### `features/campaigns/create-campaign.feature`
+
+#### Create a new campaign
+
+- [ ] **Two campaigns cannot share the same name**
+  - Given a campaign named "Lost Mines" exists
+  - When the Dungeon Master tries to create another campaign named "Lost Mines"
+  - Then the campaign is not created
+  - And the Dungeon Master sees that the name is already in use
+
+### `features/campaigns/edit-campaign-details.feature`
+
+#### Edit campaign details
+
+- [ ] **A rename cannot collide with an existing campaign name**
+  - Given a campaign named "Lost Mines" exists
+  - And another campaign named "Untitled" exists
+  - When the Dungeon Master tries to rename "Untitled" to "Lost Mines"
+  - Then the campaign is not renamed
+  - And the Dungeon Master sees that the name is already in use
+
+### `features/characters/archive-character.feature`
+
+#### Archive a character
+
+- [ ] **An archived character is hidden from the character list**
+  - Given a campaign with an archived character named "Old Hero"
+  - When the Dungeon Master views the character list
+  - Then "Old Hero" does not appear in the character list
+
+### `features/characters/choose-background.feature`
+
+#### Choose a background during character creation
+
+##### Rule: A background grants an origin feat
+
+- [ ] **A background grants its origin feat**
+  - Given a new character with the acolyte background
+  - Then the character gains an origin feat
+- [ ] **A background grants its origin feat**
+  - Given a new character with the sage background
+  - Then the character gains an origin feat
+
+### `features/characters/choose-equipment.feature`
+
+#### Choose starting equipment during character creation
+
+##### Rule: Choosing an option populates the inventory
+
+- [ ] **A character can take starting gold instead of an equipment package**
+  - Given a new character with the fighter class at level 1
+  - When the character chooses to start with gold instead of equipment
+  - Then the character's inventory reflects the gold option
+
+### `features/characters/finalize-character.feature`
+
+#### Finalize a character draft into a playable character
+
+##### Rule: A build must be complete before it can be finalized
+
+- [ ] **An incomplete build cannot be finalized**
+  - Given a character build that is missing a class
+  - When the player attempts to finalize the build
+  - Then the character is not finalized
+  - And the player is shown what is still required
+
+## Draft (66)
+
+### `features/admin/initiate-password-reset.feature`
+
+#### Admin-initiated password reset
+
+- [ ] **An admin sends a reset link to a user**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given an account exists for "lockedout@example.com"
+  - When the admin initiates a password reset for "lockedout@example.com"
+  - Then a password reset link is sent to "lockedout@example.com"
+- [ ] **The admin never sets the user's password directly**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given an account exists for "lockedout@example.com"
+  - When the admin initiates a password reset for "lockedout@example.com"
+  - Then the admin is not shown a field to type a new password
+  - And the user must complete the reset using their own link
+- [ ] **An admin can reset a disabled user's password**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given the account "lockedout@example.com" has been disabled
+  - When the admin initiates a password reset for "lockedout@example.com"
+  - Then a password reset link is sent to "lockedout@example.com"
+  - And "lockedout@example.com" still cannot sign in while disabled
+- [ ] **A non-admin cannot initiate a reset for someone else**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given the user is signed in as "player@example.com" with the "user" role
+  - And an account exists for "victim@example.com"
+  - When the user tries to initiate a password reset for "victim@example.com"
+  - Then no password reset link is sent
+  - And the user sees that they are not authorized
+
+### `features/admin/manage-accounts.feature`
+
+#### Disable and re-enable accounts
+
+- [ ] **An admin disables an account**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given an account exists for "noisy@example.com" with the "user" role
+  - When the admin disables "noisy@example.com"
+  - Then "noisy@example.com" is marked as disabled
+  - And "noisy@example.com" can no longer sign in
+- [ ] **An admin re-enables a disabled account**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given the account "noisy@example.com" has been disabled
+  - When the admin re-enables "noisy@example.com"
+  - Then "noisy@example.com" is marked as active
+  - And "noisy@example.com" can sign in again
+- [ ] **Disabling an owner retains their campaigns**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given an account exists for "departing@example.com" with the "user" role
+  - And "departing@example.com" owns a campaign named "Their Game"
+  - When the admin disables "departing@example.com"
+  - Then the campaign "Their Game" still exists
+  - And "Their Game" is still owned by "departing@example.com"
+- [ ] **Re-enabling an owner restores access to their retained campaigns**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given an account exists for "departing@example.com" with the "user" role
+  - And "departing@example.com" owns a campaign named "Their Game"
+  - And the account "departing@example.com" has been disabled
+  - When the admin re-enables "departing@example.com"
+  - Then "departing@example.com" can sign in again
+  - And "departing@example.com" still owns the campaign "Their Game"
+- [ ] **Disabling a player keeps their character assignments intact**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given an account exists for "departing@example.com" with the "user" role
+  - And "departing@example.com" is the assigned player of the character "Borrowed Hero" in someone else's campaign
+  - When the admin disables "departing@example.com"
+  - Then the character "Borrowed Hero" still exists
+  - And the character "Borrowed Hero" is still assigned to "departing@example.com"
+- [ ] **The last active admin cannot be disabled**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given "boss@example.com" is the only active admin
+  - When the admin tries to disable "boss@example.com"
+  - Then the account is not disabled
+  - And the admin sees that at least one active admin must remain
+- [ ] **Disabling the second-to-last admin is allowed**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given an account exists for "cofounder@example.com" with the "admin" role
+  - When the admin disables "cofounder@example.com"
+  - Then "cofounder@example.com" is marked as disabled
+- [ ] **A non-admin cannot disable accounts**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given the user is signed in as "player@example.com" with the "user" role
+  - And an account exists for "victim@example.com" with the "user" role
+  - When the user tries to disable "victim@example.com"
+  - Then the account is not disabled
+  - And the user sees that they are not authorized
+
+### `features/admin/manage-roles.feature`
+
+#### Promote and demote account roles
+
+- [ ] **An admin promotes a user to admin**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given an account exists for "trusted@example.com" with the "user" role
+  - When the admin promotes "trusted@example.com" to admin
+  - Then "trusted@example.com" has the "admin" role
+- [ ] **An admin demotes another admin to user**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given an account exists for "trusted@example.com" with the "admin" role
+  - When the admin demotes "trusted@example.com" to user
+  - Then "trusted@example.com" has the "user" role
+- [ ] **The last active admin cannot be demoted**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given "boss@example.com" is the only active admin
+  - When the admin tries to demote "boss@example.com" to user
+  - Then the role is not changed
+  - And the admin sees that at least one active admin must remain
+  - And "boss@example.com" still has the "admin" role
+- [ ] **The last active admin cannot be demoted even if a disabled admin exists**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given an account exists for "cofounder@example.com" with the "admin" role
+  - And the account "cofounder@example.com" has been disabled
+  - When the admin tries to demote "boss@example.com" to user
+  - Then the role is not changed
+  - And the admin sees that at least one active admin must remain
+- [ ] **An admin can demote themselves while another active admin remains**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given an account exists for "cofounder@example.com" with the "admin" role
+  - When the admin demotes "boss@example.com" to user
+  - Then "boss@example.com" has the "user" role
+- [ ] **A non-admin cannot change roles**
+  - Given the user is signed in as "boss@example.com" with the "admin" role
+  - Given the user is signed in as "player@example.com" with the "user" role
+  - And an account exists for "victim@example.com" with the "user" role
+  - When the user tries to promote "victim@example.com" to admin
+  - Then the role is not changed
+  - And the user sees that they are not authorized
+
+### `features/auth/authentication.feature`
+
+#### Sign in and sign out
+
+- [ ] **A user signs in with valid credentials**
+  - Given a confirmed account exists for "player@example.com" with password "Correct-Horse-1"
+  - When the user signs in with email "player@example.com" and password "Correct-Horse-1"
+  - Then the user is signed in as "player@example.com"
+- [ ] **Signing in with a wrong password is rejected**
+  - Given a confirmed account exists for "player@example.com" with password "Correct-Horse-1"
+  - When the user signs in with email "player@example.com" and password "wrong-password"
+  - Then the user is not signed in
+  - And the user sees that the credentials are invalid
+- [ ] **Signing in with an unknown email is rejected**
+  - Given no account exists for "ghost@example.com"
+  - When the user signs in with email "ghost@example.com" and password "anything"
+  - Then the user is not signed in
+  - And the user sees that the credentials are invalid
+- [ ] **A disabled account cannot sign in and is not distinguishable from a bad login**
+  - Given a confirmed account exists for "banned@example.com" with password "Correct-Horse-1"
+  - And the account "banned@example.com" has been disabled by an admin
+  - When the user signs in with email "banned@example.com" and password "Correct-Horse-1"
+  - Then the user is not signed in
+  - And the user sees that the credentials are invalid
+- [ ] **An unconfirmed account cannot sign in and is not distinguishable from a bad login**
+  - Given an account for "pending@example.com" is pending email confirmation
+  - When the user signs in with email "pending@example.com" and the correct password
+  - Then the user is not signed in
+  - And the user sees that the credentials are invalid
+- [ ] **A signed-in user signs out**
+  - Given the user is signed in as "player@example.com"
+  - When the user signs out
+  - Then the user is no longer signed in
+  - And visiting a campaign page redirects to the sign-in screen
+- [ ] **Protected pages require a signed-in user**
+  - Given no user is signed in
+  - When the visitor opens a campaign page directly
+  - Then the visitor is redirected to the sign-in screen
+
+### `features/auth/password-reset.feature`
+
+#### Reset a forgotten password
+
+- [ ] **A user requests a password reset**
+  - Given an account exists for "forgetful@example.com"
+  - When the user requests a password reset for "forgetful@example.com"
+  - Then a password reset link is sent to "forgetful@example.com"
+- [ ] **Requesting a reset for an unknown email reveals nothing**
+  - Given no account exists for "stranger@example.com"
+  - When the user requests a password reset for "stranger@example.com"
+  - Then the user sees the same generic confirmation message
+  - And no password reset link is sent
+- [ ] **A user sets a new password with a valid reset token**
+  - Given a valid password reset token was issued for "forgetful@example.com"
+  - When the user sets a new password "Brand-New-Pw-2" using that token
+  - Then the password for "forgetful@example.com" is updated
+  - And the user can sign in with "Brand-New-Pw-2"
+  - And the user cannot sign in with their old password
+- [ ] **An expired reset token is rejected**
+  - Given an expired password reset token was issued for "forgetful@example.com"
+  - When the user tries to set a new password using that token
+  - Then the password is not changed
+  - And the user sees that the reset link has expired
+- [ ] **A reset token can only be used once**
+  - Given a valid password reset token was issued for "forgetful@example.com"
+  - And the token has already been used to set a new password
+  - When the user tries to set another password using the same token
+  - Then the password is not changed
+  - And the user sees that the reset link is no longer valid
+- [ ] **The new password must meet the requirements**
+  - Given a valid password reset token was issued for "forgetful@example.com"
+  - When the user tries to set a new password that is too weak using that token
+  - Then the password is not changed
+  - And the user sees that the password does not meet the requirements
+
+### `features/auth/sign-up.feature`
+
+#### Sign up for an account
+
+- [ ] **A visitor registers with email and password**
+  - Given no account exists for "dm@example.com"
+  - When the visitor signs up with email "dm@example.com" and a valid password
+  - Then an account for "dm@example.com" is created
+  - And the new account has the "user" role
+  - And the new account is pending email confirmation
+  - And the visitor is not yet signed in
+  - And the visitor sees a generic "check your email to confirm your account" message
+- [ ] **A confirmed account can sign in**
+  - Given an account for "dm@example.com" is pending email confirmation
+  - When the visitor confirms their email using the confirmation link
+  - Then the account for "dm@example.com" is confirmed
+  - And the user can sign in as "dm@example.com"
+- [ ] **Signing up with an already-registered email does not reveal the account exists**
+  - Given an account exists for "dm@example.com"
+  - When a visitor tries to sign up with email "dm@example.com"
+  - Then no second account is created for "dm@example.com"
+  - And the visitor sees the same generic "check your email to confirm your account" message
+  - And an account-already-exists notice is emailed to "dm@example.com"
+- [ ] **A weak password is rejected**
+  - When the visitor tries to sign up with email "new@example.com" and a password that is too weak
+  - Then the account is not created
+  - And the visitor sees that the password does not meet the requirements
+- [ ] **Email format is validated**
+  - When the visitor tries to sign up with email "not-an-email"
+  - Then the account is not created
+  - And the visitor sees that the email is invalid
+
+### `features/collaboration/accept-invite.feature`
+
+#### Respond to a campaign invite
+
+- [ ] **A player accepts an invite**
+  - Given the user is signed in as "alice@example.com"
+  - And "alice@example.com" has a pending invite to "Sunless Citadel"
+  - When "alice@example.com" accepts the invite to "Sunless Citadel"
+  - Then "alice@example.com" is a player in "Sunless Citadel"
+  - And "alice@example.com" can view "Sunless Citadel"
+  - And the invite is no longer pending
+- [ ] **A player declines an invite**
+  - Given the user is signed in as "alice@example.com"
+  - And "alice@example.com" has a pending invite to "Sunless Citadel"
+  - When "alice@example.com" declines the invite to "Sunless Citadel"
+  - Then "alice@example.com" is not a member of "Sunless Citadel"
+  - And the invite is no longer pending
+  - And "alice@example.com" cannot view "Sunless Citadel"
+- [ ] **A user can only respond to their own invite**
+  - Given the user is signed in as "alice@example.com"
+  - And "alice@example.com" has a pending invite to "Sunless Citadel"
+  - Given the user is signed in as "mallory@example.com"
+  - When "mallory@example.com" tries to accept the invite addressed to "alice@example.com"
+  - Then "mallory@example.com" is not a member of "Sunless Citadel"
+  - And "mallory@example.com" sees that they are not authorized
+- [ ] **An invite revoked by the owner can no longer be accepted**
+  - Given the user is signed in as "alice@example.com"
+  - And "alice@example.com" has a pending invite to "Sunless Citadel"
+  - Given the owner has revoked the invite to "alice@example.com"
+  - When "alice@example.com" tries to accept the invite to "Sunless Citadel"
+  - Then "alice@example.com" is not a member of "Sunless Citadel"
+  - And "alice@example.com" sees that the invite is no longer available
+- [ ] **A player can leave a campaign they joined**
+  - Given the user is signed in as "alice@example.com"
+  - And "alice@example.com" has a pending invite to "Sunless Citadel"
+  - Given "alice@example.com" accepted the invite and is a player in "Sunless Citadel"
+  - When "alice@example.com" leaves "Sunless Citadel"
+  - Then "alice@example.com" is not a member of "Sunless Citadel"
+  - And any characters assigned to "alice@example.com" in "Sunless Citadel" have no assigned player
+
+### `features/collaboration/assign-characters.feature`
+
+#### Assign characters to players
+
+- [ ] **An owner assigns a character to a player in the campaign**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - And "alice@example.com" is a player in "Sunless Citadel"
+  - And a character named "Thorin" exists in "Sunless Citadel" with no assigned player
+  - When the owner assigns "Thorin" to "alice@example.com"
+  - Then "Thorin" is assigned to "alice@example.com"
+- [ ] **A character cannot be assigned to a non-member**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - And "alice@example.com" is a player in "Sunless Citadel"
+  - And a character named "Thorin" exists in "Sunless Citadel" with no assigned player
+  - Given "bob@example.com" is not a member of "Sunless Citadel"
+  - When the owner tries to assign "Thorin" to "bob@example.com"
+  - Then "Thorin" has no assigned player
+  - And the owner sees that the player must be a member of the campaign
+- [ ] **Assigning a character to a new player replaces the previous assignee**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - And "alice@example.com" is a player in "Sunless Citadel"
+  - And a character named "Thorin" exists in "Sunless Citadel" with no assigned player
+  - Given "Thorin" is assigned to "alice@example.com"
+  - And "carol@example.com" is a player in "Sunless Citadel"
+  - When the owner assigns "Thorin" to "carol@example.com"
+  - Then "Thorin" is assigned to "carol@example.com"
+  - And "Thorin" is not assigned to "alice@example.com"
+- [ ] **An owner unassigns a character**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - And "alice@example.com" is a player in "Sunless Citadel"
+  - And a character named "Thorin" exists in "Sunless Citadel" with no assigned player
+  - Given "Thorin" is assigned to "alice@example.com"
+  - When the owner unassigns "Thorin"
+  - Then "Thorin" has no assigned player
+- [ ] **A character belongs to exactly one campaign**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - And "alice@example.com" is a player in "Sunless Citadel"
+  - And a character named "Thorin" exists in "Sunless Citadel" with no assigned player
+  - Given "owner@example.com" also owns a campaign named "Dragon Heist"
+  - When the owner views the character "Thorin"
+  - Then "Thorin" belongs only to "Sunless Citadel"
+  - And there is no way to also place "Thorin" in "Dragon Heist"
+- [ ] **A non-owner cannot assign characters**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - And "alice@example.com" is a player in "Sunless Citadel"
+  - And a character named "Thorin" exists in "Sunless Citadel" with no assigned player
+  - Given the user is signed in as "alice@example.com"
+  - When the player tries to assign "Thorin" to "alice@example.com"
+  - Then "Thorin" has no assigned player
+  - And the player sees that they are not authorized
+
+### `features/collaboration/data-ownership-isolation.feature`
+
+#### Each user owns their own campaigns and characters
+
+- [ ] **Pre-auth data is assigned to the seeded admin when auth is introduced**
+  - Given a campaign named "Legacy Game" existed before authentication was introduced
+  - And "admin@example.com" is the seeded admin account
+  - When the ownership migration runs
+  - Then "Legacy Game" is owned by "admin@example.com"
+  - And every character in "Legacy Game" belongs to "Legacy Game"
+- [ ] **A new user starts with no campaigns**
+  - Given the user is signed in as "newbie@example.com"
+  - And "newbie@example.com" owns no campaigns and has joined none
+  - When "newbie@example.com" views their campaign list
+  - Then the campaign list is empty
+- [ ] **A user sees campaigns they own**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - When "owner@example.com" views their campaign list
+  - Then "Sunless Citadel" appears in their campaign list
+- [ ] **A user does not see another user's campaigns**
+  - Given an account exists for "stranger@example.com" who owns a campaign named "Private Game"
+  - And the user is signed in as "owner@example.com"
+  - When "owner@example.com" views their campaign list
+  - Then "Private Game" does not appear in their campaign list
+- [ ] **A user cannot open another user's campaign by direct link**
+  - Given an account exists for "stranger@example.com" who owns a campaign named "Private Game"
+  - And the user is signed in as "owner@example.com"
+  - And "owner@example.com" is not a member of "Private Game"
+  - When "owner@example.com" opens the "Private Game" campaign page directly
+  - Then access is denied with a 403 Forbidden
+- [ ] **A joined player sees the campaign but not the owner's other campaigns**
+  - Given the user is signed in as "alice@example.com"
+  - And "alice@example.com" is a player in "Sunless Citadel" owned by "owner@example.com"
+  - And "owner@example.com" also owns a campaign named "Secret Game" that "alice@example.com" has not joined
+  - When "alice@example.com" views their campaign list
+  - Then "Sunless Citadel" appears in their campaign list
+  - And "Secret Game" does not appear in their campaign list
+- [ ] **A user cannot see characters in a campaign they have not joined**
+  - Given an account exists for "stranger@example.com" who owns a campaign named "Private Game" with a character named "Hidden Hero"
+  - And the user is signed in as "owner@example.com"
+  - When "owner@example.com" tries to view the characters in "Private Game"
+  - Then access is denied with a 403 Forbidden
+  - And "Hidden Hero" is not shown
+
+### `features/collaboration/invite-players.feature`
+
+#### Invite players to a campaign
+
+- [ ] **An owner invites a registered user as a player**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - Given an account exists for "alice@example.com"
+  - When the owner invites "alice@example.com" to "Sunless Citadel"
+  - Then "alice@example.com" has a pending invite to "Sunless Citadel"
+- [ ] **An unregistered email cannot be invited**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - Given no account exists for "nobody@example.com"
+  - When the owner tries to invite "nobody@example.com" to "Sunless Citadel"
+  - Then no invite is created
+  - And the owner sees that only registered users can be invited
+- [ ] **A pending invite does not yet grant access**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - Given the owner has invited "alice@example.com" to "Sunless Citadel"
+  - And the invite is still pending
+  - When "alice@example.com" tries to view "Sunless Citadel"
+  - Then "alice@example.com" cannot view the campaign
+- [ ] **The same user cannot be invited twice while a pending invite exists**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - Given the owner has invited "alice@example.com" to "Sunless Citadel"
+  - When the owner tries to invite "alice@example.com" to "Sunless Citadel" again
+  - Then no second invite is created
+  - And the owner sees that an invite is already pending
+- [ ] **A current member cannot be re-invited**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - Given "alice@example.com" is already a player in "Sunless Citadel"
+  - When the owner tries to invite "alice@example.com" to "Sunless Citadel"
+  - Then no invite is created
+  - And the owner sees that the user is already a member
+- [ ] **A non-owner cannot invite players**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - Given "alice@example.com" is already a player in "Sunless Citadel"
+  - And the user is signed in as "alice@example.com"
+  - When the player tries to invite "bob@example.com" to "Sunless Citadel"
+  - Then no invite is created
+  - And the player sees that they are not authorized
+- [ ] **An owner removes a player from the campaign**
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns a campaign named "Sunless Citadel"
+  - Given "alice@example.com" is already a player in "Sunless Citadel"
+  - When the owner removes "alice@example.com" from "Sunless Citadel"
+  - Then "alice@example.com" is no longer a member of "Sunless Citadel"
+  - And "alice@example.com" can no longer view the campaign
+
+### `features/collaboration/manage-own-characters.feature`
+
+#### Players manage their own characters
+
+- [ ] **A player creates a character in a campaign they joined and is auto-assigned**
+  - Given the user is signed in as "alice@example.com"
+  - And "alice@example.com" is a player in "Sunless Citadel"
+  - When "alice@example.com" creates a character named "Lyra" in "Sunless Citadel"
+  - Then "Lyra" exists in "Sunless Citadel"
+  - And "Lyra" is assigned to "alice@example.com"
+- [ ] **A player edits a character assigned to them**
+  - Given the user is signed in as "alice@example.com"
+  - And "alice@example.com" is a player in "Sunless Citadel"
+  - Given a character named "Lyra" in "Sunless Citadel" is assigned to "alice@example.com"
+  - When "alice@example.com" levels up "Lyra"
+  - Then the change is saved without any approval step
+- [ ] **A player cannot edit another player's character**
+  - Given the user is signed in as "alice@example.com"
+  - And "alice@example.com" is a player in "Sunless Citadel"
+  - Given "bob@example.com" is a player in "Sunless Citadel"
+  - And a character named "Grog" in "Sunless Citadel" is assigned to "bob@example.com"
+  - When "alice@example.com" tries to edit "Grog"
+  - Then the change is not saved
+  - And "alice@example.com" sees that they are not authorized
+- [ ] **A player cannot create a character in a campaign they have not joined**
+  - Given the user is signed in as "alice@example.com"
+  - And "alice@example.com" is a player in "Sunless Citadel"
+  - Given "alice@example.com" is not a member of "Waterdeep"
+  - When "alice@example.com" tries to create a character in "Waterdeep"
+  - Then no character is created
+  - And "alice@example.com" sees that they are not a member of the campaign
+- [ ] **The campaign owner can edit any character in their campaign**
+  - Given the user is signed in as "alice@example.com"
+  - And "alice@example.com" is a player in "Sunless Citadel"
+  - Given the user is signed in as "owner@example.com"
+  - And "owner@example.com" owns "Sunless Citadel"
+  - And a character named "Lyra" in "Sunless Citadel" is assigned to "alice@example.com"
+  - When the owner edits "Lyra"
+  - Then the change is saved

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -82,5 +82,12 @@ export default defineConfig(
       'no-console': 'off',
     },
   },
+  {
+    // Standalone CLI tooling (run via tsx, not bundled into the app).
+    files: ['scripts/**/*.ts'],
+    rules: {
+      'no-console': 'off',
+    },
+  },
   prettierConfig
 );

--- a/package-lock.json
+++ b/package-lock.json
@@ -29,6 +29,8 @@
       },
       "devDependencies": {
         "@cucumber/cucumber": "^13.0.0",
+        "@cucumber/gherkin": "^39.1.0",
+        "@cucumber/messages": "^32.3.1",
         "@eslint/js": "^10.0.1",
         "@tailwindcss/vite": "^4.3.0",
         "@tanstack/devtools-vite": "^0.7.0",

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "test:watch": "vitest",
     "test:coverage": "vitest run --coverage",
     "coverage:matrix": "COVERAGE_WRITE=1 vitest run src/lib/sources/coverage-matrix.test.ts",
+    "uat:checklist": "TSX_TSCONFIG_PATH=tsconfig.app.json tsx scripts/gen-uat-checklist.ts",
     "supabase:types": "npx supabase gen types typescript --local > src/types/supabase.ts",
     "supabase:reset": "npx supabase stop --no-backup && npx supabase start && npm run supabase:types",
     "format": "prettier --write .",
@@ -44,6 +45,8 @@
   },
   "devDependencies": {
     "@cucumber/cucumber": "^13.0.0",
+    "@cucumber/gherkin": "^39.1.0",
+    "@cucumber/messages": "^32.3.1",
     "@eslint/js": "^10.0.1",
     "@tailwindcss/vite": "^4.3.0",
     "@tanstack/devtools-vite": "^0.7.0",

--- a/scripts/gen-uat-checklist.ts
+++ b/scripts/gen-uat-checklist.ts
@@ -1,0 +1,325 @@
+/**
+ * Generate a manual user-acceptance-testing (UAT) checklist from the Gherkin
+ * BDD specs under `features/`.
+ *
+ * Cucumber.js has no built-in "checklist" or "spreadsheet" exporter — its
+ * formatters all describe *automated* runs. This script parses every
+ * `.feature` file with the Gherkin AST parser (already a Cucumber dependency)
+ * and emits one row per scenario so a human tester can tick each one off by
+ * hand.
+ *
+ * The key signal it surfaces is each scenario's **status**, derived from the
+ * project's tag taxonomy (see `docs/bdd.md` / `cucumber.js`):
+ *
+ *   - `ready`  — untagged; the app is expected to support this today, so a UAT
+ *                tester SHOULD be able to validate it now.
+ *   - `future` — `@future`; spec-ahead work order, not built yet. Listed so the
+ *                checklist is complete, but a tester should expect it to fail
+ *                (or skip it).
+ *   - `draft`  — `@draft`; legacy "no steps yet", being retired.
+ *
+ * Tags inherit downward: a `@future` on a Feature or Rule applies to every
+ * scenario beneath it, exactly as Cucumber's tag filtering treats them.
+ *
+ * Usage:
+ *   npm run uat:checklist            # CSV  -> docs/uat-checklist.csv
+ *   npm run uat:checklist -- --format md     # Markdown -> docs/uat-checklist.md
+ *   npm run uat:checklist -- --format both   # both files
+ *
+ * The CSV opens directly in Excel / Google Sheets (Result + Notes columns left
+ * blank for the tester). The Markdown form prints cleanly with `[ ]` checkboxes.
+ */
+import { readFileSync, writeFileSync, globSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { AstBuilder, GherkinClassicTokenMatcher, Parser } from '@cucumber/gherkin';
+import { IdGenerator, type GherkinDocument, type Scenario, type Step } from '@cucumber/messages';
+
+type Status = 'ready' | 'future' | 'draft';
+
+interface ChecklistRow {
+  readonly file: string;
+  readonly feature: string;
+  readonly rule: string;
+  readonly scenario: string;
+  readonly status: Status;
+  readonly tags: readonly string[];
+  readonly steps: readonly string[];
+}
+
+const REPO_ROOT: string = fileURLToPath(new URL('..', import.meta.url));
+const FEATURES_DIR: string = join(REPO_ROOT, 'features');
+const DOCS_DIR: string = join(REPO_ROOT, 'docs');
+
+function statusFromTags(tags: readonly string[]): Status {
+  if (tags.includes('@future')) return 'future';
+  if (tags.includes('@draft')) return 'draft';
+  return 'ready';
+}
+
+function parseFeature(source: string): GherkinDocument {
+  const builder = new AstBuilder(IdGenerator.uuid());
+  const matcher = new GherkinClassicTokenMatcher();
+  const parser = new Parser(builder, matcher);
+  return parser.parse(source);
+}
+
+function stepText(step: Step): string {
+  return `${step.keyword}${step.text}`.trim();
+}
+
+/**
+ * Expand a Scenario Outline into one row per Examples table row, substituting
+ * `<placeholder>` tokens in the name and steps. A plain Scenario yields a single
+ * row with its steps verbatim.
+ *
+ * `backgroundSteps` are the Feature- (and Rule-) level Background steps that
+ * Cucumber runs before every scenario; they are prepended so each checklist row
+ * is self-contained setup-wise for a manual tester.
+ */
+function expandScenario(
+  scenario: Scenario,
+  inheritedTags: readonly string[],
+  backgroundSteps: readonly string[],
+  context: { file: string; feature: string; rule: string }
+): ChecklistRow[] {
+  const ownTags: string[] = scenario.tags.map((t) => t.name);
+  const tags: string[] = [...inheritedTags, ...ownTags];
+  const baseSteps: string[] = [...backgroundSteps, ...scenario.steps.map(stepText)];
+
+  if (scenario.examples.length === 0) {
+    return [
+      {
+        ...context,
+        scenario: scenario.name,
+        status: statusFromTags(tags),
+        tags,
+        steps: baseSteps,
+      },
+    ];
+  }
+
+  const rows: ChecklistRow[] = [];
+  for (const example of scenario.examples) {
+    const headers: string[] = (example.tableHeader?.cells ?? []).map((c) => c.value);
+    const exampleTags: string[] = [...tags, ...example.tags.map((t) => t.name)];
+    for (const bodyRow of example.tableBody) {
+      const values: string[] = bodyRow.cells.map((c) => c.value);
+      const substitute = (text: string): string =>
+        headers.reduce((acc, header, i) => acc.split(`<${header}>`).join(values[i] ?? ''), text);
+      rows.push({
+        ...context,
+        scenario: substitute(scenario.name),
+        status: statusFromTags(exampleTags),
+        tags: exampleTags,
+        steps: baseSteps.map(substitute),
+      });
+    }
+  }
+  return rows;
+}
+
+function collectRows(): ChecklistRow[] {
+  const files: string[] = globSync('**/*.feature', { cwd: FEATURES_DIR }).sort();
+  const rows: ChecklistRow[] = [];
+
+  for (const rel of files) {
+    const abs: string = join(FEATURES_DIR, rel);
+    const fileLabel: string = relative(REPO_ROOT, abs);
+    const doc: GherkinDocument = parseFeature(readFileSync(abs, 'utf8'));
+    const feature = doc.feature;
+    if (!feature) continue;
+
+    const featureTags: string[] = feature.tags.map((t) => t.name);
+    // A Feature-level Background runs before every scenario in the file, including
+    // those nested under Rules.
+    const featureBackground: string[] =
+      feature.children.find((c) => c.background)?.background?.steps.map(stepText) ?? [];
+
+    for (const child of feature.children) {
+      if (child.scenario) {
+        rows.push(
+          ...expandScenario(child.scenario, featureTags, featureBackground, {
+            file: fileLabel,
+            feature: feature.name,
+            rule: '',
+          })
+        );
+      }
+      if (child.rule) {
+        const ruleTags: string[] = [...featureTags, ...child.rule.tags.map((t) => t.name)];
+        // A Rule-level Background runs after the Feature Background, before each
+        // scenario in that Rule.
+        const ruleBackground: string[] = [
+          ...featureBackground,
+          ...(child.rule.children.find((c) => c.background)?.background?.steps.map(stepText) ?? []),
+        ];
+        for (const ruleChild of child.rule.children) {
+          if (!ruleChild.scenario) continue;
+          rows.push(
+            ...expandScenario(ruleChild.scenario, ruleTags, ruleBackground, {
+              file: fileLabel,
+              feature: feature.name,
+              rule: child.rule.name,
+            })
+          );
+        }
+      }
+    }
+  }
+  return rows;
+}
+
+// Short labels for headers; STATUS_LABEL is the descriptive form for the CSV
+// Status column (which has no legend alongside it).
+const STATUS_HEADING: Readonly<Record<Status, string>> = {
+  ready: 'Ready',
+  future: 'Future',
+  draft: 'Draft',
+};
+
+const STATUS_LABEL: Readonly<Record<Status, string>> = {
+  ready: 'Ready',
+  future: 'Future (not built yet)',
+  draft: 'Draft',
+};
+
+// Tester-facing priority: validate what works today first, then spec-ahead, then stubs.
+const STATUS_ORDER: readonly Status[] = ['ready', 'future', 'draft'];
+
+/**
+ * Order rows by status (Ready → Future → Draft). The sort is stable, so the
+ * file/feature ordering from collectRows() is preserved within each status.
+ */
+function sortByStatus(rows: readonly ChecklistRow[]): ChecklistRow[] {
+  return [...rows].sort((a, b) => STATUS_ORDER.indexOf(a.status) - STATUS_ORDER.indexOf(b.status));
+}
+
+function csvField(value: string): string {
+  return `"${value.replace(/"/g, '""')}"`;
+}
+
+function toCsv(rows: readonly ChecklistRow[]): string {
+  const header: string[] = [
+    'File',
+    'Feature',
+    'Rule',
+    'Scenario',
+    'Status',
+    'Tags',
+    'Steps',
+    'Result (Pass/Fail/Blocked)',
+    'Notes',
+  ];
+  const lines: string[] = [header.map(csvField).join(',')];
+  for (const row of rows) {
+    lines.push(
+      [
+        row.file,
+        row.feature,
+        row.rule,
+        row.scenario,
+        STATUS_LABEL[row.status],
+        row.tags.join(' '),
+        row.steps.join('\n'),
+        '',
+        '',
+      ]
+        .map(csvField)
+        .join(',')
+    );
+  }
+  return `${lines.join('\n')}\n`;
+}
+
+function toMarkdown(rows: readonly ChecklistRow[]): string {
+  const total: number = rows.length;
+  const ready: number = rows.filter((r) => r.status === 'ready').length;
+  const future: number = rows.filter((r) => r.status === 'future').length;
+  const draft: number = rows.filter((r) => r.status === 'draft').length;
+
+  const COUNT: Readonly<Record<Status, number>> = { ready, future, draft };
+
+  const out: string[] = [
+    '# UAT Checklist',
+    '',
+    '> Generated from the Gherkin specs under `features/` by `npm run uat:checklist`.',
+    '> Do not edit by hand — re-run the script to refresh.',
+    '',
+    `**${total} scenarios** — ${ready} ready · ${future} future (not built yet) · ${draft} draft`,
+    '',
+    'Status legend: **Ready** = expected to work today, validate it · ' +
+      '**Future** = spec-ahead, expect it to fail/skip · **Draft** = no steps yet.',
+  ];
+
+  // Outermost grouping is status (Ready → Future → Draft); within each, group by
+  // file, then feature, then rule. Rows are pre-sorted by status, so a single
+  // pass keeps every status's scenarios contiguous.
+  let currentStatus: Status | '' = '';
+  let currentFile = '';
+  let currentFeature = '';
+  let currentRule = '';
+  for (const row of rows) {
+    if (row.status !== currentStatus) {
+      currentStatus = row.status;
+      currentFile = '';
+      currentFeature = '';
+      currentRule = '';
+      out.push('', `## ${STATUS_HEADING[row.status]} (${COUNT[row.status]})`);
+    }
+    if (row.file !== currentFile) {
+      currentFile = row.file;
+      currentFeature = '';
+      currentRule = '';
+      out.push('', `### \`${row.file}\``, '');
+    }
+    if (row.feature !== currentFeature) {
+      currentFeature = row.feature;
+      currentRule = '';
+      out.push(`#### ${row.feature}`, '');
+    }
+    if (row.rule && row.rule !== currentRule) {
+      currentRule = row.rule;
+      out.push(`##### Rule: ${row.rule}`, '');
+    }
+    out.push(`- [ ] **${row.scenario}**`);
+    for (const step of row.steps) {
+      out.push(`  - ${step}`);
+    }
+  }
+  out.push('');
+  return out.join('\n');
+}
+
+function main(): void {
+  const args: string[] = process.argv.slice(2);
+  const formatIndex: number = args.indexOf('--format');
+  const format: string = formatIndex >= 0 ? (args[formatIndex + 1] ?? 'csv') : 'csv';
+  if (!['csv', 'md', 'both'].includes(format)) {
+    console.error(`Unknown --format "${format}". Use csv | md | both.`);
+    process.exit(1);
+  }
+
+  const rows: ChecklistRow[] = sortByStatus(collectRows());
+  const written: string[] = [];
+
+  if (format === 'csv' || format === 'both') {
+    const path: string = join(DOCS_DIR, 'uat-checklist.csv');
+    writeFileSync(path, toCsv(rows));
+    written.push(relative(REPO_ROOT, path));
+  }
+  if (format === 'md' || format === 'both') {
+    const path: string = join(DOCS_DIR, 'uat-checklist.md');
+    writeFileSync(path, toMarkdown(rows));
+    written.push(relative(REPO_ROOT, path));
+  }
+
+  const ready: number = rows.filter((r) => r.status === 'ready').length;
+  const future: number = rows.filter((r) => r.status === 'future').length;
+  const draft: number = rows.filter((r) => r.status === 'draft').length;
+  console.log(
+    `Wrote ${written.join(', ')} — ${rows.length} scenarios ` + `(${ready} ready, ${future} future, ${draft} draft).`
+  );
+}
+
+main();

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -23,6 +23,6 @@
       "@/*": ["./src/*"]
     }
   },
-  "include": ["src", "features/**/*.ts"],
+  "include": ["src", "features/**/*.ts", "scripts/**/*.ts"],
   "exclude": ["node_modules"]
 }


### PR DESCRIPTION
## What

Adds `npm run uat:checklist` — exports the Cucumber BDD specs under `features/` to a manual user-acceptance-testing checklist. Cucumber.js has no built-in checklist/spreadsheet exporter, so this parses each `.feature` file with Cucumber's own Gherkin AST parser and emits one row per scenario.

## Usage

| Command | Output |
| --- | --- |
| `npm run uat:checklist` | `docs/uat-checklist.csv` (Excel/Sheets; blank Result + Notes columns) |
| `npm run uat:checklist -- --format md` | `docs/uat-checklist.md` (printable `[ ]` checkboxes) |
| `npm run uat:checklist -- --format both` | both |

## Details

- **Tag-derived status** per scenario, ordered **Ready → Future → Draft** (status is the top-level grouping in both outputs):
  - **Ready** — untagged; app is expected to support it today, validate now.
  - **Future** — `@future`; spec-ahead work order, not built yet.
  - **Draft** — `@draft`; steps not implemented.
- **Verified against Cucumber**: the 80 Ready rows equal `npm run test:bdd -- --dry-run`'s default-profile scenario count, confirming the tag inheritance (including example-level `@future`) matches Cucumber's own filtering.
- **Scenario Outlines** expand to one row per Examples entry with placeholders substituted.
- **Background** steps (feature- and rule-level) are prepended so each row is self-contained for a manual tester.

## Tooling

- Pin `@cucumber/gherkin` / `@cucumber/messages` as explicit devDeps (were transitive via `@cucumber/cucumber`); lockfile updated.
- `scripts/` now typechecked; `no-console` allowed in `scripts/`; generated docs prettier-ignored (matching `coverage-matrix.md`).
- Documented in README, CLAUDE.md, and `docs/bdd.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)