### PR TITLE
[5.5e] Resource-pool extensions: PB/level-scaled pools, die-size scaling, per-rest counters (#217 #219 #210 #193)

### DIFF
--- a/src/components/character-sheet/ResourcePoolsPanel.test.tsx
+++ b/src/components/character-sheet/ResourcePoolsPanel.test.tsx
@@ -157,6 +157,57 @@ describe('ResourcePoolsPanel', () => {
     expect(screen.getByText(/long-rest/)).toBeInTheDocument();
   });
 
+  it('renders compound regen label without crashing on the object regen', () => {
+    const resolved = buildMinimalResolved({
+      resourcePools: [
+        {
+          poolId: 'psionic-energy',
+          max: 6,
+          regen: { mode: 'compound', shortRestAmount: 1 },
+          source: { origin: 'subclass', id: 'psiwarrior', classId: 'fighter', level: 3 },
+        },
+      ],
+    });
+    render(<ResourcePoolsPanel resolved={resolved} />);
+    // tc('characterSheet.resourcePools.regen.compound', { shortRestAmount: 1 })
+    // → last segment 'compound', mock appends the interpolation value → "compound 1"
+    expect(screen.getByText(/compound/)).toBeInTheDocument();
+    expect(screen.getByText(/\b1\b/)).toBeInTheDocument();
+  });
+
+  it('renders the die size when the pool declares one', () => {
+    const resolved = buildMinimalResolved({
+      resourcePools: [
+        {
+          poolId: 'psionic-energy',
+          max: 6,
+          regen: { mode: 'compound', shortRestAmount: 1 },
+          dieSize: 8,
+          source: { origin: 'subclass', id: 'psiwarrior', classId: 'fighter', level: 3 },
+        },
+      ],
+    });
+    render(<ResourcePoolsPanel resolved={resolved} />);
+    // tc('characterSheet.resourcePools.dieSize', { dieSize: 8 }) → "dieSize 8"
+    expect(screen.getByText(/\b8\b/)).toBeInTheDocument();
+  });
+
+  it('omits the die size segment when no dieSize is present', () => {
+    const resolved = buildMinimalResolved({
+      resourcePools: [
+        {
+          poolId: 'focus-points',
+          max: 4,
+          regen: 'short-rest',
+          source: { origin: 'class', id: 'monk', level: 1 },
+        },
+      ],
+    });
+    render(<ResourcePoolsPanel resolved={resolved} />);
+    // dieSize label uses the 'dieSize' key segment; with no dieSize it must not render
+    expect(screen.queryByText(/dieSize/)).not.toBeInTheDocument();
+  });
+
   it('renders source attribution via getSourceDisplayName', async () => {
     const { getSourceDisplayName } = await import('@/lib/class-icons');
     const source = { origin: 'class' as const, id: 'monk' as const, level: 1 };

--- a/src/components/character-sheet/ResourcePoolsPanel.tsx
+++ b/src/components/character-sheet/ResourcePoolsPanel.tsx
@@ -16,21 +16,33 @@ export function ResourcePoolsPanel({ resolved }: ResourcePoolsPanelProps): React
     <div className="bg-card border rounded-lg p-6">
       <h2 className="text-lg font-bold text-foreground mb-4">{tc('characterSheet.sections.resourcePools')}</h2>
       <div className="space-y-3">
-        {resolved.resourcePools.map((pool) => (
-          <div key={pool.poolId} className="bg-muted/50 p-3 rounded border">
-            <div className="font-semibold text-foreground text-sm mb-1">
-              {t(`resourcePools.${pool.poolId}.name`, { defaultValue: pool.poolId })}
+        {resolved.resourcePools.map((pool) => {
+          const regenLabel =
+            typeof pool.regen === 'string'
+              ? tc(`characterSheet.resourcePools.regen.${pool.regen}`)
+              : tc('characterSheet.resourcePools.regen.compound', { shortRestAmount: pool.regen.shortRestAmount });
+          return (
+            <div key={pool.poolId} className="bg-muted/50 p-3 rounded border">
+              <div className="font-semibold text-foreground text-sm mb-1">
+                {t(`resourcePools.${pool.poolId}.name`, { defaultValue: pool.poolId })}
+              </div>
+              <div className="text-xs text-muted-foreground">
+                {tc('characterSheet.resourcePools.max', { max: pool.max })}
+                {pool.dieSize !== undefined && (
+                  <>
+                    {' · '}
+                    {tc('characterSheet.resourcePools.dieSize', { dieSize: pool.dieSize })}
+                  </>
+                )}
+                {' · '}
+                {regenLabel}
+              </div>
+              <div className="text-xs text-muted-foreground/70 mt-1">
+                {tc('characterSheet.resourcePools.source', { source: getSourceDisplayName(pool.source, t) })}
+              </div>
             </div>
-            <div className="text-xs text-muted-foreground">
-              {tc('characterSheet.resourcePools.max', { max: pool.max })}
-              {' · '}
-              {tc(`characterSheet.resourcePools.regen.${pool.regen}`)}
-            </div>
-            <div className="text-xs text-muted-foreground/70 mt-1">
-              {tc('characterSheet.resourcePools.source', { source: getSourceDisplayName(pool.source, t) })}
-            </div>
-          </div>
-        ))}
+          );
+        })}
       </div>
     </div>
   );

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -2488,12 +2488,22 @@ describe('Psi Warrior Fighter L7 integration', () => {
     expect(warnings).toEqual([]);
   });
 
-  it('resourcePools contains psionic-energy with max=4 and regen=long-rest', () => {
+  it('resourcePools contains psionic-energy scaled for fighter L7: max=6 (2×PB), die d8, compound regen', () => {
     const result = resolveCharacter(input);
     const psionicPool = result.resourcePools.filter((p) => p.poolId === 'psionic-energy');
     expect(psionicPool).toHaveLength(1);
-    expect(psionicPool[0].max).toBe(4);
-    expect(psionicPool[0].regen).toBe('long-rest');
+    // PB 3 at fighter L7 → 2×PB = 6 dice; die size d8 (minLevel 5 step)
+    expect(psionicPool[0].max).toBe(6);
+    expect(psionicPool[0].dieSize).toBe(8);
+    expect(psionicPool[0].regen).toEqual({ mode: 'compound', shortRestAmount: 1 });
+  });
+
+  it('resourcePools contains the psi-powered-leap free use (fixed:1, short-rest) at L7', () => {
+    const result = resolveCharacter(input);
+    const leap = result.resourcePools.filter((p) => p.poolId === 'psi-powered-leap-use');
+    expect(leap).toHaveLength(1);
+    expect(leap[0].max).toBe(1);
+    expect(leap[0].regen).toBe('short-rest');
   });
 
   it('psiwarrior-telekinetic-adept saveDC = 8 + PB(3 at L7) + INT mod(4) = 15', () => {

--- a/src/lib/resolver/resource-pools.test.ts
+++ b/src/lib/resolver/resource-pools.test.ts
@@ -126,6 +126,33 @@ describe('resolveResourcePools', () => {
       expect(pools).toHaveLength(1);
       expect(pools[0]).toMatchObject({ poolId: 'healing-light', max: expectedMax, regen: 'long-rest' });
     });
+
+    it('resolves to just the offset (no crash) when the named class is absent (level 0)', () => {
+      const otherClassBundles = classBundles('monk', 3); // no warlock bundles
+      const pools = resolveResourcePools([
+        ...otherClassBundles,
+        { source: { origin: 'class', id: 'monk', level: 1 }, grants: [HEAL_GRANT] },
+      ]);
+      expect(pools).toHaveLength(1);
+      // warlock level 0 + offset 1 = 1 (clamp at 0 does not fire for a positive offset)
+      expect(pools[0].max).toBe(1);
+    });
+
+    it('clamps a negative offset that underflows below 0 to 0', () => {
+      const NEG_GRANT: GrantBundle['grants'][number] = {
+        type: 'resource-pool',
+        poolId: 'underflow',
+        max: { mode: 'class-level-plus', classId: 'warlock', offset: -5 },
+        regen: 'long-rest',
+      };
+      const bundles: GrantBundle[] = [
+        { source: { origin: 'class', id: 'warlock', level: 1 }, grants: [NEG_GRANT] },
+        { source: { origin: 'class', id: 'warlock', level: 2 }, grants: [] },
+      ];
+      // warlock level 2 + (-5) = -3 → clamped to 0
+      const pools = resolveResourcePools(bundles);
+      expect(pools[0].max).toBe(0);
+    });
   });
 
   describe('dieSizeSteps (Psionic Energy die scaling)', () => {
@@ -144,11 +171,12 @@ describe('resolveResourcePools', () => {
         ],
       },
       regen: { mode: 'compound', shortRestAmount: 1 },
+      // Die size scales d6 (L3) → d8 (L5) → d10 (L11) → d12 (L17) — distinct thresholds from the count steps.
       dieSizeSteps: [
         { minLevel: 3, dieSize: 6 },
         { minLevel: 5, dieSize: 8 },
-        { minLevel: 9, dieSize: 10 },
-        { minLevel: 13, dieSize: 12 },
+        { minLevel: 11, dieSize: 10 },
+        { minLevel: 17, dieSize: 12 },
       ],
     };
 
@@ -163,14 +191,16 @@ describe('resolveResourcePools', () => {
       return bundles;
     }
 
+    // [fighter level, expected max (2×PB), expected die size]. Die transitions at 5/11/17; count at 5/9/13/17.
     it.each([
       [3, 4, 6],
       [4, 4, 6],
       [5, 6, 8],
-      [8, 6, 8],
-      [9, 8, 10],
-      [12, 8, 10],
-      [13, 10, 12],
+      [9, 8, 8], // count steps to 8, die still d8 (d10 not until L11)
+      [10, 8, 8],
+      [11, 8, 10], // die steps to d10 here, count unchanged at 8
+      [13, 10, 10], // count steps to 10, die still d10
+      [16, 10, 10],
       [17, 12, 12],
       [20, 12, 12],
     ])('at fighter level %i: max=%i dice of size d%i', (level, expectedMax, expectedDie) => {
@@ -179,6 +209,27 @@ describe('resolveResourcePools', () => {
       expect(pools[0].max).toBe(expectedMax);
       expect(pools[0].dieSize).toBe(expectedDie);
       expect(pools[0].regen).toEqual({ mode: 'compound', shortRestAmount: 1 });
+    });
+
+    it('drops dieSize (and does not throw) when dieSizeSteps is declared on a fixed-max pool', () => {
+      const bundles: GrantBundle[] = [
+        {
+          source: { origin: 'feat', id: 'magic-initiate' },
+          grants: [
+            {
+              type: 'resource-pool',
+              poolId: 'misconfigured',
+              max: { mode: 'fixed', value: 3 },
+              regen: 'long-rest',
+              dieSizeSteps: [{ minLevel: 1, dieSize: 6 }],
+            },
+          ],
+        },
+      ];
+      const pools = resolveResourcePools(bundles);
+      expect(pools).toHaveLength(1);
+      expect(pools[0].max).toBe(3);
+      expect(pools[0].dieSize).toBeUndefined();
     });
   });
 

--- a/src/lib/resolver/resource-pools.test.ts
+++ b/src/lib/resolver/resource-pools.test.ts
@@ -63,7 +63,7 @@ describe('resolveResourcePools', () => {
     expect(pools[0].max).toBe(3);
   });
 
-  it('psiwarrior psionic-energy pool resolves to max 4, regen long-rest', () => {
+  it('preserves compound regen on the resolved pool unchanged', () => {
     const bundles: GrantBundle[] = [
       {
         source: { origin: 'subclass', id: 'psiwarrior', classId: 'fighter', level: 3 },
@@ -72,14 +72,114 @@ describe('resolveResourcePools', () => {
             type: 'resource-pool',
             poolId: 'psionic-energy',
             max: { mode: 'fixed', value: 4 },
-            regen: 'long-rest',
+            regen: { mode: 'compound', shortRestAmount: 1 },
           },
         ],
       },
     ];
     const pools = resolveResourcePools(bundles);
     expect(pools).toHaveLength(1);
-    expect(pools[0]).toMatchObject({ poolId: 'psionic-energy', max: 4, regen: 'long-rest' });
+    expect(pools[0].max).toBe(4);
+    expect(pools[0].regen).toEqual({ mode: 'compound', shortRestAmount: 1 });
+  });
+
+  it('omits dieSize when the pool declares no dieSizeSteps', () => {
+    const bundles = classBundles('monk', 5, [
+      {
+        type: 'resource-pool',
+        poolId: 'focus-points',
+        max: { mode: 'class-level', classId: 'monk' },
+        regen: 'short-rest',
+      },
+    ]);
+    const pools = resolveResourcePools(bundles);
+    expect(pools[0].dieSize).toBeUndefined();
+  });
+
+  describe('class-level-plus max (Celestial Patron Healing Light)', () => {
+    const HEAL_GRANT: GrantBundle['grants'][number] = {
+      type: 'resource-pool',
+      poolId: 'healing-light',
+      max: { mode: 'class-level-plus', classId: 'warlock', offset: 1 },
+      regen: 'long-rest',
+    };
+
+    function warlockAtLevel(level: number): GrantBundle[] {
+      const bundles: GrantBundle[] = [];
+      for (let l = 1; l <= level; l++) {
+        bundles.push({
+          source: { origin: 'class', id: 'warlock', level: l },
+          grants: l === 1 ? [HEAL_GRANT] : [],
+        });
+      }
+      return bundles;
+    }
+
+    // max = warlock level + 1
+    it.each([
+      [1, 2],
+      [5, 6],
+      [10, 11],
+      [20, 21],
+    ])('resolves healing-light max to level+1 at warlock level %i', (level, expectedMax) => {
+      const pools = resolveResourcePools(warlockAtLevel(level));
+      expect(pools).toHaveLength(1);
+      expect(pools[0]).toMatchObject({ poolId: 'healing-light', max: expectedMax, regen: 'long-rest' });
+    });
+  });
+
+  describe('dieSizeSteps (Psionic Energy die scaling)', () => {
+    const PSIONIC_GRANT: GrantBundle['grants'][number] = {
+      type: 'resource-pool',
+      poolId: 'psionic-energy',
+      max: {
+        mode: 'level-steps',
+        classId: 'fighter',
+        steps: [
+          { minLevel: 3, value: 4 },
+          { minLevel: 5, value: 6 },
+          { minLevel: 9, value: 8 },
+          { minLevel: 13, value: 10 },
+          { minLevel: 17, value: 12 },
+        ],
+      },
+      regen: { mode: 'compound', shortRestAmount: 1 },
+      dieSizeSteps: [
+        { minLevel: 3, dieSize: 6 },
+        { minLevel: 5, dieSize: 8 },
+        { minLevel: 9, dieSize: 10 },
+        { minLevel: 13, dieSize: 12 },
+      ],
+    };
+
+    function psiwarriorAtLevel(level: number): GrantBundle[] {
+      const bundles: GrantBundle[] = [];
+      for (let l = 1; l <= level; l++) {
+        bundles.push({
+          source: { origin: 'class', id: 'fighter', level: l },
+          grants: l === 3 ? [PSIONIC_GRANT] : [],
+        });
+      }
+      return bundles;
+    }
+
+    it.each([
+      [3, 4, 6],
+      [4, 4, 6],
+      [5, 6, 8],
+      [8, 6, 8],
+      [9, 8, 10],
+      [12, 8, 10],
+      [13, 10, 12],
+      [17, 12, 12],
+      [20, 12, 12],
+    ])('at fighter level %i: max=%i dice of size d%i', (level, expectedMax, expectedDie) => {
+      const pools = resolveResourcePools(psiwarriorAtLevel(level));
+      expect(pools).toHaveLength(1);
+      expect(pools[0].max).toBe(expectedMax);
+      expect(pools[0].dieSize).toBe(expectedDie);
+      expect(pools[0].regen).toEqual({ mode: 'compound', shortRestAmount: 1 });
+    });
   });
 
   describe('level-steps max (Barbarian Rage table)', () => {

--- a/src/lib/resolver/resource-pools.ts
+++ b/src/lib/resolver/resource-pools.ts
@@ -1,5 +1,6 @@
 import type { GrantBundle } from '@/types/sources';
 import type { ResolvedResourcePool } from '@/types/resolved';
+import type { PsionicDieSize } from '@/types/grants';
 import { collectGrantsByType, getClassLevel } from '@/lib/resolver/helpers';
 import { getProficiencyBonus } from '@/lib/dnd-helpers';
 import { getLogger } from '@/lib/logger';
@@ -44,16 +45,33 @@ export function resolveResourcePools(bundles: readonly GrantBundle[]): readonly 
         max = level === 0 ? 0 : getProficiencyBonus(level);
       } else if (maxSpec.mode === 'class-level') {
         max = level;
+      } else if (maxSpec.mode === 'class-level-plus') {
+        // e.g. Healing Light = 1 + Warlock level. Clamp at 0 (negative offset is unusual but allowed).
+        max = Math.max(0, level + maxSpec.offset);
       } else {
         const _exhaustive: never = maxSpec;
         throw new Error(`Unhandled resource-pool max mode: ${JSON.stringify(_exhaustive)}`);
       }
     }
+
+    // Optional die-size scaling (e.g. Psionic Energy d6→d12). Keys on the same class as `max`;
+    // a `fixed`-max pool has no class to key on, so dieSizeSteps is ignored there.
+    let dieSize: PsionicDieSize | undefined;
+    if (grant.dieSizeSteps && grant.max.mode !== 'fixed') {
+      const dieLevel = getClassLevel(bundles, grant.max.classId);
+      const resolved = stepValueForLevel(
+        grant.dieSizeSteps.map((step) => ({ minLevel: step.minLevel, value: step.dieSize })),
+        dieLevel
+      );
+      if (resolved !== 0) dieSize = resolved as PsionicDieSize;
+    }
+
     pools.push({
       poolId: grant.poolId,
       max,
       regen: grant.regen,
       source,
+      ...(dieSize !== undefined ? { dieSize } : {}),
     });
   }
   return pools;

--- a/src/lib/resolver/resource-pools.ts
+++ b/src/lib/resolver/resource-pools.ts
@@ -55,15 +55,21 @@ export function resolveResourcePools(bundles: readonly GrantBundle[]): readonly 
     }
 
     // Optional die-size scaling (e.g. Psionic Energy d6→d12). Keys on the same class as `max`;
-    // a `fixed`-max pool has no class to key on, so dieSizeSteps is ignored there.
+    // a `fixed`-max pool has no class to key on, so dieSizeSteps cannot be resolved there.
     let dieSize: PsionicDieSize | undefined;
-    if (grant.dieSizeSteps && grant.max.mode !== 'fixed') {
-      const dieLevel = getClassLevel(bundles, grant.max.classId);
-      const resolved = stepValueForLevel(
-        grant.dieSizeSteps.map((step) => ({ minLevel: step.minLevel, value: step.dieSize })),
-        dieLevel
-      );
-      if (resolved !== 0) dieSize = resolved as PsionicDieSize;
+    if (grant.dieSizeSteps) {
+      if (grant.max.mode === 'fixed') {
+        logger.warn(
+          `resource-pool "${grant.poolId}" declares dieSizeSteps with a fixed max — there is no class level to key the die size on, so dieSize is dropped`
+        );
+      } else {
+        const dieLevel = getClassLevel(bundles, grant.max.classId);
+        const resolved = stepValueForLevel(
+          grant.dieSizeSteps.map((step) => ({ minLevel: step.minLevel, value: step.dieSize })),
+          dieLevel
+        );
+        if (resolved !== 0) dieSize = resolved as PsionicDieSize;
+      }
     }
 
     pools.push({

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -1161,8 +1161,8 @@ describe('getSubclassSource — Psi Warrior', () => {
           dieSizeSteps: [
             { minLevel: 3, dieSize: 6 },
             { minLevel: 5, dieSize: 8 },
-            { minLevel: 9, dieSize: 10 },
-            { minLevel: 13, dieSize: 12 },
+            { minLevel: 11, dieSize: 10 },
+            { minLevel: 17, dieSize: 12 },
           ],
         }),
         expect.objectContaining({
@@ -2227,8 +2227,24 @@ describe('getSubclassSource — Soulknife', () => {
         expect.objectContaining({
           type: 'resource-pool',
           poolId: 'psionic-energy',
-          max: expect.objectContaining({ mode: 'level-steps', classId: 'rogue' }),
+          max: {
+            mode: 'level-steps',
+            classId: 'rogue',
+            steps: [
+              { minLevel: 3, value: 4 },
+              { minLevel: 5, value: 6 },
+              { minLevel: 9, value: 8 },
+              { minLevel: 13, value: 10 },
+              { minLevel: 17, value: 12 },
+            ],
+          },
           regen: { mode: 'compound', shortRestAmount: 1 },
+          dieSizeSteps: [
+            { minLevel: 3, dieSize: 6 },
+            { minLevel: 5, dieSize: 8 },
+            { minLevel: 11, dieSize: 10 },
+            { minLevel: 17, dieSize: 12 },
+          ],
         }),
         expect.objectContaining({
           type: 'feature',

--- a/src/lib/sources/subclasses.test.ts
+++ b/src/lib/sources/subclasses.test.ts
@@ -809,16 +809,22 @@ describe('getSubclassSource — War Domain', () => {
     expect(source?.features.map((f) => f.classLevel)).toEqual([3, 5, 6, 7, 9]);
   });
 
-  it('wardomain level 3 grants heavy armor, martial weapons, war-priest, guided-strike, and 4 domain spell grants', () => {
+  it('wardomain level 3 grants heavy armor, martial weapons, war-priest + its PB pool, guided-strike, and 4 domain spell grants', () => {
     const source = getSubclassSource('wardomain');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
-    expect(level3?.grants).toHaveLength(8);
+    expect(level3?.grants).toHaveLength(9);
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ type: 'proficiency', category: 'armor', id: 'heavy' }),
         expect.objectContaining({ type: 'proficiency', category: 'weapon', id: 'martial' }),
         expect.objectContaining({ type: 'feature', feature: expect.objectContaining({ id: 'wardomain-war-priest' }) }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'war-priest',
+          max: { mode: 'proficiency-bonus', classId: 'cleric' },
+          regen: 'long-rest',
+        }),
         expect.objectContaining({
           type: 'feature',
           feature: expect.objectContaining({ id: 'wardomain-guided-strike' }),
@@ -1082,15 +1088,25 @@ describe('getSubclassSource — Circle of Stars', () => {
     );
   });
 
-  it('circlestars level 6 grants cosmic-omen feature', () => {
+  it('circlestars level 6 grants cosmic-omen feature + its once-per-rest Reaction pool', () => {
     const source = getSubclassSource('circlestars');
     const level6 = source?.features.find((f) => f.classLevel === 6);
     expect(level6).toBeDefined();
-    expect(level6?.grants).toHaveLength(1);
-    expect(level6?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'circlestars-cosmic-omen' },
-    });
+    expect(level6?.grants).toHaveLength(2);
+    expect(level6?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'circlestars-cosmic-omen' }),
+        }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'cosmic-omen-use',
+          max: { mode: 'fixed', value: 1 },
+          regen: 'long-rest',
+        }),
+      ])
+    );
   });
 
   it('circlestars level 10 grants twinkling-constellations feature', () => {
@@ -1116,11 +1132,11 @@ describe('getSubclassSource — Psi Warrior', () => {
     expect(source?.features.map((f) => f.classLevel)).toEqual([3, 7, 10, 15, 18]);
   });
 
-  it('psiwarrior level 3 grants psionic-power feature + psionic-energy resource pool', () => {
+  it('psiwarrior level 3 grants psionic-power feature, the scaling psionic-energy pool, and the telekinetic-movement free use', () => {
     const source = getSubclassSource('psiwarrior');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
-    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toHaveLength(3);
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
@@ -1130,22 +1146,54 @@ describe('getSubclassSource — Psi Warrior', () => {
         expect.objectContaining({
           type: 'resource-pool',
           poolId: 'psionic-energy',
-          max: { mode: 'fixed', value: 4 },
-          regen: 'long-rest',
+          max: {
+            mode: 'level-steps',
+            classId: 'fighter',
+            steps: [
+              { minLevel: 3, value: 4 },
+              { minLevel: 5, value: 6 },
+              { minLevel: 9, value: 8 },
+              { minLevel: 13, value: 10 },
+              { minLevel: 17, value: 12 },
+            ],
+          },
+          regen: { mode: 'compound', shortRestAmount: 1 },
+          dieSizeSteps: [
+            { minLevel: 3, dieSize: 6 },
+            { minLevel: 5, dieSize: 8 },
+            { minLevel: 9, dieSize: 10 },
+            { minLevel: 13, dieSize: 12 },
+          ],
+        }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'telekinetic-movement-use',
+          max: { mode: 'fixed', value: 1 },
+          regen: 'short-rest',
         }),
       ])
     );
   });
 
-  it('psiwarrior level 7 grants telekinetic-adept feature with INT-based saveDC', () => {
+  it('psiwarrior level 7 grants telekinetic-adept feature (INT saveDC) + the psi-powered-leap free use', () => {
     const source = getSubclassSource('psiwarrior');
     const level7 = source?.features.find((f) => f.classLevel === 7);
     expect(level7).toBeDefined();
-    expect(level7?.grants).toHaveLength(1);
-    expect(level7?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'psiwarrior-telekinetic-adept', saveDC: { dcAbility: 'int' } },
-    });
+    expect(level7?.grants).toHaveLength(2);
+    expect(level7?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'psiwarrior-telekinetic-adept', saveDC: { dcAbility: 'int' } }),
+        }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'psi-powered-leap-use',
+          max: { mode: 'fixed', value: 1 },
+          regen: 'short-rest',
+        }),
+      ])
+    );
   });
 
   it('psiwarrior level 10 grants 2 items: psychic resistance and guarded-mind feature', () => {
@@ -2165,16 +2213,22 @@ describe('getSubclassSource — Soulknife', () => {
     expect(source?.features.map((f) => f.classLevel)).toEqual([3, 9]);
   });
 
-  it('soulknife level 3 grants 2 features: psionic-power and psychic-blades', () => {
+  it('soulknife level 3 grants psionic-power, the rogue-keyed psionic-energy pool, and psychic-blades', () => {
     const source = getSubclassSource('soulknife');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
-    expect(level3?.grants).toHaveLength(2);
+    expect(level3?.grants).toHaveLength(3);
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({
           type: 'feature',
           feature: expect.objectContaining({ id: 'soulknife-psionic-power' }),
+        }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'psionic-energy',
+          max: expect.objectContaining({ mode: 'level-steps', classId: 'rogue' }),
+          regen: { mode: 'compound', shortRestAmount: 1 },
         }),
         expect.objectContaining({
           type: 'feature',
@@ -2662,15 +2716,25 @@ describe('getSubclassSource — Archfey Patron', () => {
     );
   });
 
-  it('archfeypatron level 6 grants 1 feature: misty-escape', () => {
+  it('archfeypatron level 6 grants misty-escape feature + its PB-scaled long-rest pool', () => {
     const source = getSubclassSource('archfeypatron');
     const level6 = source?.features.find((f) => f.classLevel === 6);
     expect(level6).toBeDefined();
-    expect(level6?.grants).toHaveLength(1);
-    expect(level6?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'archfeypatron-misty-escape' },
-    });
+    expect(level6?.grants).toHaveLength(2);
+    expect(level6?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'archfeypatron-misty-escape' }),
+        }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'misty-escape',
+          max: { mode: 'proficiency-bonus', classId: 'warlock' },
+          regen: 'long-rest',
+        }),
+      ])
+    );
   });
 
   it('archfeypatron level 7 grants dominate-beast and greater-invisibility (always prepared)', () => {
@@ -2737,13 +2801,19 @@ describe('getSubclassSource — Celestial Patron', () => {
     const source = getSubclassSource('celestialpatron');
     const level3 = source?.features.find((f) => f.classLevel === 3);
     expect(level3).toBeDefined();
-    expect(level3?.grants).toHaveLength(8);
+    expect(level3?.grants).toHaveLength(9);
     expect(level3?.grants).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ type: 'proficiency', category: 'skill', id: 'religion' }),
         expect.objectContaining({
           type: 'feature',
           feature: expect.objectContaining({ id: 'celestialpatron-healing-light' }),
+        }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'healing-light',
+          max: { mode: 'class-level-plus', classId: 'warlock', offset: 1 },
+          regen: 'long-rest',
         }),
         expect.objectContaining({ type: 'spell', spellId: 'light', alwaysPrepared: false }),
         expect.objectContaining({ type: 'spell', spellId: 'sacred-flame', alwaysPrepared: false }),
@@ -2890,15 +2960,25 @@ describe('getSubclassSource — Fiend Patron', () => {
     );
   });
 
-  it('fiendpatron level 6 grants 1 feature: dark-ones-own-luck', () => {
+  it('fiendpatron level 6 grants dark-ones-own-luck feature + its PB pool (short/long-rest regen)', () => {
     const source = getSubclassSource('fiendpatron');
     const level6 = source?.features.find((f) => f.classLevel === 6);
     expect(level6).toBeDefined();
-    expect(level6?.grants).toHaveLength(1);
-    expect(level6?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'fiendpatron-dark-ones-own-luck' },
-    });
+    expect(level6?.grants).toHaveLength(2);
+    expect(level6?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'fiendpatron-dark-ones-own-luck' }),
+        }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'dark-ones-own-luck',
+          max: { mode: 'proficiency-bonus', classId: 'warlock' },
+          regen: 'short-rest',
+        }),
+      ])
+    );
   });
 
   it('fiendpatron level 7 grants fire-shield and wall-of-fire (always prepared)', () => {
@@ -3026,15 +3106,25 @@ describe('getSubclassSource — Great Old One Patron', () => {
     );
   });
 
-  it('greatoldonepatron level 6 grants 1 feature: clairvoyant-combatant', () => {
+  it('greatoldonepatron level 6 grants clairvoyant-combatant feature + its PB long-rest pool', () => {
     const source = getSubclassSource('greatoldonepatron');
     const level6 = source?.features.find((f) => f.classLevel === 6);
     expect(level6).toBeDefined();
-    expect(level6?.grants).toHaveLength(1);
-    expect(level6?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'greatoldonepatron-clairvoyant-combatant' },
-    });
+    expect(level6?.grants).toHaveLength(2);
+    expect(level6?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'greatoldonepatron-clairvoyant-combatant' }),
+        }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'clairvoyant-combatant',
+          max: { mode: 'proficiency-bonus', classId: 'warlock' },
+          regen: 'long-rest',
+        }),
+      ])
+    );
   });
 
   it('greatoldonepatron level 7 grants confusion and summon-aberration (always prepared)', () => {
@@ -3063,15 +3153,25 @@ describe('getSubclassSource — Great Old One Patron', () => {
     );
   });
 
-  it('greatoldonepatron level 10 grants 1 feature: eldritch-hex', () => {
+  it('greatoldonepatron level 10 grants eldritch-hex feature + its 1/long-rest pool', () => {
     const source = getSubclassSource('greatoldonepatron');
     const level10 = source?.features.find((f) => f.classLevel === 10);
     expect(level10).toBeDefined();
-    expect(level10?.grants).toHaveLength(1);
-    expect(level10?.grants[0]).toMatchObject({
-      type: 'feature',
-      feature: { id: 'greatoldonepatron-eldritch-hex' },
-    });
+    expect(level10?.grants).toHaveLength(2);
+    expect(level10?.grants).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          type: 'feature',
+          feature: expect.objectContaining({ id: 'greatoldonepatron-eldritch-hex' }),
+        }),
+        expect.objectContaining({
+          type: 'resource-pool',
+          poolId: 'eldritch-hex',
+          max: { mode: 'fixed', value: 1 },
+          regen: 'long-rest',
+        }),
+      ])
+    );
   });
 
   it('greatoldonepatron level 14 grants 1 feature: create-thrall', () => {

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -319,8 +319,14 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
         grants: [
           { type: 'proficiency', category: 'armor', id: 'heavy' },
           { type: 'proficiency', category: 'weapon', id: 'martial' },
-          // TODO(#142): wire wardomain-war-priest to resource-pool once ability-score max mode exists
+          // War Priest: a number of Bonus Action attacks equal to your Proficiency Bonus, regained on a Long Rest.
           { type: 'feature', feature: { id: 'wardomain-war-priest' } },
+          {
+            type: 'resource-pool',
+            poolId: 'war-priest',
+            max: { mode: 'proficiency-bonus', classId: 'cleric' },
+            regen: 'long-rest',
+          },
           { type: 'feature', feature: { id: 'wardomain-guided-strike' } },
           { type: 'spell', spellId: 'guiding-bolt', alwaysPrepared: true },
           { type: 'spell', spellId: 'magic-weapon', alwaysPrepared: true },
@@ -525,8 +531,11 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 6,
         grants: [
-          // After each Long Rest, roll d6: even = Weal, odd = Woe; Reaction to add/subtract d6 from rolls
+          // After each Long Rest, roll d6: even = Weal, odd = Woe; Reaction to add/subtract d6 from rolls.
+          // The Weal/Woe runtime state (which is active) is not modeled here — only the once-per-rest
+          // Reaction use, which resets on a Long Rest.
           { type: 'feature', feature: { id: 'circlestars-cosmic-omen' } },
+          { type: 'resource-pool', poolId: 'cosmic-omen-use', max: { mode: 'fixed', value: 1 }, regen: 'long-rest' },
         ],
       },
       {
@@ -594,13 +603,41 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
         classLevel: 3,
         grants: [
           // Single umbrella feature for Psionic Power pool (Protective Field, Psionic Strike,
-          // Telekinetic Movement). Die size scales with PB (d6 at PB+2 → d12 at PB+6); encoded in description.
+          // Telekinetic Movement).
           { type: 'feature', feature: { id: 'psiwarrior-psionic-power' } },
-          // Psionic Energy resource pool: frozen at the L3 value of 4 dice, regain on Long Rest.
-          // Deferred: count scales as 2×PB (4 at L3–4, 6 at L5–8, 8 at L9–12, 10 at L13–16, 12 at L17–20)
-          // and is not yet modeled (no 2×PB step-function in the resource-pool grant); PB-scaled die size
-          // (d6–d12) and +1 per Short Rest partial regen are also not yet modeled.
-          { type: 'resource-pool', poolId: 'psionic-energy', max: { mode: 'fixed', value: 4 }, regen: 'long-rest' },
+          // Psionic Energy resource pool: count is 2×PB (4 at L3–4, 6 at L5–8, 8 at L9–12,
+          // 10 at L13–16, 12 at L17–20 — the step values equal 2×PB at each PB breakpoint),
+          // die size scales d6→d8→d10→d12 by level, and 1 die is regained on a Short Rest (all on a Long Rest).
+          {
+            type: 'resource-pool',
+            poolId: 'psionic-energy',
+            max: {
+              mode: 'level-steps',
+              classId: 'fighter',
+              steps: [
+                { minLevel: 3, value: 4 },
+                { minLevel: 5, value: 6 },
+                { minLevel: 9, value: 8 },
+                { minLevel: 13, value: 10 },
+                { minLevel: 17, value: 12 },
+              ],
+            },
+            regen: { mode: 'compound', shortRestAmount: 1 },
+            dieSizeSteps: [
+              { minLevel: 3, dieSize: 6 },
+              { minLevel: 5, dieSize: 8 },
+              { minLevel: 9, dieSize: 10 },
+              { minLevel: 13, dieSize: 12 },
+            ],
+          },
+          // Telekinetic Movement: usable once per Short Rest WITHOUT spending a Psionic Energy die
+          // — a per-feature counter distinct from the pool.
+          {
+            type: 'resource-pool',
+            poolId: 'telekinetic-movement-use',
+            max: { mode: 'fixed', value: 1 },
+            regen: 'short-rest',
+          },
         ],
       },
       {
@@ -609,6 +646,13 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
           // Umbrella feature for Psi-Powered Leap and Telekinetic Thrust.
           // Telekinetic Thrust forces a STR save vs DC 8 + PB + INT mod.
           { type: 'feature', feature: { id: 'psiwarrior-telekinetic-adept', saveDC: { dcAbility: 'int' } } },
+          // Psi-Powered Leap: usable once per Short Rest WITHOUT spending a Psionic Energy die.
+          {
+            type: 'resource-pool',
+            poolId: 'psi-powered-leap-use',
+            max: { mode: 'fixed', value: 1 },
+            regen: 'short-rest',
+          },
         ],
       },
       {
@@ -1262,8 +1306,31 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
         classLevel: 3,
         grants: [
           // Single umbrella feature for Psionic Power pool (Psi-Bolstered Knack, Psychic Whispers).
-          // Die size scales with PB (d6 at PB+2 → d12 at PB+6); shared resource pool with psiwarrior.
           { type: 'feature', feature: { id: 'soulknife-psionic-power' } },
+          // Psionic Energy pool — same shape as Psi Warrior but keyed on Rogue level: 2×PB dice
+          // (step values equal 2×PB at each breakpoint), die size scales d6→d12, +1 die on Short Rest.
+          {
+            type: 'resource-pool',
+            poolId: 'psionic-energy',
+            max: {
+              mode: 'level-steps',
+              classId: 'rogue',
+              steps: [
+                { minLevel: 3, value: 4 },
+                { minLevel: 5, value: 6 },
+                { minLevel: 9, value: 8 },
+                { minLevel: 13, value: 10 },
+                { minLevel: 17, value: 12 },
+              ],
+            },
+            regen: { mode: 'compound', shortRestAmount: 1 },
+            dieSizeSteps: [
+              { minLevel: 3, dieSize: 6 },
+              { minLevel: 5, dieSize: 8 },
+              { minLevel: 9, dieSize: 10 },
+              { minLevel: 13, dieSize: 12 },
+            ],
+          },
           // Psychic Blades: Bonus Action to produce glowing psychic blades as Unarmed Strike alternatives;
           // 1d6 psychic damage (1d8 for the off-hand blade in a two-weapon attack); counts as Finesse for Sneak Attack.
           // No weapon-grant infrastructure exists — described entirely in feature text.
@@ -1543,6 +1610,12 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
         grants: [
           // Misty Escape: Reaction when you take damage — Misty Step and become Invisible until end of next turn; uses = PB/long rest
           { type: 'feature', feature: { id: 'archfeypatron-misty-escape' } },
+          {
+            type: 'resource-pool',
+            poolId: 'misty-escape',
+            max: { mode: 'proficiency-bonus', classId: 'warlock' },
+            regen: 'long-rest',
+          },
         ],
       },
       {
@@ -1587,6 +1660,12 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
           { type: 'spell', spellId: 'sacred-flame', alwaysPrepared: false },
           // Healing Light: pool of d6s = 1 + Warlock level; spend as Bonus Action to heal creature within 60 ft
           { type: 'feature', feature: { id: 'celestialpatron-healing-light' } },
+          {
+            type: 'resource-pool',
+            poolId: 'healing-light',
+            max: { mode: 'class-level-plus', classId: 'warlock', offset: 1 },
+            regen: 'long-rest',
+          },
           // Celestial patron spells (always prepared)
           { type: 'spell', spellId: 'aid', alwaysPrepared: true },
           { type: 'spell', spellId: 'cure-wounds', alwaysPrepared: true },
@@ -1663,8 +1742,15 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 6,
         grants: [
-          // Dark One's Own Luck: add d10 to an ability check or save; uses = PB per long rest; replenishes on short/long rest
+          // Dark One's Own Luck: add d10 to an ability check or save; uses = PB; regained on a Short or Long Rest
+          // ('short-rest' regen covers both short and long).
           { type: 'feature', feature: { id: 'fiendpatron-dark-ones-own-luck' } },
+          {
+            type: 'resource-pool',
+            poolId: 'dark-ones-own-luck',
+            max: { mode: 'proficiency-bonus', classId: 'warlock' },
+            regen: 'short-rest',
+          },
         ],
       },
       {
@@ -1731,6 +1817,12 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
         grants: [
           // Clairvoyant Combatant: creature within 60 ft must make WIS save or you have Advantage against it and are invisible to it for 1 min; uses = PB/long rest
           { type: 'feature', feature: { id: 'greatoldonepatron-clairvoyant-combatant' } },
+          {
+            type: 'resource-pool',
+            poolId: 'clairvoyant-combatant',
+            max: { mode: 'proficiency-bonus', classId: 'warlock' },
+            regen: 'long-rest',
+          },
         ],
       },
       {
@@ -1750,8 +1842,9 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
       {
         classLevel: 10,
         grants: [
-          // Eldritch Hex: one creature you can see becomes Hexed; if it damages you, it takes psychic damage = PB; 1/day
+          // Eldritch Hex: one creature you can see becomes Hexed; if it damages you, it takes psychic damage = PB; 1 use/long rest
           { type: 'feature', feature: { id: 'greatoldonepatron-eldritch-hex' } },
+          { type: 'resource-pool', poolId: 'eldritch-hex', max: { mode: 'fixed', value: 1 }, regen: 'long-rest' },
         ],
       },
       {

--- a/src/lib/sources/subclasses.ts
+++ b/src/lib/sources/subclasses.ts
@@ -623,11 +623,13 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
               ],
             },
             regen: { mode: 'compound', shortRestAmount: 1 },
+            // 2024 PHB die size scales d6 (L3) → d8 (L5) → d10 (L11) → d12 (L17).
+            // These thresholds differ from the 2×PB count steps above (3/5/9/13/17).
             dieSizeSteps: [
               { minLevel: 3, dieSize: 6 },
               { minLevel: 5, dieSize: 8 },
-              { minLevel: 9, dieSize: 10 },
-              { minLevel: 13, dieSize: 12 },
+              { minLevel: 11, dieSize: 10 },
+              { minLevel: 17, dieSize: 12 },
             ],
           },
           // Telekinetic Movement: usable once per Short Rest WITHOUT spending a Psionic Energy die
@@ -1324,11 +1326,13 @@ export const SUBCLASS_SOURCES: Record<SubclassId, SubclassSource> = {
               ],
             },
             regen: { mode: 'compound', shortRestAmount: 1 },
+            // 2024 PHB die size scales d6 (L3) → d8 (L5) → d10 (L11) → d12 (L17).
+            // These thresholds differ from the 2×PB count steps above (3/5/9/13/17).
             dieSizeSteps: [
               { minLevel: 3, dieSize: 6 },
               { minLevel: 5, dieSize: 8 },
-              { minLevel: 9, dieSize: 10 },
-              { minLevel: 13, dieSize: 12 },
+              { minLevel: 11, dieSize: 10 },
+              { minLevel: 17, dieSize: 12 },
             ],
           },
           // Psychic Blades: Bonus Action to produce glowing psychic blades as Unarmed Strike alternatives;

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -487,10 +487,12 @@
     },
     "resourcePools": {
       "max": "Max: {{max}}",
+      "dieSize": "Die: d{{dieSize}}",
       "source": "Granted by {{source}}",
       "regen": {
         "short-rest": "Short Rest",
-        "long-rest": "Long Rest"
+        "long-rest": "Long Rest",
+        "compound": "Long Rest ({{shortRestAmount}} on Short Rest)"
       }
     },
     "attacks": {

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -2546,7 +2546,43 @@
     },
     "psionic-energy": {
       "name": "Psionic Energy Dice",
-      "description": "Fuel Psi Warrior abilities. You have 4 dice at level 3 (the count scales as 2×PB up to 12 at level 17, which is not yet modeled), regained on a Long Rest (the +1-per-Short-Rest regain and the PB-scaled die size d6–d12 are also not yet modeled)."
+      "description": "Fuel Psi Warrior and Soulknife abilities. You have a number of dice equal to twice your Proficiency Bonus (4 at level 3, scaling to 12 at level 17), and the die size grows from d6 to d12 as you level. You regain 1 die on a Short Rest and all dice on a Long Rest."
+    },
+    "telekinetic-movement-use": {
+      "name": "Telekinetic Movement",
+      "description": "Once per Short or Long Rest, move a Large or smaller object or a willing creature within 30 feet up to 30 feet — without spending a Psionic Energy die."
+    },
+    "psi-powered-leap-use": {
+      "name": "Psi-Powered Leap",
+      "description": "Once per Short or Long Rest, gain a Fly Speed equal to twice your Speed until the end of your turn — without spending a Psionic Energy die."
+    },
+    "misty-escape": {
+      "name": "Misty Escape",
+      "description": "As a Reaction when you take damage, turn invisible and teleport up to 60 feet. Uses equal your Proficiency Bonus; regain all on a Long Rest."
+    },
+    "healing-light": {
+      "name": "Healing Light",
+      "description": "A pool of d6s equal to 1 + your Warlock level. Spend as a Bonus Action to heal a creature within 60 feet. Regain all dice on a Long Rest."
+    },
+    "dark-ones-own-luck": {
+      "name": "Dark One's Own Luck",
+      "description": "Add a d10 to an ability check or saving throw. Uses equal your Proficiency Bonus; regain all on a Short or Long Rest."
+    },
+    "clairvoyant-combatant": {
+      "name": "Clairvoyant Combatant",
+      "description": "Force a creature within 60 feet to make a Wisdom save or you have Advantage against it (and it can't see you) for 1 minute. Uses equal your Proficiency Bonus; regain all on a Long Rest."
+    },
+    "eldritch-hex": {
+      "name": "Eldritch Hex",
+      "description": "Hex a creature you can see; when it damages you it takes Psychic damage equal to your Proficiency Bonus. One use; regain on a Long Rest."
+    },
+    "war-priest": {
+      "name": "War Priest",
+      "description": "Make one weapon attack as a Bonus Action. Uses equal your Proficiency Bonus; regain all on a Long Rest."
+    },
+    "cosmic-omen-use": {
+      "name": "Cosmic Omen",
+      "description": "After each Long Rest, roll a d6: even (Weal) lets you add a d6, odd (Woe) lets you subtract a d6, from a roll made by a creature within 30 feet. One Reaction use; regain on a Long Rest."
     }
   },
   "spells": {

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -318,15 +318,45 @@ export type ResourcePoolMax =
    * characters; multiclass PB (which scales with total character level) is a
    * pre-existing limitation shared by all level-keyed modes.
    */
-  | { readonly mode: 'proficiency-bonus'; readonly classId: ClassId };
+  | { readonly mode: 'proficiency-bonus'; readonly classId: ClassId }
+  /**
+   * The max equals the character's level in the named class plus a fixed `offset`
+   * — e.g. the Celestial Patron's Healing Light (1 + Warlock level). Keys on a
+   * single class's level (same single-class assumption as the other level-keyed
+   * modes). The resolver clamps the result at 0.
+   */
+  | { readonly mode: 'class-level-plus'; readonly classId: ClassId; readonly offset: number };
 
-export type ResourcePoolRegen = 'short-rest' | 'long-rest';
+/**
+ * Die sizes that scale with character level — currently only the Psi Warrior /
+ * Soulknife Psionic Energy dice (d6→d8→d10→d12). Declared on a `ResourcePoolGrant`
+ * via `dieSizeSteps`; resolved onto `ResolvedResourcePool.dieSize`.
+ */
+export type PsionicDieSize = 6 | 8 | 10 | 12;
+
+/**
+ * How a resource pool's uses are recovered.
+ * - `'short-rest'` / `'long-rest'`: all uses recovered on the named rest (short-rest also implies long).
+ * - `compound`: all uses recovered on a Long Rest, plus `shortRestAmount` uses recovered on a Short Rest
+ *   — e.g. Psionic Energy regains 1 die on a Short Rest and all dice on a Long Rest.
+ */
+export type ResourcePoolRegen =
+  | 'short-rest'
+  | 'long-rest'
+  | { readonly mode: 'compound'; readonly shortRestAmount: number };
 
 export interface ResourcePoolGrant {
   readonly type: 'resource-pool';
   readonly poolId: string;
   readonly max: ResourcePoolMax;
   readonly regen: ResourcePoolRegen;
+  /**
+   * Optional die-size scaling table — e.g. Psionic Energy dice scale d6→d8→d10→d12
+   * by class level. Resolved like `level-steps` (highest satisfied `minLevel` wins),
+   * keyed on the same class as `max`. Only meaningful when `max` keys on a class
+   * level; ignored for `fixed`-max pools (no class to key the steps on).
+   */
+  readonly dieSizeSteps?: readonly { readonly minLevel: number; readonly dieSize: PsionicDieSize }[];
 }
 
 export interface SpellChoiceGrant {

--- a/src/types/resolved.ts
+++ b/src/types/resolved.ts
@@ -9,7 +9,15 @@ import type {
   ClassId,
   FeatId,
 } from '@/lib/dnd-helpers';
-import type { FeatureDef, DamageTypeId, HitDie, SpeedMode, SpeedCondition, ResourcePoolRegen } from '@/types/grants';
+import type {
+  FeatureDef,
+  DamageTypeId,
+  HitDie,
+  SpeedMode,
+  SpeedCondition,
+  ResourcePoolRegen,
+  PsionicDieSize,
+} from '@/types/grants';
 import type { SourceTag, FeatCategory } from '@/types/sources';
 import type { ChoiceKey } from '@/types/choices';
 import type {
@@ -95,6 +103,8 @@ export interface ResolvedResourcePool {
   readonly max: number;
   readonly regen: ResourcePoolRegen;
   readonly source: SourceTag;
+  /** Present only when the pool declares `dieSizeSteps` — e.g. Psionic Energy (d6→d12). */
+  readonly dieSize?: PsionicDieSize;
 }
 
 export interface ResolvedArmorClass {


### PR DESCRIPTION
Implements all four **Next Up** resource-pool / per-rest issues together — they share the same Source→Grant→Resolver pipeline, so a single coherent change avoids conflicting edits.

Closes #217
Closes #219
Closes #210
Closes #193

## Summary

Extends the resource-pool grant system with the modes the four issues needed, then wires the affected subclass/domain features. Also retires the #142 blocker (War Priest) — the `proficiency-bonus` max mode it needed already existed.

## Type-system changes

- `ResourcePoolMax` → new `class-level-plus` mode (`classLevel + offset`) for Healing Light (1 + Warlock level).
- `ResourcePoolRegen` → union with a `compound` mode (`{ mode: 'compound'; shortRestAmount }`): all uses on a Long Rest + N on a Short Rest (Psionic Energy).
- `ResourcePoolGrant.dieSizeSteps` + `ResolvedResourcePool.dieSize` (`PsionicDieSize` = 6|8|10|12) for Psionic Energy die scaling.
- Resolver keeps its exhaustive `never` guard on the max-mode switch.

## Source wiring

- **#217** Psi Warrior + Soulknife Psionic Energy: 2×PB dice via `level-steps` (4→6→8→10→12), `dieSizeSteps` d6→d12, compound regen (+1/short rest).
- **#219** Psi Warrior Telekinetic Movement (L3) & Psi-Powered Leap (L7): `fixed:1` short-rest free-use pools.
- **#210** Warlock patrons: Misty Escape, Healing Light, Dark One's Own Luck, Clairvoyant Combatant, Eldritch Hex pools.
- **#142/#210** War Domain War Priest: PB long-rest pool.
- **#193** Circle of Stars Cosmic Omen: `fixed:1` long-rest Reaction pool (Weal/Woe runtime state remains out of scope).

## UI / i18n

`ResourcePoolsPanel` now renders compound regen and die size without crashing on the object-shaped regen. Added `resourcePools.regen.compound` + `resourcePools.dieSize` (common) and 9 new pool entries (gamedata).

## Out of scope (noted in code)

Runtime use-tracking, dice-rolling UI, Weal/Woe active-state tracking, and `rest.ts` recovery integration — these need DB/state work beyond the grant/resolver layer.

## Testing
- [x] `npm run typecheck` — clean
- [x] `npm run test` — 2223 passing
- [x] `npm run lint` — clean
- [x] `npm run test:bdd` — 82 scenarios / 514 steps passing
- New resolver tests: `class-level-plus`, `dieSizeSteps` (level→die matrix), compound-regen passthrough; updated subclass + integration tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)