### PR TITLE
fix(bdd): recognize direct-feature Magic Initiate as origin feat (#183)

### DIFF
--- a/features/characters/choose-background.feature
+++ b/features/characters/choose-background.feature
@@ -33,12 +33,5 @@ Feature: Choose a background during character creation
       Examples:
         | background |
         | soldier    |
-
-      # Magic Initiate backgrounds model their origin feat as a fixed `feature`
-      # grant (not a `feat` grant) because Magic Initiate feats don't resolve
-      # through collectBundles — tracked in issue #178. Spec-ahead until then.
-      @future
-      Examples:
-        | background |
         | acolyte    |
         | sage       |

--- a/features/characters/steps/choose-background.steps.ts
+++ b/features/characters/steps/choose-background.steps.ts
@@ -59,18 +59,51 @@ Then('the background grants {int} points of ability score increases', function (
 
 Then('the character gains an origin feat', function (this: DndWorld) {
   const background = getBackgroundSource(this.build!.backgroundId as BackgroundId);
-  const featGrant = background?.grants.find((g) => g.type === 'feat');
-  if (!featGrant) {
-    throw new Error(`Background "${this.build!.backgroundId}" defines no origin feat grant`);
+  if (!background) {
+    throw new Error(`No background source found for "${this.build!.backgroundId}"`);
   }
-  const featId = (featGrant as { readonly featId: FeatId }).featId;
-  const hasFeat = this.resolved!.features.some((f) => f.source.origin === 'feat' && f.source.id === featId);
-  if (!hasFeat) {
-    const featSources = this.resolved!.features
-      .filter((f) => f.source.origin === 'feat')
-      .map((f) => (f.source.origin === 'feat' ? f.source.id : null));
-    throw new Error(
-      `Expected origin feat "${featId}" in resolved features; feat-origin sources: ${JSON.stringify(featSources)}`
+
+  // Case (a): background uses a `feat` grant — the feat expands into its own feat-origin bundle,
+  // so the resolved feature carries source.origin === 'feat'.
+  const featGrant = background.grants.find((g) => g.type === 'feat');
+  if (featGrant) {
+    const featId = (featGrant as { readonly featId: FeatId }).featId;
+    const hasFeat = this.resolved!.features.some((f) => f.source.origin === 'feat' && f.source.id === featId);
+    if (!hasFeat) {
+      const featSources = this.resolved!.features
+        .filter((f) => f.source.origin === 'feat')
+        .map((f) => (f.source.origin === 'feat' ? f.source.id : null));
+      throw new Error(
+        `Expected origin feat "${featId}" in resolved features; feat-origin sources: ${JSON.stringify(featSources)}`
+      );
+    }
+    return;
+  }
+
+  // Case (b): background uses a direct `feature` grant whose id matches feat-magic-initiate-*.
+  // The feature resolves directly from the background bundle, so source.origin === 'background'.
+  const directFeatFeatureGrant = background.grants.find(
+    (g) =>
+      g.type === 'feature' &&
+      (g as { readonly feature: { readonly id: string } }).feature.id.startsWith('feat-magic-initiate-')
+  );
+  if (directFeatFeatureGrant) {
+    const featureId = (directFeatFeatureGrant as { readonly feature: { readonly id: string } }).feature.id;
+    const hasFeature = this.resolved!.features.some(
+      (f) => f.source.origin === 'background' && f.feature.id === featureId
     );
+    if (!hasFeature) {
+      const backgroundFeatures = this.resolved!.features
+        .filter((f) => f.source.origin === 'background')
+        .map((f) => f.feature.id);
+      throw new Error(
+        `Expected direct-feature "${featureId}" in resolved features; background-origin features: ${JSON.stringify(backgroundFeatures)}`
+      );
+    }
+    return;
   }
+
+  throw new Error(
+    `Background "${this.build!.backgroundId}" defines no origin feat grant (neither feat nor direct Magic Initiate feature)`
+  );
 });


### PR DESCRIPTION
Closes #183

## Summary
The default-profile BDD suite was red on `main`: the `Then('the character gains an origin feat')` step only recognized `feat`-type grants, but PR #177 changed acolyte/guide/sage to grant Magic Initiate as a direct `feature` grant (`feat-magic-initiate-*`). This is a test-glue fix only — no `src/` changes.

## What Changed
- `features/characters/steps/choose-background.steps.ts` — the origin-feat step now accepts EITHER a `feat`-type grant (existing) OR a direct `feature` grant matching `feat-magic-initiate-*`, asserting the corresponding resolved feature is present.
- `features/characters/choose-background.feature` — removed the `@future` tag from the now-passing acolyte/sage examples.

## Testing
- `npm run test:bdd` (default profile) → 82 scenarios / 514 steps, all passing
- `npm run typecheck` → passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)