### PR TITLE
[5.5e] Level-gate Circle of the Land circle spells by druid level (L3/5/7/9)

### DIFF
--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -2758,110 +2758,132 @@ describe('Circle of the Land terrain feature-choice integration', () => {
     }
   });
 
-  it('arid terrain: resolves leveled spells into alwaysPreparedSpells and cantrip into cantrips', () => {
+  // Per-terrain spell tiers (2024 PHB). The cantrip and the L1–2 spells (`tier3`) are available the
+  // moment Circle of the Land is chosen (druid 3); the L3/L4/L5 spells unlock at druid 5/7/9 (#189).
+  const TERRAINS = [
+    {
+      optionId: 'arid',
+      cantrip: 'fire-bolt',
+      tier3: ['burning-hands', 'blur'],
+      l5: 'fireball',
+      l7: 'blight',
+      l9: 'wall-of-stone',
+    },
+    {
+      optionId: 'polar',
+      cantrip: 'ray-of-frost',
+      tier3: ['fog-cloud', 'hold-person'],
+      l5: 'sleet-storm',
+      l7: 'ice-storm',
+      l9: 'cone-of-cold',
+    },
+    {
+      optionId: 'temperate',
+      cantrip: 'shocking-grasp',
+      tier3: ['sleep', 'misty-step'],
+      l5: 'lightning-bolt',
+      l7: 'freedom-of-movement',
+      l9: 'tree-stride',
+    },
+    {
+      optionId: 'tropical',
+      cantrip: 'acid-splash',
+      tier3: ['ray-of-sickness', 'web'],
+      l5: 'stinking-cloud',
+      l7: 'polymorph',
+      l9: 'insect-plague',
+    },
+  ] as const;
+
+  const resolveDruidAtLevel = (optionId: string, druidLevel: number) => {
+    const levels = Array.from({ length: druidLevel }, (_, i) => ({
+      classId: 'druid' as ClassId,
+      classLevel: i + 1,
+      hpRoll: null,
+    }));
     const build: CharacterBuild = {
       ...baseBuild,
+      levels,
+      choices: {
+        ...baseBuild.choices,
+        [terrainChoiceKey]: { type: 'feature-choice' as const, optionId },
+      },
+    };
+    const { bundles, warnings } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: druidLevel,
+      bundles,
+      choices: build.choices,
+    });
+    return { result, warnings };
+  };
+
+  it.each(TERRAINS)(
+    '$optionId terrain at druid 3: cantrip + L1–2 spells only, higher tiers gated (issue #189)',
+    ({ optionId, cantrip, tier3, l5, l7, l9 }) => {
+      const { result, warnings } = resolveDruidAtLevel(optionId, 3);
+      // The subclass-origin feature-choice must NOT produce an "invisible choice" warning
+      expect(warnings).toEqual([]);
+      expect(result.spellcasting).not.toBeNull();
+      const alwaysPrepared = result.spellcasting!.alwaysPreparedSpells;
+      for (const spellId of tier3) {
+        expect(alwaysPrepared, `${optionId} L1–2 spell ${spellId} @ druid 3`).toContain(spellId);
+      }
+      // Higher tiers are gated until druid 5/7/9
+      expect(alwaysPrepared, `${optionId} ${l5} gated @ druid 3`).not.toContain(l5);
+      expect(alwaysPrepared, `${optionId} ${l7} gated @ druid 3`).not.toContain(l7);
+      expect(alwaysPrepared, `${optionId} ${l9} gated @ druid 3`).not.toContain(l9);
+      // Cantrip routes to cantrips[], not alwaysPreparedSpells
+      expect(alwaysPrepared).not.toContain(cantrip);
+      expect(result.spellcasting!.cantrips).toContain(cantrip);
+    }
+  );
+
+  it.each(TERRAINS)(
+    '$optionId terrain unlocks the L3/L4/L5 spell progressively at druid 5/7/9 (issue #189)',
+    ({ optionId, tier3, l5, l7, l9 }) => {
+      // druid 5: the L3 spell unlocks; L4/L5 still gated
+      const at5 = resolveDruidAtLevel(optionId, 5).result.spellcasting!.alwaysPreparedSpells;
+      for (const s of tier3) expect(at5).toContain(s);
+      expect(at5).toContain(l5);
+      expect(at5).not.toContain(l7);
+      expect(at5).not.toContain(l9);
+      // druid 7: the L4 spell unlocks; L5 still gated
+      const at7 = resolveDruidAtLevel(optionId, 7).result.spellcasting!.alwaysPreparedSpells;
+      expect(at7).toContain(l5);
+      expect(at7).toContain(l7);
+      expect(at7).not.toContain(l9);
+      // druid 9: everything unlocked
+      const at9 = resolveDruidAtLevel(optionId, 9).result.spellcasting!.alwaysPreparedSpells;
+      expect(at9).toContain(l5);
+      expect(at9).toContain(l7);
+      expect(at9).toContain(l9);
+    }
+  );
+
+  it('gates on druid level, not total character level (multiclass druid 5 / wizard 3)', () => {
+    const levels = [
+      ...Array.from({ length: 5 }, (_, i) => ({ classId: 'druid' as ClassId, classLevel: i + 1, hpRoll: null })),
+      ...Array.from({ length: 3 }, (_, i) => ({ classId: 'wizard' as ClassId, classLevel: i + 1, hpRoll: null })),
+    ];
+    const build: CharacterBuild = {
+      ...baseBuild,
+      levels,
       choices: {
         ...baseBuild.choices,
         [terrainChoiceKey]: { type: 'feature-choice' as const, optionId: 'arid' },
       },
     };
-    const { bundles, warnings } = collectBundles(build);
-    // The subclass-origin feature-choice must NOT produce an "invisible choice" warning
-    expect(warnings).toEqual([]);
-    const result = resolveCharacter({
-      baseAbilities: build.baseAbilities,
-      level: 3,
-      bundles,
-      choices: build.choices,
-    });
-    expect(result.spellcasting).not.toBeNull();
-    const alwaysPrepared = result.spellcasting!.alwaysPreparedSpells;
-    expect(alwaysPrepared).toContain('burning-hands');
-    expect(alwaysPrepared).toContain('blur');
-    expect(alwaysPrepared).toContain('fireball');
-    expect(alwaysPrepared).toContain('blight');
-    expect(alwaysPrepared).toContain('wall-of-stone');
-    // Cantrip routes to cantrips[], not alwaysPreparedSpells
-    expect(alwaysPrepared).not.toContain('fire-bolt');
-    expect(result.spellcasting!.cantrips).toContain('fire-bolt');
-  });
-
-  it('polar terrain: resolves leveled spells into alwaysPreparedSpells', () => {
-    const build: CharacterBuild = {
-      ...baseBuild,
-      choices: {
-        ...baseBuild.choices,
-        [terrainChoiceKey]: { type: 'feature-choice' as const, optionId: 'polar' },
-      },
-    };
     const { bundles } = collectBundles(build);
-    const result = resolveCharacter({
-      baseAbilities: build.baseAbilities,
-      level: 3,
-      bundles,
-      choices: build.choices,
-    });
-    expect(result.spellcasting).not.toBeNull();
+    const result = resolveCharacter({ baseAbilities: build.baseAbilities, level: 8, bundles, choices: build.choices });
     const alwaysPrepared = result.spellcasting!.alwaysPreparedSpells;
-    expect(alwaysPrepared).toContain('fog-cloud');
-    expect(alwaysPrepared).toContain('hold-person');
-    expect(alwaysPrepared).toContain('sleet-storm');
-    expect(alwaysPrepared).toContain('ice-storm');
-    expect(alwaysPrepared).toContain('cone-of-cold');
-    expect(alwaysPrepared).not.toContain('ray-of-frost');
-    expect(result.spellcasting!.cantrips).toContain('ray-of-frost');
+    // Druid is only level 5, so the L3-tier (fireball) unlocks but the L4/L5 tiers do NOT —
+    // even though the total character level is 8. Gating is on the druid level, not total level.
+    expect(alwaysPrepared).toContain('fireball');
+    expect(alwaysPrepared).not.toContain('blight');
+    expect(alwaysPrepared).not.toContain('wall-of-stone');
   });
-
-  it.each([
-    {
-      optionId: 'arid',
-      cantrip: 'fire-bolt',
-      leveledSpells: ['burning-hands', 'blur', 'fireball', 'blight', 'wall-of-stone'],
-    },
-    {
-      optionId: 'polar',
-      cantrip: 'ray-of-frost',
-      leveledSpells: ['fog-cloud', 'hold-person', 'sleet-storm', 'ice-storm', 'cone-of-cold'],
-    },
-    {
-      optionId: 'temperate',
-      cantrip: 'shocking-grasp',
-      leveledSpells: ['sleep', 'misty-step', 'lightning-bolt', 'freedom-of-movement', 'tree-stride'],
-    },
-    {
-      optionId: 'tropical',
-      cantrip: 'acid-splash',
-      leveledSpells: ['ray-of-sickness', 'web', 'stinking-cloud', 'polymorph', 'insect-plague'],
-    },
-  ])(
-    '$optionId terrain: cantrip in cantrips[], leveled spells in alwaysPreparedSpells',
-    ({ optionId, cantrip, leveledSpells }) => {
-      const build: CharacterBuild = {
-        ...baseBuild,
-        choices: {
-          ...baseBuild.choices,
-          [terrainChoiceKey]: { type: 'feature-choice' as const, optionId },
-        },
-      };
-      const { bundles } = collectBundles(build);
-      const result = resolveCharacter({
-        baseAbilities: build.baseAbilities,
-        level: 3,
-        bundles,
-        choices: build.choices,
-      });
-      expect(result.spellcasting).not.toBeNull();
-      const alwaysPrepared = result.spellcasting!.alwaysPreparedSpells;
-      for (const spellId of leveledSpells) {
-        expect(alwaysPrepared, `${optionId} leveled spell ${spellId}`).toContain(spellId);
-      }
-      expect(alwaysPrepared, `${optionId} cantrip ${cantrip} must not be in alwaysPreparedSpells`).not.toContain(
-        cantrip
-      );
-      expect(result.spellcasting!.cantrips, `${optionId} cantrip ${cantrip} must be in cantrips[]`).toContain(cantrip);
-    }
-  );
 
   it('does not emit a pending terrain choice once a valid option is selected', () => {
     const build: CharacterBuild = {

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -32,12 +32,14 @@ import {
   getFeatSource,
   getItemSource,
   collectBundles,
+  gateGrantsByMinClassLevel,
   SPECIES_SOURCES,
   CLASS_SOURCES,
   SUBCLASS_SOURCES,
   BACKGROUND_SOURCES,
   FEAT_SOURCES,
 } from '@/lib/sources';
+import type { GrantBundle } from '@/types/sources';
 import { resolveCharacter } from '@/lib/resolver';
 import type { CharacterBuild, ChoiceDecision, ChoiceKey } from '@/types/choices';
 import { createChoiceKey } from '@/types/choices';
@@ -1293,5 +1295,82 @@ describe('feature-choice warning suppression boundary', () => {
     } finally {
       mockItemSources.value = null;
     }
+  });
+});
+
+describe('gateGrantsByMinClassLevel (issue #189)', () => {
+  const druidSubclassSource = { origin: 'subclass', id: 'circleland', classId: 'druid', level: 3 } as const;
+
+  const bundleWith = (source: GrantBundle['source'], grants: GrantBundle['grants']): GrantBundle => ({
+    source,
+    grants,
+  });
+
+  it('drops a subclass spell grant whose minClassLevel exceeds the druid level', () => {
+    const bundles = [
+      bundleWith(druidSubclassSource, [
+        { type: 'spell', spellId: 'burning-hands', alwaysPrepared: true },
+        { type: 'spell', spellId: 'fireball', alwaysPrepared: true, minClassLevel: 5 },
+      ]),
+    ];
+    const { bundles: out, warnings } = gateGrantsByMinClassLevel(bundles, new Map([['druid', 3]]));
+    const spellIds = out[0].grants.filter((g) => g.type === 'spell').map((g) => g.spellId);
+    expect(spellIds).toEqual(['burning-hands']); // fireball gated at druid 3
+    expect(warnings).toEqual([]);
+  });
+
+  it('keeps the grant once the druid level reaches minClassLevel', () => {
+    const bundles = [
+      bundleWith(druidSubclassSource, [{ type: 'spell', spellId: 'fireball', alwaysPrepared: true, minClassLevel: 5 }]),
+    ];
+    const { bundles: out } = gateGrantsByMinClassLevel(bundles, new Map([['druid', 5]]));
+    expect(out[0].grants).toHaveLength(1);
+  });
+
+  it('gates an alwaysPrepared:false (cantrip) grant the same way', () => {
+    const bundles = [
+      bundleWith(druidSubclassSource, [
+        { type: 'spell', spellId: 'fire-bolt', alwaysPrepared: false, minClassLevel: 5 },
+      ]),
+    ];
+    expect(gateGrantsByMinClassLevel(bundles, new Map([['druid', 3]])).bundles[0].grants).toHaveLength(0);
+    expect(gateGrantsByMinClassLevel(bundles, new Map([['druid', 5]])).bundles[0].grants).toHaveLength(1);
+  });
+
+  it('leaves grants without minClassLevel untouched (identity-preserving)', () => {
+    const bundles = [
+      bundleWith(druidSubclassSource, [{ type: 'spell', spellId: 'burning-hands', alwaysPrepared: true }]),
+    ];
+    const { bundles: out, warnings } = gateGrantsByMinClassLevel(bundles, new Map([['druid', 1]]));
+    expect(out[0]).toBe(bundles[0]); // same reference — no rebuild when nothing is filtered
+    expect(warnings).toEqual([]);
+  });
+
+  it('keeps a minClassLevel grant on a non-class source and warns instead of silently dropping', () => {
+    const bundles = [
+      bundleWith({ origin: 'species', id: 'human' }, [
+        { type: 'spell', spellId: 'fireball', alwaysPrepared: true, minClassLevel: 5 },
+      ]),
+    ];
+    const { bundles: out, warnings } = gateGrantsByMinClassLevel(bundles, new Map([['druid', 9]]));
+    expect(out[0].grants).toHaveLength(1); // kept, not dropped
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toContain('minClassLevel');
+    expect(warnings[0]).toContain('species');
+  });
+
+  it('gates on the granting class level, not another class (multiclass)', () => {
+    const bundles = [
+      bundleWith(druidSubclassSource, [{ type: 'spell', spellId: 'blight', alwaysPrepared: true, minClassLevel: 7 }]),
+    ];
+    // druid 5 / wizard 7 → druid tier 7 not yet unlocked (gate keys off druid, not wizard)
+    const { bundles: out } = gateGrantsByMinClassLevel(
+      bundles,
+      new Map([
+        ['druid', 5],
+        ['wizard', 7],
+      ])
+    );
+    expect(out[0].grants).toHaveLength(0);
   });
 });

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -86,6 +86,48 @@ export function getItemSource(id: string): ItemSource | undefined {
   return ITEM_SOURCES.find((i) => i.id === id);
 }
 
+/**
+ * Level-gate grants by their optional `minClassLevel` (issue #189). A grant whose `minClassLevel`
+ * exceeds the granting class's current level (from `classCounts`) is suppressed. This mirrors the
+ * feature-level gate in `collectBundles` (`feature.classLevel <= levelCount`) at grant granularity —
+ * e.g. Circle of the Land unlocks its higher circle spells at druid L5/L7/L9 instead of all at L3.
+ *
+ * Gating is on the *granting class's* level (subclass → its `classId`, class → its `id`), which is
+ * multiclass-correct: a druid 5 / wizard 3 unlocks the druid-5 tier, not a total-level tier.
+ *
+ * If a grant carries `minClassLevel` but its source has no class level to gate against (e.g. a
+ * feat/species/background origin), the grant is KEPT and a warning is surfaced rather than silently
+ * dropped — `minClassLevel` is only meaningful on class/subclass grants, so this flags an authoring
+ * error loudly instead of making a feature vanish. Exported for direct unit testing.
+ */
+export function gateGrantsByMinClassLevel(
+  bundles: readonly GrantBundle[],
+  classCounts: ReadonlyMap<ClassId, number>
+): { readonly bundles: GrantBundle[]; readonly warnings: string[] } {
+  const warnings: string[] = [];
+  const classLevelOf = (source: SourceTag): number | undefined => {
+    if (source.origin === 'subclass') return classCounts.get(source.classId);
+    if (source.origin === 'class') return classCounts.get(source.id);
+    return undefined;
+  };
+  const gated = bundles.map((bundle) => {
+    const classLevel = classLevelOf(bundle.source);
+    const kept = bundle.grants.filter((g) => {
+      const min = (g as { readonly minClassLevel?: number }).minClassLevel;
+      if (min == null) return true;
+      if (classLevel == null) {
+        warnings.push(
+          `grant with minClassLevel=${min} on non-class source origin "${bundle.source.origin}" — minClassLevel ignored (no class level to gate against)`
+        );
+        return true;
+      }
+      return classLevel >= min;
+    });
+    return kept.length === bundle.grants.length ? bundle : { source: bundle.source, grants: kept };
+  });
+  return { bundles: gated, warnings };
+}
+
 export interface CollectBundlesResult {
   readonly bundles: readonly GrantBundle[];
   readonly warnings: readonly string[];
@@ -409,26 +451,13 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
     }
   }
 
-  // Level-gate grants by `minClassLevel` (issue #189). This mirrors the feature-level gate above
-  // (`feature.classLevel <= levelCount`) but at grant granularity: a grant whose `minClassLevel`
-  // exceeds the granting class's current level is suppressed. Circle of the Land uses this to unlock
-  // its higher circle spells at druid L5/L7/L9 instead of all at once at L3. Runs after feature-choice
-  // expansion so expanded option grants are gated too. Gating is on the *granting class's* level
-  // (e.g. druid level), which is multiclass-correct — a druid 5 / wizard 3 unlocks the druid-5 tier.
-  const sourceClassLevel = (source: SourceTag): number | undefined => {
-    if (source.origin === 'subclass') return classCounts.get(source.classId);
-    if (source.origin === 'class') return classCounts.get(source.id);
-    return undefined;
-  };
-  const gatedBundles: GrantBundle[] = bundles.map((bundle) => {
-    const classLevel = sourceClassLevel(bundle.source);
-    const gated = bundle.grants.filter((g) => {
-      const min = (g as { readonly minClassLevel?: number }).minClassLevel;
-      if (min == null) return true;
-      return classLevel != null && classLevel >= min;
-    });
-    return gated.length === bundle.grants.length ? bundle : { source: bundle.source, grants: gated };
-  });
+  // Level-gate grants by `minClassLevel` (issue #189). Runs after feature-choice expansion so
+  // expanded option grants are gated too.
+  const gateResult = gateGrantsByMinClassLevel(bundles, classCounts);
+  for (const msg of gateResult.warnings) {
+    warnings.push(msg);
+    logger.warn(msg);
+  }
 
-  return { bundles: gatedBundles, warnings, expandedFeats };
+  return { bundles: gateResult.bundles, warnings, expandedFeats };
 }

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -409,5 +409,26 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
     }
   }
 
-  return { bundles, warnings, expandedFeats };
+  // Level-gate grants by `minClassLevel` (issue #189). This mirrors the feature-level gate above
+  // (`feature.classLevel <= levelCount`) but at grant granularity: a grant whose `minClassLevel`
+  // exceeds the granting class's current level is suppressed. Circle of the Land uses this to unlock
+  // its higher circle spells at druid L5/L7/L9 instead of all at once at L3. Runs after feature-choice
+  // expansion so expanded option grants are gated too. Gating is on the *granting class's* level
+  // (e.g. druid level), which is multiclass-correct — a druid 5 / wizard 3 unlocks the druid-5 tier.
+  const sourceClassLevel = (source: SourceTag): number | undefined => {
+    if (source.origin === 'subclass') return classCounts.get(source.classId);
+    if (source.origin === 'class') return classCounts.get(source.id);
+    return undefined;
+  };
+  const gatedBundles: GrantBundle[] = bundles.map((bundle) => {
+    const classLevel = sourceClassLevel(bundle.source);
+    const gated = bundle.grants.filter((g) => {
+      const min = (g as { readonly minClassLevel?: number }).minClassLevel;
+      if (min == null) return true;
+      return classLevel != null && classLevel >= min;
+    });
+    return gated.length === bundle.grants.length ? bundle : { source: bundle.source, grants: gated };
+  });
+
+  return { bundles: gatedBundles, warnings, expandedFeats };
 }

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -364,8 +364,9 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
           { type: 'feature', feature: { id: 'circleland-lands-aid' } },
           // Land type choice: Arid/Polar/Temperate/Tropical, each granting its circle spells as
           // always-prepared (leveled) plus a terrain cantrip (alwaysPrepared:false → routes to cantrips[]).
-          // Level-gating (L3/5/7/9 tiers) is a known simplification: all spells applied at L3.
-          // A follow-up issue tracks proper per-tier gating.
+          // Per-tier gating (issue #189): the cantrip and the L1–2 spells are available the moment the
+          // subclass is chosen (druid 3); the higher tiers carry `minClassLevel` (5/7/9) and are gated
+          // generically in collectBundles against the druid level — so a druid unlocks them at L5/L7/L9.
           {
             type: 'feature-choice',
             key: createChoiceKey('feature-choice', 'subclass', 'circleland', 0),
@@ -380,11 +381,11 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
                   { type: 'spell', spellId: 'burning-hands', alwaysPrepared: true },
                   { type: 'spell', spellId: 'blur', alwaysPrepared: true },
                   // L5: spell level 3
-                  { type: 'spell', spellId: 'fireball', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'fireball', alwaysPrepared: true, minClassLevel: 5 },
                   // L7: spell level 4
-                  { type: 'spell', spellId: 'blight', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'blight', alwaysPrepared: true, minClassLevel: 7 },
                   // L9: spell level 5
-                  { type: 'spell', spellId: 'wall-of-stone', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'wall-of-stone', alwaysPrepared: true, minClassLevel: 9 },
                 ],
               },
               {
@@ -397,11 +398,11 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
                   { type: 'spell', spellId: 'fog-cloud', alwaysPrepared: true },
                   { type: 'spell', spellId: 'hold-person', alwaysPrepared: true },
                   // L5: spell level 3
-                  { type: 'spell', spellId: 'sleet-storm', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'sleet-storm', alwaysPrepared: true, minClassLevel: 5 },
                   // L7: spell level 4
-                  { type: 'spell', spellId: 'ice-storm', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'ice-storm', alwaysPrepared: true, minClassLevel: 7 },
                   // L9: spell level 5
-                  { type: 'spell', spellId: 'cone-of-cold', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'cone-of-cold', alwaysPrepared: true, minClassLevel: 9 },
                 ],
               },
               {
@@ -414,11 +415,11 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
                   { type: 'spell', spellId: 'sleep', alwaysPrepared: true },
                   { type: 'spell', spellId: 'misty-step', alwaysPrepared: true },
                   // L5: spell level 3
-                  { type: 'spell', spellId: 'lightning-bolt', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'lightning-bolt', alwaysPrepared: true, minClassLevel: 5 },
                   // L7: spell level 4
-                  { type: 'spell', spellId: 'freedom-of-movement', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'freedom-of-movement', alwaysPrepared: true, minClassLevel: 7 },
                   // L9: spell level 5
-                  { type: 'spell', spellId: 'tree-stride', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'tree-stride', alwaysPrepared: true, minClassLevel: 9 },
                 ],
               },
               {
@@ -431,11 +432,11 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
                   { type: 'spell', spellId: 'ray-of-sickness', alwaysPrepared: true },
                   { type: 'spell', spellId: 'web', alwaysPrepared: true },
                   // L5: spell level 3
-                  { type: 'spell', spellId: 'stinking-cloud', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'stinking-cloud', alwaysPrepared: true, minClassLevel: 5 },
                   // L7: spell level 4
-                  { type: 'spell', spellId: 'polymorph', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'polymorph', alwaysPrepared: true, minClassLevel: 7 },
                   // L9: spell level 5
-                  { type: 'spell', spellId: 'insect-plague', alwaysPrepared: true },
+                  { type: 'spell', spellId: 'insect-plague', alwaysPrepared: true, minClassLevel: 9 },
                 ],
               },
             ],

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -199,6 +199,10 @@ export interface SpellGrant {
   readonly type: 'spell';
   readonly spellId: string;
   readonly alwaysPrepared: boolean;
+  // Optional level gate: the grant is suppressed until the granting class reaches this level
+  // (e.g. Circle of the Land progressively unlocks its circle spells at druid L3/5/7/9).
+  // Gated generically in collectBundles against the granting class's level — see issue #189.
+  readonly minClassLevel?: number;
 }
 
 export interface AsiGrant {


### PR DESCRIPTION
Closes #189

## Summary
Circle of the Land's terrain feature-choice applied **all** of a terrain's circle spells at druid **L3**. The 2024 PHB unlocks them progressively: the cantrip + L1–2 spells at druid 3, then the L3/L4/L5 spells at druid **5/7/9**. This gates them correctly.

## Approach
Add an optional `minClassLevel` to `SpellGrant`, and a **general gate pass** in `collectBundles` that suppresses any grant whose `minClassLevel` exceeds the **granting class's** current level. This mirrors the existing feature-level gate (`feature.classLevel <= levelCount` at sources/index.ts) — same pattern, same layer, just at *grant* granularity. The higher-tier circle spells are annotated `minClassLevel: 5/7/9`.

No "carry chosen-option state across per-level bundles" resolver infra is needed: the terrain decision is in `build.choices` and the druid level is in `classCounts`, both available at `collectBundles` time (after feature-choice expansion).

## What Changed
- `src/types/grants.ts` — optional `minClassLevel?` on `SpellGrant`
- `src/lib/sources/subclasses.ts` — circleland L3/L4/L5-tier spells (all 4 terrains) carry `minClassLevel` 5/7/9; updated the simplification comment
- `src/lib/sources/index.ts` — general `minClassLevel` gate pass + `sourceClassLevel` helper
- `src/lib/resolver/index.test.ts` — rewrote the circleland tests (which encoded the old all-at-L3 behavior) to assert progressive unlock at druid 3/5/7/9, plus a multiclass test (druid 5 / wizard 3 → druid-5 tier, not total-level tier)

## Multiclass correctness
Gating on `classCounts.get(source.classId)` (the **druid** level) is the right key — Circle of the Land unlocks on druid level, not character level. Covered by a test.

## Testing
- [x] `npm run typecheck` passing
- [x] `npm run lint` passing (`--max-warnings 0`)
- [x] `npm run test` — 2199 tests passing
- [x] `npm run test:bdd` — 82 scenarios passing (no spec-first regression)
- [x] `npm run coverage:matrix` — no structural change

🤖 Generated with [Claude Code](https://claude.com/claude-code)