### PR TITLE
fix(feats): Magic Initiate offers only Cleric/Druid/Wizard (#288)

### DIFF
--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -2589,11 +2589,8 @@ describe('collapsed repeatable feat resolver integration', () => {
               type: 'feature-choice',
               key: magicInitiateKey,
               options: [
-                { optionId: 'bard', featureId: 'feat-magic-initiate-bard', grants: [] },
                 { optionId: 'cleric', featureId: 'feat-magic-initiate-cleric', grants: [] },
                 { optionId: 'druid', featureId: 'feat-magic-initiate-druid', grants: [] },
-                { optionId: 'sorcerer', featureId: 'feat-magic-initiate-sorcerer', grants: [] },
-                { optionId: 'warlock', featureId: 'feat-magic-initiate-warlock', grants: [] },
                 { optionId: 'wizard', featureId: 'feat-magic-initiate-wizard', grants: [] },
               ],
             },
@@ -2609,7 +2606,7 @@ describe('collapsed repeatable feat resolver integration', () => {
         const optionIds = pending.options.map((o) => o.optionId);
         expect(optionIds).toContain('wizard');
         expect(optionIds).toContain('cleric');
-        expect(optionIds).toHaveLength(6);
+        expect(optionIds).toHaveLength(3);
       }
     });
 

--- a/src/lib/sources/feats.magic-initiate.test.ts
+++ b/src/lib/sources/feats.magic-initiate.test.ts
@@ -18,6 +18,39 @@ function magicInitiateFeatureIds(): readonly string[] {
   return featureChoice.options.map((o) => o.featureId);
 }
 
+function magicInitiateOptionIds(): readonly string[] {
+  const feat = FEAT_SOURCES.find((f) => f.id === 'magic-initiate');
+  const featureChoice = feat?.grants.find((g) => g.type === 'feature-choice');
+  if (featureChoice?.type !== 'feature-choice') return [];
+  return featureChoice.options.map((o) => o.optionId);
+}
+
+// Regression coverage for #288: in the 2024 PHB the Magic Initiate origin feat
+// offers only the Cleric, Druid, or Wizard spell lists. Bard, Sorcerer, and
+// Warlock are 2014 holdovers and must not be selectable.
+describe('Magic Initiate class options (#288)', () => {
+  it('offers exactly Cleric, Druid, and Wizard', () => {
+    expect([...magicInitiateOptionIds()].sort()).toEqual(['cleric', 'druid', 'wizard']);
+  });
+
+  it.each(['bard', 'sorcerer', 'warlock'])('does not offer %s', (optionId) => {
+    expect(magicInitiateOptionIds()).not.toContain(optionId);
+  });
+
+  it.each(['feat-magic-initiate-bard', 'feat-magic-initiate-sorcerer', 'feat-magic-initiate-warlock'])(
+    'has no gamedata description for the removed %s variant',
+    (featureId) => {
+      expect(features[featureId]).toBeUndefined();
+    }
+  );
+
+  it('top-level description lists only Cleric, Druid, or Wizard', () => {
+    const description = feats['magic-initiate']?.description ?? '';
+    expect(description).toContain('Cleric, Druid, or Wizard');
+    expect(description).not.toMatch(/Bard|Sorcerer|Warlock/);
+  });
+});
+
 describe('Magic Initiate spellcasting ability (#286)', () => {
   const featureIds = magicInitiateFeatureIds();
 

--- a/src/lib/sources/feats.test.ts
+++ b/src/lib/sources/feats.test.ts
@@ -171,13 +171,13 @@ describe('FEAT_SOURCES', () => {
       expect(feat?.repeatable).toBe(true);
     });
 
-    it('magic-initiate has 6 feature-choice options (bard/cleric/druid/sorcerer/warlock/wizard)', () => {
+    it('magic-initiate has 3 feature-choice options (cleric/druid/wizard) per 2024 PHB (#288)', () => {
       const feat = FEAT_SOURCES.find((f) => f.id === 'magic-initiate');
       const choiceGrant = feat?.grants.find((g) => g.type === 'feature-choice');
       expect(choiceGrant).toBeDefined();
       if (choiceGrant?.type === 'feature-choice') {
         const optionIds = choiceGrant.options.map((o) => o.optionId);
-        expect(optionIds).toEqual(['bard', 'cleric', 'druid', 'sorcerer', 'warlock', 'wizard']);
+        expect(optionIds).toEqual(['cleric', 'druid', 'wizard']);
       }
     });
 

--- a/src/lib/sources/feats.ts
+++ b/src/lib/sources/feats.ts
@@ -49,13 +49,9 @@ export const FEAT_SOURCES: readonly FeatSource[] = [
       {
         type: 'feature-choice',
         key: createChoiceKey('feature-choice', 'feat', 'magic-initiate', 0),
+        // 2024 PHB: Magic Initiate offers only the Cleric, Druid, or Wizard spell
+        // lists (Bard/Sorcerer/Warlock are 2014 holdovers and are not valid).
         options: [
-          {
-            optionId: 'bard',
-            featureId: 'feat-magic-initiate-bard',
-            // TODO(#82): spell grants deferred — spell catalog not yet built
-            grants: [],
-          },
           {
             optionId: 'cleric',
             featureId: 'feat-magic-initiate-cleric',
@@ -65,18 +61,6 @@ export const FEAT_SOURCES: readonly FeatSource[] = [
           {
             optionId: 'druid',
             featureId: 'feat-magic-initiate-druid',
-            // TODO(#82): spell grants deferred — spell catalog not yet built
-            grants: [],
-          },
-          {
-            optionId: 'sorcerer',
-            featureId: 'feat-magic-initiate-sorcerer',
-            // TODO(#82): spell grants deferred — spell catalog not yet built
-            grants: [],
-          },
-          {
-            optionId: 'warlock',
-            featureId: 'feat-magic-initiate-warlock',
             // TODO(#82): spell grants deferred — spell catalog not yet built
             grants: [],
           },

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -423,10 +423,6 @@
       "name": "Martial Weapon Training",
       "description": "You gain proficiency with all Martial weapons."
     },
-    "feat-magic-initiate-bard": {
-      "name": "Magic Initiate (Bard)",
-      "description": "Learn two Bard cantrips and one 1st-level Bard spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells when you take this feat."
-    },
     "feat-magic-initiate-cleric": {
       "name": "Magic Initiate (Cleric)",
       "description": "Learn two Cleric cantrips and one 1st-level Cleric spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells when you take this feat."
@@ -434,14 +430,6 @@
     "feat-magic-initiate-druid": {
       "name": "Magic Initiate (Druid)",
       "description": "Learn two Druid cantrips and one 1st-level Druid spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells when you take this feat."
-    },
-    "feat-magic-initiate-sorcerer": {
-      "name": "Magic Initiate (Sorcerer)",
-      "description": "Learn two Sorcerer cantrips and one 1st-level Sorcerer spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells when you take this feat."
-    },
-    "feat-magic-initiate-warlock": {
-      "name": "Magic Initiate (Warlock)",
-      "description": "Learn two Warlock cantrips and one 1st-level Warlock spell. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. Choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells when you take this feat."
     },
     "feat-magic-initiate-wizard": {
       "name": "Magic Initiate (Wizard)",
@@ -2339,7 +2327,7 @@
     },
     "magic-initiate": {
       "name": "Magic Initiate",
-      "description": "Choose a class: Bard, Cleric, Druid, Sorcerer, Warlock, or Wizard. You learn two cantrips and one 1st-level spell from that class's spell list. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. When you take this feat, choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells."
+      "description": "Choose a class: Cleric, Druid, or Wizard. You learn two cantrips and one 1st-level spell from that class's spell list. You can cast the 1st-level spell once without a spell slot, regaining the ability to do so on a Long Rest. When you take this feat, choose Intelligence, Wisdom, or Charisma as your spellcasting ability for these spells."
     },
     "musician": {
       "name": "Musician",


### PR DESCRIPTION
Closes #288.

## Problem
The Magic Initiate origin feat let you choose Bard, Sorcerer, and Warlock spell lists, which are not valid choices for that feat in the 2024 PHB — it offers only **Cleric, Druid, or Wizard**.

## Fix
- Removed the Bard/Sorcerer/Warlock options from the `magic-initiate` feature-choice grant in `feats.ts`.
- Removed the orphaned `feat-magic-initiate-{bard,sorcerer,warlock}` gamedata entries and corrected the top-level feat description's class list.
- Added a regression test asserting the options are exactly Cleric/Druid/Wizard and the removed variants are gone; updated existing option-count tests (`feats.test.ts`, `resolver/index.test.ts`).

## Verification
typecheck ✅ · lint ✅ · test ✅ (2343) · test:bdd ✅ (82/82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)