### PR TITLE
[5.5e] Conditional speeds: Circle of the Sea Stormborn fly speed (non-enclosed only)

### DIFF
--- a/src/lib/resolver/combat.test.ts
+++ b/src/lib/resolver/combat.test.ts
@@ -259,6 +259,31 @@ describe('resolveSpeed', () => {
     const result = resolveSpeed(bundles);
     expect(result.swim!.sources).toEqual([{ origin: 'subclass', id: 'circlesea', classId: 'druid', level: 6 }]);
   });
+
+  // ── Conditional speeds (issue #191) ────────────────────────────────────────
+  it('carries a speed grant condition through to the resolved speed (Stormborn fly)', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'subclass', id: 'circlesea', classId: 'druid', level: 10 },
+        grants: [{ type: 'speed', mode: 'fly', value: 30, condition: 'not-enclosed' }],
+      },
+    ];
+    const result = resolveSpeed(bundles);
+    expect(result.fly!.value).toBe(30);
+    expect(result.fly!.condition).toBe('not-enclosed');
+  });
+
+  it('omits condition on an unconditional speed', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'species', id: 'human' },
+        grants: [{ type: 'speed', mode: 'walk', value: 30 }],
+      },
+    ];
+    const result = resolveSpeed(bundles);
+    expect(result.walk!.value).toBe(30);
+    expect(result.walk!.condition).toBeUndefined();
+  });
 });
 
 describe('resolveAc', () => {

--- a/src/lib/resolver/combat.test.ts
+++ b/src/lib/resolver/combat.test.ts
@@ -284,6 +284,22 @@ describe('resolveSpeed', () => {
     expect(result.walk!.value).toBe(30);
     expect(result.walk!.condition).toBeUndefined();
   });
+
+  it('condition travels with the winning value when a higher conditional grant replaces a lower one', () => {
+    const bundles: GrantBundle[] = [
+      {
+        source: { origin: 'species', id: 'human' },
+        grants: [{ type: 'speed', mode: 'fly', value: 25 }],
+      },
+      {
+        source: { origin: 'subclass', id: 'circlesea', classId: 'druid', level: 10 },
+        grants: [{ type: 'speed', mode: 'fly', value: 30, condition: 'not-enclosed' }],
+      },
+    ];
+    const result = resolveSpeed(bundles);
+    expect(result.fly!.value).toBe(30);
+    expect(result.fly!.condition).toBe('not-enclosed');
+  });
 });
 
 describe('resolveAc', () => {

--- a/src/lib/resolver/combat.ts
+++ b/src/lib/resolver/combat.ts
@@ -65,6 +65,8 @@ export function resolveSpeed(bundles: readonly GrantBundle[]): Readonly<Partial<
     } else if (grant.value > existing.value) {
       bestPerMode.set(grant.mode, { value: grant.value, sources: [source], condition: grant.condition });
     } else if (grant.value === existing.value) {
+      // Condition is not reconciled on a value tie (first-seen wins) — fine while
+      // Stormborn is the only conditional speed and no two fly grants tie.
       existing.sources.push(source);
     }
   }

--- a/src/lib/resolver/combat.ts
+++ b/src/lib/resolver/combat.ts
@@ -1,6 +1,6 @@
-import type { SpeedMode } from '@/types/grants';
+import type { SpeedMode, SpeedCondition } from '@/types/grants';
 import type { GrantBundle, SourceTag } from '@/types/sources';
-import type { ResolvedArmorClass, Sourced } from '@/types/resolved';
+import type { ResolvedArmorClass, ResolvedSpeed } from '@/types/resolved';
 import { collectGrantsByType } from '@/lib/resolver/helpers';
 
 export function resolveHp(
@@ -39,13 +39,14 @@ export function resolveHp(
   return { max };
 }
 
-export function resolveSpeed(bundles: readonly GrantBundle[]): Readonly<Partial<Record<SpeedMode, Sourced<number>>>> {
+export function resolveSpeed(bundles: readonly GrantBundle[]): Readonly<Partial<Record<SpeedMode, ResolvedSpeed>>> {
   const speedGrants = collectGrantsByType(bundles, 'speed');
 
   // First pass: resolve all fixed-value grants, taking the highest per mode.
   // 'walk-equivalent' grants are deferred to a second pass once the walk
-  // speed is known.
-  const bestPerMode = new Map<SpeedMode, { value: number; sources: SourceTag[] }>();
+  // speed is known. The winning grant's optional `condition` (e.g. Stormborn's
+  // not-enclosed fly) is carried through for display; it is never evaluated.
+  const bestPerMode = new Map<SpeedMode, { value: number; sources: SourceTag[]; condition?: SpeedCondition }>();
   const walkEquivalent = new Map<SpeedMode, SourceTag[]>();
 
   for (const { grant, source } of speedGrants) {
@@ -60,9 +61,9 @@ export function resolveSpeed(bundles: readonly GrantBundle[]): Readonly<Partial<
     }
     const existing = bestPerMode.get(grant.mode);
     if (!existing) {
-      bestPerMode.set(grant.mode, { value: grant.value, sources: [source] });
+      bestPerMode.set(grant.mode, { value: grant.value, sources: [source], condition: grant.condition });
     } else if (grant.value > existing.value) {
-      bestPerMode.set(grant.mode, { value: grant.value, sources: [source] });
+      bestPerMode.set(grant.mode, { value: grant.value, sources: [source], condition: grant.condition });
     } else if (grant.value === existing.value) {
       existing.sources.push(source);
     }
@@ -86,9 +87,9 @@ export function resolveSpeed(bundles: readonly GrantBundle[]): Readonly<Partial<
     }
   }
 
-  const result: Partial<Record<SpeedMode, Sourced<number>>> = {};
-  for (const [mode, { value, sources }] of bestPerMode) {
-    result[mode] = { value, sources };
+  const result: Partial<Record<SpeedMode, ResolvedSpeed>> = {};
+  for (const [mode, { value, sources, condition }] of bestPerMode) {
+    result[mode] = condition ? { value, sources, condition } : { value, sources };
   }
   return result;
 }

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -1038,15 +1038,17 @@ describe('getSubclassSource — Circle of the Sea', () => {
     );
   });
 
-  it('circlesea level 10 grants stormborn feature', () => {
+  it('circlesea level 10 grants stormborn feature + condition-tagged fly speed (issue #191)', () => {
     const source = getSubclassSource('circlesea');
     const level10 = source?.features.find((f) => f.classLevel === 10);
     expect(level10).toBeDefined();
-    expect(level10?.grants).toHaveLength(1);
-    expect(level10?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'circlesea-stormborn' },
-    });
+    expect(level10?.grants).toHaveLength(2);
+    expect(level10?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ type: 'feature', feature: expect.objectContaining({ id: 'circlesea-stormborn' }) }),
+        expect.objectContaining({ type: 'speed', mode: 'fly', value: 30, condition: 'not-enclosed' }),
+      ])
+    );
   });
 });
 

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -501,8 +501,11 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 10,
         grants: [
-          // Fly speed 30 ft while in a non-enclosed space; conditional speed not supported — inert feature grant
+          // Stormborn: Fly speed 30 ft while not in an enclosed space (2024 PHB). Modeled as a
+          // condition-tagged speed grant (descriptive, not runtime-evaluated) plus the feature
+          // grant for the full description — mirrors the L6 Aquatic Affinity speed+feature pairing.
           { type: 'feature', feature: { id: 'circlesea-stormborn' } },
+          { type: 'speed', mode: 'fly', value: 30, condition: 'not-enclosed' },
         ],
       },
     ] satisfies readonly SubclassFeature[],

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -439,6 +439,9 @@
       "hitPoints": "HIT POINTS",
       "proficiencyBonus": "Proficiency Bonus",
       "speed": "Speed",
+      "speedConditions": {
+        "not-enclosed": "while not in an enclosed space"
+      },
       "source": "Source: {{source}}",
       "maxHp": "Max HP",
       "currentHp": "Current HP",

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1393,7 +1393,7 @@
     },
     "circlesea-stormborn": {
       "name": "Stormborn",
-      "description": "You gain a Fly speed of 30 feet while you are not in a confined space. (Conditional fly speed is modeled as a descriptive feature pending conditional speed support.)"
+      "description": "You gain a Fly speed of 30 feet while you are not in an enclosed space, such as a cave or a building."
     },
     "circlestars-star-map": {
       "name": "Star Map",

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -143,12 +143,23 @@ export interface FeatureGrant {
 
 export type SpeedMode = 'walk' | 'fly' | 'swim' | 'climb' | 'burrow';
 
+/**
+ * Environment condition that gates a speed (descriptive, not runtime-evaluated).
+ * The label is carried through to the resolved speed so the UI can show e.g.
+ * "Fly 30 ft (while not in an enclosed space)" without modeling enclosed-space detection.
+ * - `'not-enclosed'`: Circle of the Sea L10 Stormborn fly speed.
+ */
+export type SpeedCondition = 'not-enclosed';
+
 export interface SpeedGrant {
   readonly type: 'speed';
   readonly mode: SpeedMode;
   // `'walk-equivalent'` resolves to the character's resolved walking speed
   // (e.g. Circle of the Sea L6 Aquatic Affinity). Only meaningful on non-walk modes.
   readonly value: number | 'walk-equivalent';
+  // Optional descriptive gating condition (e.g. Stormborn fly only when not enclosed).
+  // Carried through to the resolved speed for display; never evaluated at runtime.
+  readonly condition?: SpeedCondition;
 }
 
 export type HitDie = 4 | 6 | 8 | 10 | 12;

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -9,7 +9,7 @@ import type {
   ClassId,
   FeatId,
 } from '@/lib/dnd-helpers';
-import type { FeatureDef, DamageTypeId, HitDie, SpeedMode, ResourcePoolRegen } from '@/types/grants';
+import type { FeatureDef, DamageTypeId, HitDie, SpeedMode, SpeedCondition, ResourcePoolRegen } from '@/types/grants';
 import type { SourceTag, FeatCategory } from '@/types/sources';
 import type { ChoiceKey } from '@/types/choices';
 import type {
@@ -27,6 +27,13 @@ export interface Sourced<T> {
   readonly value: T;
   readonly sources: readonly SourceTag[];
 }
+
+/**
+ * A resolved speed for one mode. Carries an optional descriptive `condition`
+ * (e.g. Stormborn fly only when not enclosed) for display; the condition is
+ * never evaluated — the value is always present.
+ */
+export type ResolvedSpeed = Sourced<number> & { readonly condition?: SpeedCondition };
 
 export interface ResolvedAbility {
   readonly base: number;
@@ -245,7 +252,7 @@ export interface ResolvedCharacter {
   readonly abilities: Readonly<Record<AbilityKey, ResolvedAbility>>;
   readonly hitDie: readonly { readonly die: HitDie; readonly count: number }[];
   readonly hitPoints: { readonly max: number };
-  readonly speed: Readonly<Partial<Record<SpeedMode, Sourced<number>>>>;
+  readonly speed: Readonly<Partial<Record<SpeedMode, ResolvedSpeed>>>;
   readonly initiative: number;
   readonly proficiencyBonus: number;
   readonly armorClass: ResolvedArmorClass;


### PR DESCRIPTION
Closes #191

## Summary
Models the Circle of the Sea L10 **Stormborn** fly speed (30 ft, only when not in an enclosed space) as a **condition-tagged SpeedGrant** instead of an inert feature grant. The condition is **descriptive only** — carried through to the resolved speed for display, never evaluated at runtime (no enclosed-space detection), exactly the interim the issue permits.

## What Changed
- `src/types/grants.ts` — new `SpeedCondition` type (`'not-enclosed'`) + optional `condition?` on `SpeedGrant`
- `src/types/resolved.ts` — new `ResolvedSpeed = Sourced<number> & { condition? }`; `ResolvedCharacter.speed` uses it (`.walk` consumers unchanged — `condition` is optional)
- `src/lib/resolver/combat.ts` — `resolveSpeed` carries the winning grant's `condition` onto the resolved speed
- `src/lib/sources/subclasses.ts` — Stormborn L10 now emits `{ type: 'speed', mode: 'fly', value: 30, condition: 'not-enclosed' }` alongside the feature grant (mirrors the L6 Aquatic Affinity speed+feature pattern)
- `src/locales/en/common.json` — `characterSheet.fields.speedConditions['not-enclosed']` label
- `src/locales/en/gamedata.json` — trimmed the now-stale "pending conditional speed support" parenthetical from the Stormborn description

## Scope
No runtime condition **evaluation** (that would be the deferred enclosed-space-detection work). No speed-display UI exists yet; nothing consumes `speed.fly` today (PDF + sheet read `speed.walk` only), so emitting a conditional fly is safe and the data is ready for a future speed display.

## Testing
- [x] `npm run typecheck` passing
- [x] `npm run lint` passing (`--max-warnings 0`)
- [x] `npm run test` — 2193 tests passing (added combat resolveSpeed condition tests + updated Stormborn L10 grant test)
- [x] `npm run coverage:matrix` — no structural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)