### PR TITLE
fix(sources): correct Druid level placements for Wild Resurgence / Elemental Fury / Improved Elemental Fury (#180)

### DIFF
--- a/src/lib/sources/classes.test.ts
+++ b/src/lib/sources/classes.test.ts
@@ -658,9 +658,15 @@ describe('Druid class grant structures', () => {
     }
   });
 
-  // TODO(#180): Elemental Fury belongs at L7 (levels[6]); currently misplaced at L11.
-  it('level 11 has an elemental-fury feature-choice between Potent Spellcasting and Primal Strike', () => {
-    const grant = source?.levels[10].grants.find((g) => g.type === 'feature-choice');
+  it('level 5 has wild-resurgence feature', () => {
+    const featureIds = source?.levels[4].grants
+      .filter((g) => g.type === 'feature')
+      .map((g) => (g.type === 'feature' ? g.feature.id : ''));
+    expect(featureIds).toContain('druid-wild-resurgence');
+  });
+
+  it('level 7 has an elemental-fury feature-choice between Potent Spellcasting and Primal Strike', () => {
+    const grant = source?.levels[6].grants.find((g) => g.type === 'feature-choice');
     expect(grant?.type).toBe('feature-choice');
     if (grant?.type === 'feature-choice') {
       expect(grant.key).toBe(createChoiceKey('feature-choice', 'class', 'druid', 1));
@@ -671,6 +677,13 @@ describe('Druid class grant structures', () => {
       const primalStrike = grant.options.find((o) => o.optionId === 'primal-strike');
       expect(primalStrike?.featureId).toBe('druid-elemental-fury-primal-strike');
     }
+  });
+
+  it('level 15 has improved-elemental-fury feature', () => {
+    const featureIds = source?.levels[14].grants
+      .filter((g) => g.type === 'feature')
+      .map((g) => (g.type === 'feature' ? g.feature.id : ''));
+    expect(featureIds).toContain('druid-improved-elemental-fury');
   });
 
   it('level 20 has archdruid feature', () => {

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -411,16 +411,7 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
           { type: 'feature', feature: { id: 'druid-wild-shape-improvement-1' } },
         ],
       },
-      EMPTY_LEVEL,
-      EMPTY_LEVEL,
       { grants: [{ type: 'feature', feature: { id: 'druid-wild-resurgence' } }] },
-      {
-        grants: [
-          { type: 'asi', key: createChoiceKey('asi', 'class', 'druid', 1), points: 2, from: null },
-          { type: 'feature', feature: { id: 'druid-wild-shape-improvement-2' } },
-        ],
-      },
-      EMPTY_LEVEL,
       EMPTY_LEVEL,
       {
         grants: [
@@ -444,12 +435,21 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
           },
         ],
       },
+      {
+        grants: [
+          { type: 'asi', key: createChoiceKey('asi', 'class', 'druid', 1), points: 2, from: null },
+          { type: 'feature', feature: { id: 'druid-wild-shape-improvement-2' } },
+        ],
+      },
+      EMPTY_LEVEL,
+      EMPTY_LEVEL,
+      EMPTY_LEVEL,
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'druid', 2), points: 2, from: null }] },
       EMPTY_LEVEL,
       EMPTY_LEVEL,
-      EMPTY_LEVEL,
-      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'druid', 3), points: 2, from: null }] },
       { grants: [{ type: 'feature', feature: { id: 'druid-improved-elemental-fury' } }] },
+      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'druid', 3), points: 2, from: null }] },
+      EMPTY_LEVEL,
       { grants: [{ type: 'feature', feature: { id: 'druid-beast-spells' } }] },
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'druid', 4), points: 2, from: null }] },
       { grants: [{ type: 'feature', feature: { id: 'druid-archdruid' } }] },


### PR DESCRIPTION
Closes #180

## Summary
The Druid `ClassSource` in `src/lib/sources/classes.ts` placed three features at the wrong class levels vs the 2024 PHB. PR #179 deliberately left them in place during a location-preserving structural conversion; this corrects the placements. ASIs remain at L4/L8/L12/L16/L19 and Wild Shape Improvements at L4/L8 (unchanged).

## What Changed
- `druid-wild-resurgence`: L7 → **L5** (`levels[6]` → `levels[4]`)
- Elemental Fury `feature-choice` grant: L11 → **L7** (`levels[10]` → `levels[6]`)
- `druid-improved-elemental-fury`: L17 → **L15** (`levels[16]` → `levels[14]`)
- `src/lib/sources/classes.test.ts` — updated the Elemental Fury position assertion (L11→L7) and added assertions for Wild Resurgence at L5 and Improved Elemental Fury at L15.

## Testing
- `npm run typecheck` → passing
- `npm run test` → 2140/2140 passing (incl. the "every class has 20 levels" invariant)
- `npm run test:bdd` → default profile green (80 scenarios / 504 steps)

## Note
An out-of-scope observation: the Druid ASI cadence (L4/8/12/16/19) and remaining features were spot-checked against the 2024 PHB and look correct.

🤖 Generated with [Claude Code](https://claude.com/claude-code)