### PR TITLE
[5.5e] Wizard Illusionist Phantasmal Creatures: wire Summon Beast + Summon Fey (L6)

### DIFF
--- a/src/lib/sources/spells.ts
+++ b/src/lib/sources/spells.ts
@@ -1297,7 +1297,7 @@ export const SPELL_CATALOG = [
     // 2024 PHB: native to bard, sorcerer, warlock, wizard
     nativeClasses: ['bard', 'sorcerer', 'warlock', 'wizard'],
   },
-  // Fey Wanderer L9
+  // Fey Wanderer L9 / Illusionist Phantasmal Creatures (issue #213)
   {
     id: 'summon-fey',
     level: 3,
@@ -1310,6 +1310,24 @@ export const SPELL_CATALOG = [
     duration: 'Up to 1 hour',
     // 2024 PHB: native to druid, ranger, warlock, wizard
     nativeClasses: ['druid', 'ranger', 'warlock', 'wizard'],
+  },
+  // Illusionist Phantasmal Creatures (issue #213)
+  {
+    id: 'summon-beast',
+    level: 2,
+    school: 'conjuration',
+    ritual: false,
+    concentration: true,
+    castingTime: 'Action',
+    range: '90 feet',
+    components: {
+      verbal: true,
+      somatic: true,
+      material: 'a feather, tuft of fur, and fish tail inside a gilded acorn worth 200+ GP',
+    },
+    duration: 'Up to 1 hour',
+    // 2024 PHB: native to druid, ranger, wizard
+    nativeClasses: ['druid', 'ranger', 'wizard'],
   },
   // Gloom Stalker L13
   {

--- a/src/lib/sources/spells.ts
+++ b/src/lib/sources/spells.ts
@@ -1320,11 +1320,7 @@ export const SPELL_CATALOG = [
     concentration: true,
     castingTime: 'Action',
     range: '90 feet',
-    components: {
-      verbal: true,
-      somatic: true,
-      material: 'a feather, tuft of fur, and fish tail inside a gilded acorn worth 200+ GP',
-    },
+    components: { verbal: true, somatic: true, material: 'a gilded acorn worth 200+ GP' },
     duration: 'Up to 1 hour',
     // 2024 PHB: native to druid, ranger, wizard
     nativeClasses: ['druid', 'ranger', 'wizard'],

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -3326,15 +3326,21 @@ describe('getSubclassSource — Illusionist', () => {
     );
   });
 
-  it('illusionist level 6 grants 1 feature: phantasmal-creatures', () => {
+  it('illusionist level 6 grants phantasmal-creatures + Summon Beast/Fey always prepared (issue #213)', () => {
     const source = getSubclassSource('illusionist');
     const level6 = source?.features.find((f) => f.classLevel === 6);
     expect(level6).toBeDefined();
-    expect(level6?.grants).toHaveLength(1);
-    expect(level6?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'illusionist-phantasmal-creatures' },
-    });
+    expect(level6?.grants).toHaveLength(3);
+    expect(level6?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'illusionist-phantasmal-creatures' }),
+        }),
+        expect.objectContaining({ type: 'spell', spellId: 'summon-beast', alwaysPrepared: true }),
+        expect.objectContaining({ type: 'spell', spellId: 'summon-fey', alwaysPrepared: true }),
+      ])
+    );
   });
 
   it('illusionist level 10 grants 2 grants: illusory-self feature and illusory-self resource pool', () => {

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -1893,9 +1893,11 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 6,
         grants: [
-          // Phantasmal Creatures: 2024 PHB grants Summon Beast + Summon Fey with free casts (PB uses per long rest)
-          // TODO(#159-followup): wire summon-beast/summon-fey always-prepared once catalogued
+          // Phantasmal Creatures: 2024 PHB grants Summon Beast + Summon Fey always prepared (issue #213).
+          // The PB free-casts-per-long-rest pool is deferred (runtime/PB-max blocker, refs #159).
           { type: 'feature', feature: { id: 'illusionist-phantasmal-creatures' } },
+          { type: 'spell', spellId: 'summon-beast', alwaysPrepared: true },
+          { type: 'spell', spellId: 'summon-fey', alwaysPrepared: true },
         ],
       },
       {

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -2942,6 +2942,10 @@
       "name": "Summon Fey",
       "description": "You call forth a fey spirit. It manifests in an unoccupied space within range in a form you choose: Fuming, Mirthful, or Tricksy. The creature disappears when it drops to 0 Hit Points or when the spell ends. The summoned creature is friendly to you and your companions for the duration."
     },
+    "summon-beast": {
+      "name": "Summon Beast",
+      "description": "You call forth a bestial spirit. It manifests in an unoccupied space that you can see within range in a form you choose: Land, Sea, or Sky. The creature disappears when it drops to 0 Hit Points or when the spell ends. The creature is an ally to you and your companions. In combat, it shares your Initiative count but takes its turn immediately after yours."
+    },
     "greater-invisibility": {
       "name": "Greater Invisibility",
       "description": "A creature you touch has the Invisible condition until the spell ends. Unlike Invisibility, this spell doesn't end if the target attacks or casts a spell."


### PR DESCRIPTION
Closes #213

## Summary
Wires the 2024 PHB Illusionist **Phantasmal Creatures** (L6) feature, which grants **Summon Beast** + **Summon Fey** always prepared. `summon-fey` was already catalogued (Fey Wanderer); this adds the missing `summon-beast` (L2 conjuration) entry and grants both at Illusionist class level 6.

## What Changed
- `src/lib/sources/spells.ts` — added `summon-beast` (L2 conjuration; native to druid/ranger/wizard) to `SPELL_CATALOG`
- `src/locales/en/gamedata.json` — added `spells.summon-beast` name + description (satisfies catalog↔i18n parity test)
- `src/lib/sources/subclasses.ts` — added `{ type: 'spell', spellId: 'summon-beast'|'summon-fey', alwaysPrepared: true }` at Illusionist L6; removed the stale TODO
- `src/lib/sources/subclasses.test.ts` — updated the Illusionist L6 test to assert the 3 grants

## Scope / Deferred
The **PB free-casts-per-long-rest pool** stays deferred — it depends on the proficiency-bonus-max resource pool work (runtime mechanic, refs #159). Only the always-prepared build-time wiring is in scope here.

## Testing
- [x] `npm run typecheck` passing
- [x] `npm run lint` passing (`--max-warnings 0`)
- [x] `npm run test` — 2176 tests passing
- [x] `npm run coverage:matrix` — no structural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)