### PR TITLE
[5.5e] Paladin Aura of Warding: correct to Necrotic/Psychic/Radiant resistance

### DIFF
--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -2970,6 +2970,18 @@ describe('Paladin oath spells integration — L9 Oath of the Ancients', () => {
     expect(alwaysPrepared).toContain('protection-from-energy');
   });
 
+  it('L7 Aura of Warding surfaces Necrotic/Psychic/Radiant resistance end-to-end (issue #195)', () => {
+    const { bundles } = collectBundles(baseBuild);
+    const result = resolveCharacter({
+      baseAbilities: baseBuild.baseAbilities,
+      level: 9,
+      bundles,
+      choices: baseBuild.choices,
+    });
+    const resistances = result.resistances.map((r) => r.value);
+    expect(resistances).toEqual(expect.arrayContaining(['necrotic', 'psychic', 'radiant']));
+  });
+
   it('L13 oath spells (ice-storm, stoneskin) are NOT in alwaysPreparedSpells at Paladin L9', () => {
     const { bundles } = collectBundles(baseBuild);
     const result = resolveCharacter({

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -1642,15 +1642,31 @@ describe('getSubclassSource — Oath of the Ancients', () => {
     );
   });
 
-  it('oathofancients level 7 grants aura-of-warding feature', () => {
+  it('oathofancients level 7 grants aura-of-warding + Necrotic/Psychic/Radiant resistance (2024, issue #195)', () => {
     const source = getSubclassSource('oathofancients');
     const level7 = source?.features.find((f) => f.classLevel === 7);
     expect(level7).toBeDefined();
-    expect(level7?.grants).toHaveLength(1);
-    expect(level7?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'oathofancients-aura-of-warding' },
-    });
+    expect(level7?.grants).toHaveLength(4);
+    expect(level7?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'oathofancients-aura-of-warding' }),
+        }),
+        expect.objectContaining({ type: 'resistance', damageType: 'necrotic' }),
+        expect.objectContaining({ type: 'resistance', damageType: 'psychic' }),
+        expect.objectContaining({ type: 'resistance', damageType: 'radiant' }),
+      ])
+    );
+  });
+
+  it('oathofancients aura-of-warding no longer models 2014 "damage from spells"', () => {
+    const source = getSubclassSource('oathofancients');
+    const level7 = source?.features.find((f) => f.classLevel === 7);
+    // 2024 PHB grants typed resistance, not source-conditional "spells" resistance.
+    const damageTypes = level7?.grants.filter((g) => g.type === 'resistance').map((g) => g.damageType);
+    expect(damageTypes).toEqual(expect.arrayContaining(['necrotic', 'psychic', 'radiant']));
+    expect(damageTypes).toHaveLength(3);
   });
 
   it('oathofancients level 9 grants 2 spell grants with alwaysPrepared:true', () => {

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -895,9 +895,15 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 7,
         grants: [
-          // Aura of Warding: you and allies within 10 ft have resistance to damage from spells; expands at L18
-          // Modeled as feature grant — source-conditional resistance (spells only) doesn't map to existing resistance grant
+          // Aura of Warding (2024 PHB): you and allies within 10 ft have Resistance to Necrotic,
+          // Psychic, and Radiant damage (while you are not Incapacitated). The 2024 rule is typed
+          // (not the 2014 "damage from spells"), so it maps to plain typed resistance grants — the
+          // paladin is always inside their own aura. The aura-to-allies + range expansion at L18 is
+          // descriptive (carried in the feature text) and out of scope here.
           { type: 'feature', feature: { id: 'oathofancients-aura-of-warding' } },
+          { type: 'resistance', damageType: 'necrotic' },
+          { type: 'resistance', damageType: 'psychic' },
+          { type: 'resistance', damageType: 'radiant' },
         ],
       },
       {

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -1573,7 +1573,7 @@
     },
     "oathofancients-aura-of-warding": {
       "name": "Aura of Warding",
-      "description": "Ancient magic lies so heavily upon you that it forms an aura. You and friendly creatures within 10 feet of you have resistance to damage from spells while you are conscious. At level 18, the range of this aura increases to 30 feet."
+      "description": "Ancient magic lies so heavily upon you that it forms an aura. While you aren't Incapacitated, you and your allies within 10 feet of you have Resistance to Necrotic, Psychic, and Radiant damage. At level 18, the range of this aura increases to 30 feet."
     },
     "oathofvengeance-vow-of-enmity": {
       "name": "Vow of Enmity",


### PR DESCRIPTION
Closes #195

## Summary
Oath of the Ancients L7 **Aura of Warding** was an inert feature grant whose comment described the **2014** rule ("resistance to damage from spells"). The **2024 PHB** changed it to **typed** resistance — Necrotic, Psychic, and Radiant — which maps cleanly to the existing typed `ResistanceGrant`. This emits the three resistances and corrects the description.

## What Changed
- `src/lib/sources/subclasses.ts` — Oath of the Ancients L7 now grants `{ type: 'resistance', damageType: 'necrotic' | 'psychic' | 'radiant' }` alongside the feature grant; replaced the obsolete 2014 comment
- `src/locales/en/gamedata.json` — corrected the Aura of Warding description to the 2024 typed resistance ("While you aren't Incapacitated, you and your allies within 10 feet have Resistance to Necrotic, Psychic, and Radiant damage")

## Design note
No new grant type is needed: a typed `ResistanceGrant` already exists (e.g. tiefling fire resistance) and resolves into `resolved.resistances`. The paladin is always inside their own aura, so plain personal resistance grants model the truth — exactly the tiefling precedent. The aura-to-allies, the L18 range expansion, and the while-not-Incapacitated gating are descriptive (carried in the feature text) and out of scope; they belong with the deferred aura-geometry work.

## Testing
- [x] `npm run typecheck` passing
- [x] `npm run lint` passing (`--max-warnings 0`)
- [x] `npm run test` — 2195 tests passing (updated Oath of Ancients L7 grant test + added a 2024-typed-resistance assertion)
- [x] `npm run coverage:matrix` — no structural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)