### PR TITLE
[5.5e] Extend ProficiencyChoiceGrant with 'saving-throw' category (Iron Mind multiclass edge)

### DIFF
--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -711,3 +711,70 @@ describe('ChoicePicker feat-choice — allowedFeats (disabled-book no-data-loss)
     expect(screen.queryByText('disabledSourceBook')).toBeNull();
   });
 });
+
+// ---------------------------------------------------------------------------
+// ChoicePicker — saving-throw-choice branch (issue #202)
+// ---------------------------------------------------------------------------
+
+const SAVE_SOURCE = { origin: 'subclass' as const, id: 'gloomstalker' as const, classId: 'ranger' as const, level: 7 };
+
+const SAVE_CHOICE: PendingChoice & { type: 'saving-throw-choice' } = {
+  type: 'saving-throw-choice',
+  choiceKey: 'saving-throw-choice:subclass:gloomstalker:0' as ChoiceKey,
+  source: SAVE_SOURCE,
+  category: 'saving-throw',
+  count: 1,
+  from: ['int', 'cha'],
+};
+
+describe('ChoicePicker saving-throw-choice', () => {
+  it('renders one checkbox per ability in the from pool', () => {
+    render(<ChoicePicker choice={SAVE_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />);
+    expect(screen.getAllByRole('checkbox')).toHaveLength(2);
+  });
+
+  it('falls back to all six abilities when from is null', () => {
+    render(
+      <ChoicePicker
+        choice={{ ...SAVE_CHOICE, from: null, count: 6 }}
+        currentDecision={undefined}
+        onDecide={vi.fn()}
+        onClear={vi.fn()}
+      />
+    );
+    expect(screen.getAllByRole('checkbox')).toHaveLength(6);
+  });
+
+  it('selecting an ability calls onDecide with the saving-throw-choice decision', () => {
+    const onDecide = vi.fn();
+    render(<ChoicePicker choice={SAVE_CHOICE} currentDecision={undefined} onDecide={onDecide} onClear={vi.fn()} />);
+    // Pool order is ['int','cha']; click the second (cha)
+    fireEvent.click(screen.getAllByRole('checkbox')[1]);
+    expect(onDecide).toHaveBeenCalledWith(SAVE_CHOICE.choiceKey, {
+      type: 'saving-throw-choice',
+      savingThrows: ['cha'],
+    });
+  });
+
+  it('disables unselected checkboxes once count is reached', () => {
+    const currentDecision: ChoiceDecision = { type: 'saving-throw-choice', savingThrows: ['int'] };
+    render(
+      <ChoicePicker choice={SAVE_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    const checkboxes = screen.getAllByRole('checkbox');
+    // int (index 0) selected; cha (index 1) disabled because count=1 is reached
+    expect(checkboxes[0]).toBeChecked();
+    expect(checkboxes[1]).toHaveAttribute('aria-disabled', 'true');
+  });
+
+  it('deselecting the last choice calls onClear', () => {
+    const onClear = vi.fn();
+    const currentDecision: ChoiceDecision = { type: 'saving-throw-choice', savingThrows: ['cha'] };
+    render(
+      <ChoicePicker choice={SAVE_CHOICE} currentDecision={currentDecision} onDecide={vi.fn()} onClear={onClear} />
+    );
+    // cha is index 1 and currently checked — unchecking it clears the decision
+    fireEvent.click(screen.getAllByRole('checkbox')[1]);
+    expect(onClear).toHaveBeenCalledWith(SAVE_CHOICE.choiceKey);
+  });
+});

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -6,6 +6,7 @@ import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
 import {
+  ABILITY_KEYS,
   DND_LANGUAGES,
   DND_SKILLS,
   type AbilityKey,
@@ -53,7 +54,7 @@ interface ChoicePickerProps {
 
 const ALL_SKILL_IDS: readonly SkillId[] = DND_SKILLS.map((s) => s.id);
 const ALL_LANGUAGE_IDS: readonly LanguageId[] = DND_LANGUAGES;
-const ALL_ABILITY_KEYS: readonly AbilityKey[] = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
+const ALL_ABILITY_KEYS: readonly AbilityKey[] = ABILITY_KEYS;
 
 function isSkillId(id: string): id is SkillId {
   return (ALL_SKILL_IDS as readonly string[]).includes(id);

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -5,7 +5,14 @@ import { Card, CardContent, CardTitle } from '@/components/ui/card';
 import { Checkbox } from '@/components/ui/checkbox';
 import { Label } from '@/components/ui/label';
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
-import { DND_LANGUAGES, DND_SKILLS, type LanguageId, type SkillId, type ToolProficiencyId } from '@/lib/dnd-helpers';
+import {
+  DND_LANGUAGES,
+  DND_SKILLS,
+  type AbilityKey,
+  type LanguageId,
+  type SkillId,
+  type ToolProficiencyId,
+} from '@/lib/dnd-helpers';
 import type { FeatId } from '@/lib/dnd-helpers';
 import { getItemDef, getItemNameKey, WEAPON_CATALOG } from '@/lib/sources/items';
 import { getBundleDef, getBundleNameKey, getItemsForSlot, resolveBundleRef } from '@/lib/sources/bundles';
@@ -46,9 +53,14 @@ interface ChoicePickerProps {
 
 const ALL_SKILL_IDS: readonly SkillId[] = DND_SKILLS.map((s) => s.id);
 const ALL_LANGUAGE_IDS: readonly LanguageId[] = DND_LANGUAGES;
+const ALL_ABILITY_KEYS: readonly AbilityKey[] = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
 
 function isSkillId(id: string): id is SkillId {
   return (ALL_SKILL_IDS as readonly string[]).includes(id);
+}
+
+function isAbilityKey(id: string): id is AbilityKey {
+  return (ALL_ABILITY_KEYS as readonly string[]).includes(id);
 }
 
 function isLanguageId(id: string): id is LanguageId {
@@ -106,6 +118,55 @@ export function ChoicePicker({
                 />
                 <Label htmlFor={`choice-skill-${choice.choiceKey}-${skillId}`} className="flex-1 cursor-pointer">
                   {t(`skills.${skillId}`)}
+                </Label>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    );
+  }
+
+  if (choice.type === 'saving-throw-choice') {
+    const rawPool = choice.from ?? ALL_ABILITY_KEYS;
+    const pool: readonly AbilityKey[] = rawPool.filter(isAbilityKey);
+    const current = currentDecision?.type === 'saving-throw-choice' ? currentDecision.savingThrows : [];
+    const atMax = current.length >= choice.count;
+
+    return (
+      <div className="space-y-2">
+        <div className="flex items-center gap-2">
+          <p className="text-sm text-muted-foreground">
+            {tc('characterBuilder.pendingChoices.savingThrowChoice', { count: choice.count })}
+          </p>
+          <Badge variant="outline" className="text-xs">
+            {current.length} / {choice.count}
+          </Badge>
+        </div>
+        <div className="space-y-1">
+          {pool.map((abilityKey) => {
+            const isSelected = current.includes(abilityKey);
+            const isDisabled = atMax && !isSelected;
+            return (
+              <div
+                key={abilityKey}
+                className="flex items-center gap-3 px-2 py-1.5 rounded-md transition-colors hover:bg-muted/50"
+              >
+                <Checkbox
+                  id={`choice-save-${choice.choiceKey}-${abilityKey}`}
+                  checked={isSelected}
+                  disabled={isDisabled}
+                  onCheckedChange={(checked) => {
+                    const next = checked ? [...current, abilityKey] : current.filter((a) => a !== abilityKey);
+                    if (next.length === 0) {
+                      onClear(choice.choiceKey);
+                    } else {
+                      onDecide(choice.choiceKey, { type: 'saving-throw-choice', savingThrows: next });
+                    }
+                  }}
+                />
+                <Label htmlFor={`choice-save-${choice.choiceKey}-${abilityKey}`} className="flex-1 cursor-pointer">
+                  {t(`abilities.${abilityKey}`)}
                 </Label>
               </div>
             );

--- a/src/lib/dnd-helpers.ts
+++ b/src/lib/dnd-helpers.ts
@@ -7,6 +7,9 @@ const logger = getLogger('dnd-helpers');
 export type { AbilityKey };
 export type AbilityName = AbilityKey;
 
+/** The six ability score keys, in canonical order. */
+export const ABILITY_KEYS = ['str', 'dex', 'con', 'int', 'wis', 'cha'] as const satisfies readonly AbilityKey[];
+
 export function getAbilityModifier(score: number): number {
   return Math.floor((score - 10) / 2);
 }
@@ -417,18 +420,7 @@ export const DND_SPECIES = [
     speed: 30,
     languages: ['common'],
     languageChoices: 2,
-    lineages: [
-      'black',
-      'blue',
-      'brass',
-      'bronze',
-      'copper',
-      'gold',
-      'green',
-      'red',
-      'silver',
-      'white',
-    ] as const,
+    lineages: ['black', 'blue', 'brass', 'bronze', 'copper', 'gold', 'green', 'red', 'silver', 'white'] as const,
   },
   {
     id: 'dwarf',

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -409,6 +409,46 @@ describe('Pending ASI and Subclass choices', () => {
   });
 });
 
+describe('Pending saving-throw-choice (issue #202)', () => {
+  const saveKey = createChoiceKey('saving-throw-choice', 'subclass', 'gloomstalker', 0);
+  const saveBundles: GrantBundle[] = [
+    {
+      source: { origin: 'subclass', id: 'gloomstalker', classId: 'ranger', level: 7 },
+      grants: [
+        {
+          type: 'proficiency-choice',
+          category: 'saving-throw',
+          key: saveKey,
+          count: 1,
+          from: ['int', 'cha'],
+        },
+      ],
+    },
+  ];
+
+  it('emits a pending saving-throw-choice with from pool and count when undecided', () => {
+    const result = resolveCharacter({ ...baseInput, bundles: saveBundles });
+    const pending = result.pendingChoices.find((c) => c.type === 'saving-throw-choice');
+    expect(pending).toBeDefined();
+    expect(pending?.choiceKey).toBe(saveKey);
+    if (pending?.type === 'saving-throw-choice') {
+      expect(pending.count).toBe(1);
+      expect(pending.from).toEqual(['int', 'cha']);
+    }
+  });
+
+  it('does not emit pending and applies the save once decided', () => {
+    const result = resolveCharacter({
+      ...baseInput,
+      bundles: saveBundles,
+      choices: { [saveKey]: { type: 'saving-throw-choice' as const, savingThrows: ['cha'] as AbilityKey[] } },
+    });
+    expect(result.pendingChoices.find((c) => c.type === 'saving-throw-choice')).toBeUndefined();
+    expect(result.savingThrows.cha.proficient).toBe(true);
+    expect(result.savingThrows.int.proficient).toBe(false);
+  });
+});
+
 describe('ASI from-constraint validation', () => {
   it('emits pending ASI with from pool when background soldier has no decision', () => {
     const soldierAsiKey = createChoiceKey('asi', 'background', 'soldier', 0);

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -64,7 +64,7 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
   const conModifier = abilities.con.modifier;
   const dexModifier = abilities.dex.modifier;
 
-  const savingThrows = resolveSavingThrows(abilities, bundles, proficiencyBonus);
+  const savingThrows = resolveSavingThrows(abilities, bundles, proficiencyBonus, choices);
   const skills = resolveSkills(abilities, bundles, proficiencyBonus, choices);
   const proficiencies = resolveProficiencies(bundles, choices);
   const features = resolveFeatures(bundles, abilities, proficiencyBonus);
@@ -142,6 +142,23 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
           choiceKey: grant.key,
           source,
           category: 'skill',
+          count: grant.count,
+          from: grant.from,
+        });
+      }
+    }
+  }
+
+  // Unresolved saving-throw-choice grants (e.g. the conditional Iron Mind INT/CHA branch)
+  for (const { grant, source } of collectGrantsByType(bundles, 'proficiency-choice')) {
+    if (grant.category === 'saving-throw') {
+      const decision = choices[grant.key];
+      if (!decision || decision.type !== 'saving-throw-choice') {
+        pendingChoices.push({
+          type: 'saving-throw-choice',
+          choiceKey: grant.key,
+          source,
+          category: 'saving-throw',
           count: grant.count,
           from: grant.from,
         });

--- a/src/lib/resolver/proficiencies.test.ts
+++ b/src/lib/resolver/proficiencies.test.ts
@@ -29,7 +29,7 @@ const POSITIVE_ABILITIES: Readonly<Record<string, ResolvedAbility>> = {
 
 describe('resolveSavingThrows', () => {
   it('all abilities not proficient with no bundles', () => {
-    const result = resolveSavingThrows(ZERO_ABILITIES, NO_BUNDLES, 2);
+    const result = resolveSavingThrows(ZERO_ABILITIES, NO_BUNDLES, 2, {});
     for (const key of ['str', 'dex', 'con', 'int', 'wis', 'cha'] as const) {
       expect(result[key].proficient).toBe(false);
       expect(result[key].bonus).toBe(0);
@@ -47,7 +47,7 @@ describe('resolveSavingThrows', () => {
         ],
       },
     ];
-    const result = resolveSavingThrows(ZERO_ABILITIES, bundles, 2);
+    const result = resolveSavingThrows(ZERO_ABILITIES, bundles, 2, {});
     expect(result.str.proficient).toBe(true);
     expect(result.str.bonus).toBe(2);
     expect(result.con.proficient).toBe(true);
@@ -63,7 +63,7 @@ describe('resolveSavingThrows', () => {
         grants: [{ type: 'proficiency', category: 'saving-throw', id: 'str' }],
       },
     ];
-    const result = resolveSavingThrows(POSITIVE_ABILITIES, bundles, 2);
+    const result = resolveSavingThrows(POSITIVE_ABILITIES, bundles, 2, {});
     // STR: modifier 3 + proficiencyBonus 2 = 5
     expect(result.str.bonus).toBe(5);
     // DEX: modifier 2, not proficient
@@ -78,13 +78,13 @@ describe('resolveSavingThrows', () => {
         grants: [{ type: 'proficiency', category: 'saving-throw', id: 'str' }],
       },
     ];
-    const result = resolveSavingThrows(ZERO_ABILITIES, bundles, 2);
+    const result = resolveSavingThrows(ZERO_ABILITIES, bundles, 2, {});
     expect(result.str.sources).toHaveLength(1);
     expect(result.str.sources[0]).toEqual(source);
   });
 
   it('non-proficient save breakdown has exactly one ability component', () => {
-    const result = resolveSavingThrows(POSITIVE_ABILITIES, NO_BUNDLES, 2);
+    const result = resolveSavingThrows(POSITIVE_ABILITIES, NO_BUNDLES, 2, {});
     // DEX mod = 2, not proficient
     expect(result.dex.breakdown).toHaveLength(1);
     expect(result.dex.breakdown[0]).toEqual({ type: 'ability', value: 2, label: 'dex' });
@@ -97,7 +97,7 @@ describe('resolveSavingThrows', () => {
         grants: [{ type: 'proficiency', category: 'saving-throw', id: 'str' }],
       },
     ];
-    const result = resolveSavingThrows(POSITIVE_ABILITIES, bundles, 2);
+    const result = resolveSavingThrows(POSITIVE_ABILITIES, bundles, 2, {});
     // STR mod = 3, proficiency = 2
     expect(result.str.breakdown).toHaveLength(2);
     expect(result.str.breakdown[0]).toEqual({ type: 'ability', value: 3, label: 'str' });
@@ -111,9 +111,84 @@ describe('resolveSavingThrows', () => {
         grants: [{ type: 'proficiency', category: 'saving-throw', id: 'str' }],
       },
     ];
-    const result = resolveSavingThrows(POSITIVE_ABILITIES, bundles, 2);
+    const result = resolveSavingThrows(POSITIVE_ABILITIES, bundles, 2, {});
     const sum = result.str.breakdown.reduce((acc, c) => acc + c.value, 0);
     expect(sum).toBe(result.str.bonus);
+  });
+
+  // ── saving-throw proficiency-choice (issue #202) ──────────────────────────
+  describe('saving-throw proficiency-choice', () => {
+    const SAVE_CHOICE_KEY = 'saving-throw-choice:subclass:gloomstalker:0' as ChoiceKey;
+    const SAVE_SOURCE = { origin: 'subclass', id: 'gloomstalker', classId: 'ranger', level: 7 } as const;
+    const saveChoiceBundles: GrantBundle[] = [
+      {
+        source: SAVE_SOURCE,
+        grants: [
+          {
+            type: 'proficiency-choice',
+            category: 'saving-throw',
+            key: SAVE_CHOICE_KEY,
+            count: 1,
+            from: ['int', 'cha'],
+          },
+        ],
+      },
+    ];
+    const withDecision = (decision: ChoiceDecision): Record<ChoiceKey, ChoiceDecision> => ({
+      [SAVE_CHOICE_KEY]: decision,
+    });
+
+    it('marks the chosen ability proficient once decided', () => {
+      const result = resolveSavingThrows(
+        POSITIVE_ABILITIES,
+        saveChoiceBundles,
+        2,
+        withDecision({ type: 'saving-throw-choice', savingThrows: ['cha'] })
+      );
+      expect(result.cha.proficient).toBe(true);
+      // CHA mod 1 + proficiency 2 = 3
+      expect(result.cha.bonus).toBe(3);
+      expect(result.int.proficient).toBe(false);
+    });
+
+    it('does not mark anything proficient when undecided', () => {
+      const result = resolveSavingThrows(POSITIVE_ABILITIES, saveChoiceBundles, 2, {});
+      expect(result.int.proficient).toBe(false);
+      expect(result.cha.proficient).toBe(false);
+    });
+
+    it('ignores a decision for an ability outside the from pool', () => {
+      // 'wis' is not in the from pool ['int','cha'] — must be filtered out
+      const result = resolveSavingThrows(
+        POSITIVE_ABILITIES,
+        saveChoiceBundles,
+        2,
+        withDecision({ type: 'saving-throw-choice', savingThrows: ['wis'] })
+      );
+      expect(result.wis.proficient).toBe(false);
+    });
+
+    it('respects count, only applying the first N chosen abilities', () => {
+      const result = resolveSavingThrows(
+        POSITIVE_ABILITIES,
+        saveChoiceBundles,
+        2,
+        withDecision({ type: 'saving-throw-choice', savingThrows: ['cha', 'int'] })
+      );
+      expect(result.cha.proficient).toBe(true);
+      // count is 1, so the second pick (int) is not applied
+      expect(result.int.proficient).toBe(false);
+    });
+
+    it('records the grant source on the chosen save', () => {
+      const result = resolveSavingThrows(
+        POSITIVE_ABILITIES,
+        saveChoiceBundles,
+        2,
+        withDecision({ type: 'saving-throw-choice', savingThrows: ['int'] })
+      );
+      expect(result.int.sources).toEqual([SAVE_SOURCE]);
+    });
   });
 });
 

--- a/src/lib/resolver/proficiencies.test.ts
+++ b/src/lib/resolver/proficiencies.test.ts
@@ -180,6 +180,19 @@ describe('resolveSavingThrows', () => {
       expect(result.int.proficient).toBe(false);
     });
 
+    it('filters out-of-pool picks before counting, so a valid pick is not wasted', () => {
+      // 'wis' is out of pool ['int','cha']; with filter-then-slice it is dropped before
+      // the count cap, so the valid 'cha' pick still lands (count=1).
+      const result = resolveSavingThrows(
+        POSITIVE_ABILITIES,
+        saveChoiceBundles,
+        2,
+        withDecision({ type: 'saving-throw-choice', savingThrows: ['wis', 'cha'] })
+      );
+      expect(result.cha.proficient).toBe(true);
+      expect(result.wis.proficient).toBe(false);
+    });
+
     it('records the grant source on the chosen save', () => {
       const result = resolveSavingThrows(
         POSITIVE_ABILITIES,

--- a/src/lib/resolver/proficiencies.ts
+++ b/src/lib/resolver/proficiencies.ts
@@ -53,14 +53,15 @@ export function resolveSavingThrows(
   }
 
   // Saving-throw proficiency-choice grants — apply the chosen abilities once decided.
-  // The `from` pool is enforced so a stale/invalid decision can't grant an off-list save.
+  // Filter to the `from` pool first, then cap at `count` (mirrors the expertise-choice
+  // handler) so a stale out-of-pool pick can't occupy and waste a count slot.
   for (const { grant, source } of collectGrantsByType(bundles, 'proficiency-choice')) {
     if (grant.category !== 'saving-throw') continue;
     const decision = choices[grant.key];
     if (decision?.type !== 'saving-throw-choice') continue;
     const pool = grant.from;
-    for (const ability of decision.savingThrows.slice(0, grant.count)) {
-      if (pool && !pool.includes(ability)) continue;
+    const picks = decision.savingThrows.filter((ability) => pool === null || pool.includes(ability));
+    for (const ability of picks.slice(0, grant.count)) {
       markProficient(ability, source);
     }
   }

--- a/src/lib/resolver/proficiencies.ts
+++ b/src/lib/resolver/proficiencies.ts
@@ -23,7 +23,8 @@ import { collectGrantsByType } from '@/lib/resolver/helpers';
 export function resolveSavingThrows(
   abilities: Readonly<Record<AbilityKey, ResolvedAbility>>,
   bundles: readonly GrantBundle[],
-  proficiencyBonus: number
+  proficiencyBonus: number,
+  choices: Readonly<Record<ChoiceKey, ChoiceDecision>>
 ): Readonly<
   Record<
     AbilityKey,
@@ -38,11 +39,29 @@ export function resolveSavingThrows(
   const keys: readonly AbilityKey[] = ['str', 'dex', 'con', 'int', 'wis', 'cha'];
 
   const proficientAbilities = new Map<AbilityKey, SourceTag[]>();
+  const markProficient = (ability: AbilityKey, source: SourceTag): void => {
+    const existing = proficientAbilities.get(ability) ?? [];
+    existing.push(source);
+    proficientAbilities.set(ability, existing);
+  };
+
+  // Flat saving-throw proficiency grants (e.g. class saves, Gloom Stalker Iron Mind WIS).
   for (const { grant, source } of collectGrantsByType(bundles, 'proficiency')) {
     if (grant.category === 'saving-throw') {
-      const existing = proficientAbilities.get(grant.id) ?? [];
-      existing.push(source);
-      proficientAbilities.set(grant.id, existing);
+      markProficient(grant.id, source);
+    }
+  }
+
+  // Saving-throw proficiency-choice grants — apply the chosen abilities once decided.
+  // The `from` pool is enforced so a stale/invalid decision can't grant an off-list save.
+  for (const { grant, source } of collectGrantsByType(bundles, 'proficiency-choice')) {
+    if (grant.category !== 'saving-throw') continue;
+    const decision = choices[grant.key];
+    if (decision?.type !== 'saving-throw-choice') continue;
+    const pool = grant.from;
+    for (const ability of decision.savingThrows.slice(0, grant.count)) {
+      if (pool && !pool.includes(ability)) continue;
+      markProficient(ability, source);
     }
   }
 
@@ -278,6 +297,9 @@ export function resolveProficiencies(
       }
       case 'skill':
         // Handled in resolveSkills()
+        break;
+      case 'saving-throw':
+        // Handled in resolveSavingThrows()
         break;
       case 'armor':
       case 'weapon':

--- a/src/lib/schemas/character-build.test.ts
+++ b/src/lib/schemas/character-build.test.ts
@@ -126,6 +126,21 @@ describe('ChoiceDecisionSchema', () => {
     });
   });
 
+  describe('saving-throw-choice', () => {
+    it('accepts valid saving-throw-choice', () => {
+      const result = ChoiceDecisionSchema.safeParse({
+        type: 'saving-throw-choice',
+        savingThrows: ['int', 'cha'],
+      });
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects missing savingThrows field', () => {
+      const result = ChoiceDecisionSchema.safeParse({ type: 'saving-throw-choice' });
+      expect(result.success).toBe(false);
+    });
+  });
+
   describe('tool-choice', () => {
     it('accepts valid tool-choice', () => {
       const result = ChoiceDecisionSchema.safeParse({

--- a/src/lib/schemas/character-build.ts
+++ b/src/lib/schemas/character-build.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
 import {
+  ABILITY_KEYS,
   DND_SKILLS,
   DND_TOOL_PROFICIENCIES,
   isFeatId,
@@ -33,7 +34,7 @@ export const ChoiceDecisionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('skill-choice'), skills: z.array(z.string()).readonly() }),
   z.object({ type: z.literal('tool-choice'), tools: z.array(z.string()).readonly() }),
   z.object({ type: z.literal('language-choice'), languages: z.array(z.string()).readonly() }),
-  z.object({ type: z.literal('saving-throw-choice'), savingThrows: z.array(z.string()).readonly() }),
+  z.object({ type: z.literal('saving-throw-choice'), savingThrows: z.array(z.enum(ABILITY_KEYS)).readonly() }),
   z.object({
     type: z.literal('expertise-choice'),
     skills: z.array(z.enum(SKILL_IDS)).readonly(),

--- a/src/lib/schemas/character-build.ts
+++ b/src/lib/schemas/character-build.ts
@@ -33,6 +33,7 @@ export const ChoiceDecisionSchema = z.discriminatedUnion('type', [
   z.object({ type: z.literal('skill-choice'), skills: z.array(z.string()).readonly() }),
   z.object({ type: z.literal('tool-choice'), tools: z.array(z.string()).readonly() }),
   z.object({ type: z.literal('language-choice'), languages: z.array(z.string()).readonly() }),
+  z.object({ type: z.literal('saving-throw-choice'), savingThrows: z.array(z.string()).readonly() }),
   z.object({
     type: z.literal('expertise-choice'),
     skills: z.array(z.enum(SKILL_IDS)).readonly(),

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -1110,8 +1110,12 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 7,
         grants: [
-          // Iron Mind (2024 PHB): grants Wisdom saving throw proficiency.
-          // 2024 Iron Mind grants flat Wisdom saving-throw proficiency.
+          // Iron Mind (2024 PHB): grants Wisdom saving throw proficiency. If you already have it
+          // (multiclass edge), you instead choose Intelligence or Charisma. The saving-throw
+          // proficiency-choice infra now exists (#202) to express that INT/CHA branch, but selecting
+          // it correctly is conditional on already having WIS proficiency from a prior source —
+          // conditional-grant support that doesn't exist yet (cf. #191). So single-class-correct
+          // flat WIS is applied here; the conditional branch awaits conditional-grant infra.
           { type: 'feature', feature: { id: 'gloomstalker-iron-mind' } },
           { type: 'proficiency', category: 'saving-throw', id: 'wis' },
         ],

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -153,6 +153,7 @@
       "title": "Choices Required",
       "skillChoice": "Choose {{count}} skill(s)",
       "languageChoice": "Choose {{count}} language(s)",
+      "savingThrowChoice": "Choose {{count}} saving throw(s)",
       "toolChoice": "Choose {{count}} tool",
       "toolChoice_other": "Choose {{count}} tools",
       "expertiseChoice": "Choose {{count}} expertise",

--- a/src/types/choices.ts
+++ b/src/types/choices.ts
@@ -27,6 +27,7 @@ const CHOICE_CATEGORIES = [
   'skill-choice',
   'tool-choice',
   'language-choice',
+  'saving-throw-choice',
   'ability-choice',
   'expertise-choice',
   'asi',
@@ -88,6 +89,7 @@ export type ChoiceDecision =
   | { readonly type: 'skill-choice'; readonly skills: readonly SkillId[] }
   | { readonly type: 'tool-choice'; readonly tools: readonly ToolProficiencyId[] }
   | { readonly type: 'language-choice'; readonly languages: readonly LanguageId[] }
+  | { readonly type: 'saving-throw-choice'; readonly savingThrows: readonly AbilityKey[] }
   | {
       readonly type: 'expertise-choice';
       readonly skills: readonly SkillId[];

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -114,6 +114,13 @@ export type ProficiencyChoiceGrant =
       readonly key: ChoiceKey;
       readonly count: number;
       readonly from: readonly LanguageId[] | null;
+    }
+  | {
+      readonly type: 'proficiency-choice';
+      readonly category: 'saving-throw';
+      readonly key: ChoiceKey;
+      readonly count: number;
+      readonly from: readonly AbilityKey[] | null;
     };
 
 export interface SkillExpertiseGrant {

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -155,6 +155,14 @@ export type PendingChoice =
       readonly from: readonly LanguageId[] | null;
     }
   | {
+      readonly type: 'saving-throw-choice';
+      readonly choiceKey: ChoiceKey;
+      readonly source: SourceTag;
+      readonly category: 'saving-throw';
+      readonly count: number;
+      readonly from: readonly AbilityKey[] | null;
+    }
+  | {
       readonly type: 'expertise-choice';
       readonly choiceKey: ChoiceKey;
       readonly source: SourceTag;


### PR DESCRIPTION
Closes #202

## Summary
Adds a `saving-throw` proficiency-choice capability so a character can be granted a *choice* of saving-throw proficiency (not just a flat one). Built across the five seams the issue calls for, plus resolver wiring to apply/pend the choice.

## What Changed (5 seams + resolver)
- **Grant type** — `src/types/grants.ts`: new `saving-throw` arm on `ProficiencyChoiceGrant` (`from: AbilityKey[] | null`)
- **PendingChoice** — `src/types/resolved.ts`: `saving-throw-choice` variant
- **Decision type** — `src/types/choices.ts`: `saving-throw-choice` category + `{ savingThrows: AbilityKey[] }` decision
- **Zod schema** — `src/lib/schemas/character-build.ts`: matching arm (enforced by the existing compile-time parity assertion)
- **ChoicePicker** — `src/components/character-builder/ChoicePicker.tsx`: render branch (mirrors skill-choice) + `savingThrowChoice` i18n key
- **Resolver** — `src/lib/resolver/proficiencies.ts` `resolveSavingThrows` now takes `choices` and applies a decided `saving-throw-choice` (filtered to the grant's `from` pool and `count`); `src/lib/resolver/index.ts` emits the pending choice when undecided

## Scope / honesty note
Gloom Stalker **Iron Mind** keeps its single-class-correct **flat WIS** save grant. The 2024 multiclass edge ("INT or CHA *if you already have WIS*") is genuinely conditional on prior proficiency — conditional-grant support that doesn't exist yet (cf. #191). Wiring an unconditional saving-throw-choice there would wrongly give *every* Gloom Stalker a bonus save, so the conditional branch is documented in-code as awaiting that infra. This PR ships the capability the issue specifies; the conditional wiring follows when conditional grants land.

## Testing
- [x] `npm run typecheck` passing
- [x] `npm run lint` passing (`--max-warnings 0`)
- [x] `npm run test` — 2183 tests passing (added resolver + Zod tests for the new variant)
- [x] `npm run coverage:matrix` — no structural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)