### PR TITLE
refactor(builder): call the character builder "builder" not "wizard"

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -59,7 +59,7 @@ Prettier + `eslint --fix` run automatically on every file Claude writes or edits
 
 ### Routing
 
-All routes are defined in `src/App.tsx`. Layout wraps all routes and provides a sidebar with campaign selection. Routes follow `/campaign/:id/<section>` pattern. Global routes (`/settings/theme`, `/export`) exist outside the campaign scope. The character builder lives at `/campaign/:id/character/new` with a 7-step wizard (Basics → Abilities → Skills → Class Features → Proficiencies → Equipment → Backstory), autosave via `useBuilderAutosave()`, and dedicated step components in `src/components/character-builder/`. There is no dedicated Spells step in the wizard, but spellcasting is resolved: `src/lib/resolver/spellcasting.ts` (`resolveSpellcasting()`) builds a spellcasting profile from `spellcasting` grants, returning `null` only when the build has none.
+All routes are defined in `src/App.tsx`. Layout wraps all routes and provides a sidebar with campaign selection. Routes follow `/campaign/:id/<section>` pattern. Global routes (`/settings/theme`, `/export`) exist outside the campaign scope. The character builder lives at `/campaign/:id/character/new` with a 7-step flow (Basics → Abilities → Skills → Class Features → Proficiencies → Equipment → Backstory), autosave via `useBuilderAutosave()`, and dedicated step components in `src/components/character-builder/`. There is no dedicated Spells step in the builder, but spellcasting is resolved: `src/lib/resolver/spellcasting.ts` (`resolveSpellcasting()`) builds a spellcasting profile from `spellcasting` grants, returning `null` only when the build has none.
 
 ### Internationalization (i18n)
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A free, open-source campaign management tool for D&D 5.5e (2024 Player's Handboo
 ## Features
 
 - **Campaign Management** — Create and manage multiple campaigns with setting info, status tracking, and a dashboard overview
-- **Character Builder** — 7-step wizard (Basics → Abilities → Skills → Class Features → Proficiencies → Equipment → Backstory) with autosave; implements 2024 species, backgrounds, feat catalog, weapon masteries, and subclass selection at level 3
+- **Character Builder** — 7-step flow (Basics → Abilities → Skills → Class Features → Proficiencies → Equipment → Backstory) with autosave; implements 2024 species, backgrounds, feat catalog, weapon masteries, and subclass selection at level 3
 - **Character Sheets** — Build and track PCs and NPCs with full 5.5e stats: ability scores, skills, equipment, spells, heroic inspiration, exhaustion, and weapon mastery display
 - **Session Log** — Record session summaries, XP awards, loot tracking, and link encounters to sessions
 - **Encounter Tracker** — Plan encounters with combatant lists and status tracking

--- a/features/_BACKLOG.md
+++ b/features/_BACKLOG.md
@@ -59,7 +59,7 @@ Each entry follows the template:
 **Acceptance criteria:**
 
 - Given I have filled in step 1 (name, species), when I navigate to a different page and return, then my step 1 data is still present
-- Given I have a draft saved, when I land on the builder URL, then the draft is loaded and the wizard starts from where I left off
+- Given I have a draft saved, when I land on the builder URL, then the draft is loaded and the builder starts from where I left off
   **Implementing code:** `src/hooks/useBuilderAutosave.ts`, `src/hooks/useCharacterBuild.ts`
   **Notes:** `useBuilderAutosave` writes to the `characters` table with `build_json` JSONB column. `finalize()` creates the resolved character.
 

--- a/features/characters/builder-autosave.feature
+++ b/features/characters/builder-autosave.feature
@@ -5,10 +5,10 @@ Feature: Autosave character builder draft
 
   # Render-app seam: a draft is persisted as a characters row (status='draft') plus
   # character_build_levels rows. Returning to the builder at the draft's URL loads
-  # it — useCharacter(slug) + useCharacterBuildLevels rehydrate the wizard, so step
+  # it — useCharacter(slug) + useCharacterBuildLevels rehydrate the builder, so step
   # 1 (name, species) is pre-filled. This exercises the resume/reload path (AC2 and
   # the reload half of AC1); it seeds the draft rows directly rather than driving
-  # the autosave WRITE through the wizard's inputs.
+  # the autosave WRITE through the builder's inputs.
 
   Scenario: A saved draft is reloaded when returning to the builder
     Given a saved character draft named "Aldara"

--- a/features/characters/steps/builder-autosave.steps.ts
+++ b/features/characters/steps/builder-autosave.steps.ts
@@ -9,7 +9,7 @@ import type { Row } from '../../steps/support/stateful-supabase.js';
 //
 // Seeds a draft (characters status='draft' + character_build_levels) and renders
 // the real CharacterBuilder at the draft's resume URL. useCharacter +
-// useCharacterBuildLevels rehydrate the wizard via the pure CharacterProvider,
+// useCharacterBuildLevels rehydrate the builder via the pure CharacterProvider,
 // so BasicsStep shows the saved name and species. useCampaignContext is stubbed.
 // ---------------------------------------------------------------------------
 

--- a/features/characters/steps/finalize-character.steps.ts
+++ b/features/characters/steps/finalize-character.steps.ts
@@ -11,7 +11,7 @@ import type { AutosavePayload } from '@/hooks/useBuilderAutosave';
  * Finalize-character seam: render-app / data seam (persistence) + resolver.
  *
  * The build is finalized through the REAL `useBuilderAutosave().finalize` — the
- * production entry point the wizard uses. The stateful supabase double now honors
+ * production entry point the builder uses. The stateful supabase double now honors
  * the calls it makes (`.upsert` for build-level rows, `.not('sequence','in',...)`
  * for orphan cleanup, `character_items` insert, and the `status` promotion update),
  * so the draft→ready promotion and the resolver-derived stat mapping are exercised

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -216,7 +216,7 @@
       "selectSpeciesFirst": "Select a species to see lineage options.",
       "loadingLineage": "Loading lineage options...",
       "couldNotLoadPlayerNames": "Could not load player name suggestions",
-      "quickNpcDescription": "Click a class icon to create a random NPC of that class and jump ahead in the wizard",
+      "quickNpcDescription": "Click a class icon to create a random NPC of that class and jump ahead in the builder",
       "quickNpcButton": "Random {{class}} NPC",
       "quickNpcFailed": "Could not generate NPC — name data missing for selected species",
       "quickNpcUnknownClass": "Could not generate NPC — unknown class",


### PR DESCRIPTION
## What & why
Renames the character-builder flow from "wizard" to "builder" everywhere it referred to the flow, so it can never be confused with the **Wizard** class. The codebase already standardizes on "builder" (`CharacterBuilder.tsx`, `character-builder/`, `useBuilderAutosave()`); "wizard" was the lone outlier.

## Changes
**Code (`9845de7`)** — the only user-facing string + BDD/test comments:
- `src/locales/en/common.json` — `quickNpcDescription`: "…jump ahead in the **builder**"
- `features/characters/builder-autosave.feature` — both comment mentions
- `features/characters/steps/builder-autosave.steps.ts` — comment
- `features/characters/steps/finalize-character.steps.ts` — comment

**Docs (`3497d43`)**:
- `CLAUDE.md` — "7-step **flow**" + "Spells step in the **builder**"
- `README.md` — "7-step **flow**"
- `features/_BACKLOG.md` — "the **builder** starts from where I left off"

## Left intact (genuinely the Wizard class / company)
`docs/dnd-2024.md`, `docs/coverage-matrix.md`, `docs/uat-checklist.md` ("wizard **class**", generated), `public/assets/README.md` ("Wizards of the Coast"), the `'wizard'` class-ID example in `CLAUDE.md`, and `wizardSpellcasting()`/`wizardSubclassChoice` test fixtures.

## Notes
- No behavior change; typecheck passes.
- Follow-up from the level-1 character-builder UAT round (epic #245).

🤖 Generated with [Claude Code](https://claude.com/claude-code)