### PR TITLE
chore: unblock lint and BDD gates on base branch

### DIFF
--- a/features/support/alias-loader.mjs
+++ b/features/support/alias-loader.mjs
@@ -37,6 +37,7 @@ export async function load(url, context, nextLoad) {
     // Provide placeholder values for Vite env vars so modules load without throwing
     .replace(/import\.meta\.env\.VITE_SUPABASE_URL/g, '"http://localhost:54321"')
     .replace(/import\.meta\.env\.VITE_SUPABASE_ANON_KEY/g, '"test-anon-key"')
+    .replace(/import\.meta\.env\.VITE_SUPABASE_PUBLISHABLE_KEY/g, '"test-publishable-key"')
     // Mute loggers during BDD so a passing run is nothing but green dots.
     .replace(/import\.meta\.env\.VITE_LOG_LEVEL/g, '"silent"')
     .replace(/import\.meta\.env\.VITE_\w+/g, 'undefined')

--- a/src/components/character-sheet/LevelUpDialog.tsx
+++ b/src/components/character-sheet/LevelUpDialog.tsx
@@ -8,6 +8,7 @@ import { Button } from '@/components/ui/button';
 import { Dialog, DialogContent, DialogFooter, DialogHeader, DialogTitle } from '@/components/ui/dialog';
 import { RollingNumber } from '@/components/ui/rolling-number';
 import type { ClassId, FightingStyleId } from '@/lib/dnd-helpers';
+import { getLogger } from '@/lib/logger';
 import { getGrantsForLevel } from '@/lib/sources/level-grants';
 import { collectChoiceGrantsFromGrants } from '@/lib/use-all-choice-grants';
 import { parseChoiceKey } from '@/types/choices';
@@ -18,6 +19,8 @@ import type { SourceTag, SubclassId } from '@/types/sources';
 import { Dices } from 'lucide-react';
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import { useTranslation } from 'react-i18next';
+
+const logger = getLogger('LevelUpDialog');
 
 interface LevelUpDialogProps {
   readonly open: boolean;
@@ -85,7 +88,7 @@ function isChoiceSatisfied(choice: PendingChoice, decisions: ReadonlyMap<ChoiceK
       return decision?.type === 'feature-choice' && decision.optionId.length > 0;
     default: {
       const _exhaustive: never = choice;
-      console.warn(`isChoiceSatisfied: unhandled choice type — treating as unsatisfied`, _exhaustive);
+      logger.warn(`isChoiceSatisfied: unhandled choice type — treating as unsatisfied`, _exhaustive);
       return false;
     }
   }
@@ -172,7 +175,7 @@ export function LevelUpDialog({
       try {
         parsedAsi = parseChoiceKey(asi.choiceKey);
       } catch (err) {
-        console.warn(`LevelUpDialog: failed to parse ASI choice key "${asi.choiceKey}" — skipping pair`, err);
+        logger.warn(`LevelUpDialog: failed to parse ASI choice key "${asi.choiceKey}" — skipping pair`, err);
         continue;
       }
       const companion = featChoices.find((fc) => {
@@ -180,7 +183,7 @@ export function LevelUpDialog({
         try {
           p = parseChoiceKey(fc.choiceKey);
         } catch (err) {
-          console.warn(`LevelUpDialog: failed to parse feat-choice key "${fc.choiceKey}" — skipping`, err);
+          logger.warn(`LevelUpDialog: failed to parse feat-choice key "${fc.choiceKey}" — skipping`, err);
           return false;
         }
         return p.origin === parsedAsi.origin && p.id === parsedAsi.id && p.index === parsedAsi.index;

--- a/src/lib/pdf-field-map.ts
+++ b/src/lib/pdf-field-map.ts
@@ -29,6 +29,9 @@ import type { GrantBundle, SourceTag } from '@/types/sources';
 import { getItemNameKey } from '@/lib/sources/items';
 import { getSourceDisplayName } from '@/lib/source-display';
 import { getSpellDisplayMeta } from '@/lib/spell-display';
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('pdf-field-map');
 
 /** Gamedata i18n translator. All user-facing text in the export comes from i18n — ids are never user-facing. */
 export type GamedataT = TFunction<'gamedata'>;
@@ -480,7 +483,7 @@ export function buildFieldValues(
     );
 
     if (allSpells.length > PDF_SPELL_ROWS) {
-      console.warn(
+      logger.warn(
         `PDF export: ${allSpells.length - PDF_SPELL_ROWS} spell(s) dropped — sheet capacity is ${PDF_SPELL_ROWS}`
       );
     }

--- a/src/lib/use-all-choice-grants.ts
+++ b/src/lib/use-all-choice-grants.ts
@@ -9,6 +9,9 @@ import type { PendingChoice } from '@/types/resolved';
 import type { Grant } from '@/types/grants';
 import type { SourceTag } from '@/types/sources';
 import type { FightingStyleId } from '@/lib/dnd-helpers';
+import { getLogger } from '@/lib/logger';
+
+const logger = getLogger('use-all-choice-grants');
 
 /**
  * Context passed to `collectChoiceGrantsFromGrants` to enable cross-bundle
@@ -120,7 +123,7 @@ export function collectChoiceGrantsFromGrants(
           });
           for (const id of validWeaponIds) alreadyClaimedMasteries.add(id);
         } else {
-          console.warn(
+          logger.warn(
             'collectChoiceGrantsFromGrants: weapon-mastery-choice grant skipped — alreadyClaimedMasteries context not provided'
           );
         }
@@ -223,7 +226,7 @@ export function collectChoiceGrantsFromGrants(
             from: grant.from,
           });
         } else {
-          console.warn(
+          logger.warn(
             `collectChoiceGrantsFromGrants: unhandled proficiency-choice category "${grant.category}" — no PendingChoice emitted`
           );
         }


### PR DESCRIPTION
## Why

Two pre-existing failures on `arovani-bugfixes` block `npm run lint` and `npm run test:bdd` for every downstream bugfix branch, so they must be cleared before the arovani issue fixes can land with green gates.

## Changes

- **Lint (no-console):** route six `console.warn` calls through the `getLogger` utility (`LevelUpDialog.tsx`, `pdf-field-map.ts`, `use-all-choice-grants.ts`), matching the established logger pattern.
- **BDD env shim:** commit 8f3d2c2 renamed the Supabase key from `VITE_SUPABASE_ANON_KEY` to `VITE_SUPABASE_PUBLISHABLE_KEY` in `src/lib/supabase.ts`, but `features/support/alias-loader.mjs` still only mapped the old name. The new var fell through to `undefined`, so every render-app scenario threw `Missing Supabase environment variables` (42/82 scenarios failing). Added the mapping.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅ (was 6 errors)
- `npm run test` ✅ 2325 passed
- `npm run test:bdd` ✅ 82/82 (was 40/82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)