### PR TITLE
fix(feats): Magic Initiate spellcasting ability is a choice, not class-tied (#286)

### DIFF
--- a/src/lib/sources/feats.magic-initiate.test.ts
+++ b/src/lib/sources/feats.magic-initiate.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest';
+import { FEAT_SOURCES } from '@/lib/sources/feats';
+import gamedata from '@/locales/en/gamedata.json';
+
+// Regression coverage for #286: the Magic Initiate origin feat lets you choose
+// Intelligence, Wisdom, or Charisma as the spellcasting ability when you take
+// the feat — it is NOT tied to the chosen class's spellcasting ability. These
+// tests assert the variant descriptions reflect the free ability choice and no
+// longer hardcode a single class-tied ability.
+
+const features = gamedata.features as Record<string, { name: string; description: string }>;
+
+function magicInitiateFeatureIds(): readonly string[] {
+  const feat = FEAT_SOURCES.find((f) => f.id === 'magic-initiate');
+  const featureChoice = feat?.grants.find((g) => g.type === 'feature-choice');
+  if (featureChoice?.type !== 'feature-choice') return [];
+  return featureChoice.options.map((o) => o.featureId);
+}
+
+describe('Magic Initiate spellcasting ability (#286)', () => {
+  const featureIds = magicInitiateFeatureIds();
+
+  it('has at least one Magic Initiate variant', () => {
+    expect(featureIds.length).toBeGreaterThan(0);
+  });
+
+  it.each(featureIds)('%s description offers a choice of Int/Wis/Cha spellcasting ability', (featureId) => {
+    const entry = features[featureId];
+    expect(entry, `missing gamedata description for "${featureId}"`).toBeDefined();
+    expect(entry.description).toContain('Intelligence, Wisdom, or Charisma');
+  });
+
+  it.each(featureIds)('%s description does not hardcode a single class-tied ability', (featureId) => {
+    const { description } = features[featureId];
+    expect(description).not.toMatch(/(Intelligence|Wisdom|Charisma) is your spellcasting ability/);
+  });
+});

--- a/src/lib/sources/feats.magic-initiate.test.ts
+++ b/src/lib/sources/feats.magic-initiate.test.ts
@@ -9,6 +9,7 @@ import gamedata from '@/locales/en/gamedata.json';
 // longer hardcode a single class-tied ability.
 
 const features = gamedata.features as Record<string, { name: string; description: string }>;
+const feats = gamedata.feats as Record<string, { name: string; description?: string }>;
 
 function magicInitiateFeatureIds(): readonly string[] {
   const feat = FEAT_SOURCES.find((f) => f.id === 'magic-initiate');
@@ -33,5 +34,13 @@ describe('Magic Initiate spellcasting ability (#286)', () => {
   it.each(featureIds)('%s description does not hardcode a single class-tied ability', (featureId) => {
     const { description } = features[featureId];
     expect(description).not.toMatch(/(Intelligence|Wisdom|Charisma) is your spellcasting ability/);
+  });
+
+  it('top-level feats.magic-initiate description offers the Int/Wis/Cha choice', () => {
+    const description = feats['magic-initiate']?.description;
+    expect(description, 'missing gamedata description for feats.magic-initiate').toBeDefined();
+    expect(description).toContain('Intelligence, Wisdom, or Charisma');
+    // must not tie the ability to the chosen class (the #286 bug)
+    expect(description).not.toMatch(/spellcasting ability for these spells is the same as the chosen class/);
   });
 });

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -2339,7 +2339,7 @@
     },
     "magic-initiate": {
       "name": "Magic Initiate",
-      "description": "Choose a class: Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard. You learn two cantrips and one 1st-level spell from that class's spell list. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Your spellcasting ability for these spells is the same as the chosen class."
+      "description": "Choose a class: Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard. You learn two cantrips and one 1st-level spell from that class's spell list. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. When you take this feat, choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells."
     },
     "musician": {
       "name": "Musician",

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -425,27 +425,27 @@
     },
     "feat-magic-initiate-bard": {
       "name": "Magic Initiate (Bard)",
-      "description": "Learn two Bard cantrips and one 1st-level Bard spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Charisma is your spellcasting ability for these spells."
+      "description": "Learn two Bard cantrips and one 1st-level Bard spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells when you take this feat."
     },
     "feat-magic-initiate-cleric": {
       "name": "Magic Initiate (Cleric)",
-      "description": "Learn two Cleric cantrips and one 1st-level Cleric spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Wisdom is your spellcasting ability for these spells."
+      "description": "Learn two Cleric cantrips and one 1st-level Cleric spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells when you take this feat."
     },
     "feat-magic-initiate-druid": {
       "name": "Magic Initiate (Druid)",
-      "description": "Learn two Druid cantrips and one 1st-level Druid spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Wisdom is your spellcasting ability for these spells."
+      "description": "Learn two Druid cantrips and one 1st-level Druid spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells when you take this feat."
     },
     "feat-magic-initiate-sorcerer": {
       "name": "Magic Initiate (Sorcerer)",
-      "description": "Learn two Sorcerer cantrips and one 1st-level Sorcerer spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Charisma is your spellcasting ability for these spells."
+      "description": "Learn two Sorcerer cantrips and one 1st-level Sorcerer spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells when you take this feat."
     },
     "feat-magic-initiate-warlock": {
       "name": "Magic Initiate (Warlock)",
-      "description": "Learn two Warlock cantrips and one 1st-level Warlock spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Charisma is your spellcasting ability for these spells."
+      "description": "Learn two Warlock cantrips and one 1st-level Warlock spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells when you take this feat."
     },
     "feat-magic-initiate-wizard": {
       "name": "Magic Initiate (Wizard)",
-      "description": "Learn two Wizard cantrips and one 1st-level Wizard spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Intelligence is your spellcasting ability for these spells."
+      "description": "Learn two Wizard cantrips and one 1st-level Wizard spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells when you take this feat."
     },
     "feat-elemental-adept-acid": {
       "name": "Elemental Adept (Acid)",


### PR DESCRIPTION
Closes #286.

## Problem
The Magic Initiate origin-feat variant descriptions hardcoded a class-tied spellcasting ability (Cleric/Druid → Wisdom, Wizard → Intelligence, etc.). Per the 2024 PHB, Magic Initiate lets you choose **Intelligence, Wisdom, or Charisma** as the spellcasting ability when you take the feat, independent of the chosen spell list.

## Fix
- Corrected all six `feat-magic-initiate-*` descriptions in `gamedata.json` to state the ability is chosen from Int/Wis/Cha when the feat is taken.
- Added a regression test (`feats.magic-initiate.test.ts`) asserting each variant's description offers the Int/Wis/Cha choice and no longer hardcodes a single class-tied ability.

## Scope note
The *mechanical* spellcasting-ability selection is part of the deferred spell system (#82) — the feat's grants are empty stubs and `resolveSpellcasting()` derives no ability from them — so the description text is the only user-visible artifact today.

## Verification
typecheck ✅ · lint ✅ · test ✅ (2338) · test:bdd ✅ (82/82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)