### PR TITLE
fix(species): Aasimar Celestial Revelation is a level-3 choice (#289)

### DIFF
--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -1440,4 +1440,31 @@ describe('Aasimar Celestial Revelation surfacing by character level (#289)', () 
       expect(pending.options).toHaveLength(3);
     }
   });
+
+  it('emits no warnings for a plain Aasimar build (species feature-choice is a known origin)', () => {
+    for (const numLevels of [1, 2, 3]) {
+      const { warnings } = collectBundles(aasimarFighterBuild(numLevels));
+      const revelationWarnings = warnings.filter((w) => w.includes('feature-choice:species:aasimar:0'));
+      expect(revelationWarnings, `unexpected warning at level ${numLevels}: ${revelationWarnings.join('; ')}`).toEqual(
+        []
+      );
+    }
+  });
+
+  it('does not grant the chosen revelation feature below level 3 (e.g. after a level-down)', () => {
+    const buildWithChoice = (numLevels: number): CharacterBuild => ({
+      ...aasimarFighterBuild(numLevels),
+      choices: {
+        [revelationKey]: { type: 'feature-choice', optionId: 'inner-radiance' } as ChoiceDecision,
+      },
+    });
+    const featureIdsAt = (numLevels: number): string[] =>
+      collectBundles(buildWithChoice(numLevels))
+        .bundles.flatMap((b) => b.grants)
+        .filter((g) => g.type === 'feature')
+        .map((g) => (g.type === 'feature' ? g.feature.id : ''));
+
+    expect(featureIdsAt(2)).not.toContain('aasimar-celestial-revelation-inner-radiance');
+    expect(featureIdsAt(3)).toContain('aasimar-celestial-revelation-inner-radiance');
+  });
 });

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -33,6 +33,7 @@ import {
   getItemSource,
   collectBundles,
   gateGrantsByMinClassLevel,
+  gateGrantsByMinCharacterLevel,
   SPECIES_SOURCES,
   CLASS_SOURCES,
   SUBCLASS_SOURCES,
@@ -40,6 +41,7 @@ import {
   FEAT_SOURCES,
 } from '@/lib/sources';
 import type { GrantBundle } from '@/types/sources';
+import type { Grant } from '@/types/grants';
 import { resolveCharacter } from '@/lib/resolver';
 import type { CharacterBuild, ChoiceDecision, ChoiceKey } from '@/types/choices';
 import { createChoiceKey } from '@/types/choices';
@@ -1372,5 +1374,70 @@ describe('gateGrantsByMinClassLevel (issue #189)', () => {
       ])
     );
     expect(out[0].grants).toHaveLength(0);
+  });
+});
+
+describe('gateGrantsByMinCharacterLevel (#289)', () => {
+  const speciesSource = { origin: 'species', id: 'aasimar' } as const;
+  const bundleWith = (grants: GrantBundle['grants']): GrantBundle => ({ source: speciesSource, grants });
+  const revelationChoice: Grant = {
+    type: 'feature-choice',
+    key: createChoiceKey('feature-choice', 'species', 'aasimar', 0),
+    minCharacterLevel: 3,
+    options: [{ optionId: 'inner-radiance', featureId: 'aasimar-celestial-revelation-inner-radiance', grants: [] }],
+  };
+
+  it('drops a minCharacterLevel:3 grant below character level 3', () => {
+    const out = gateGrantsByMinCharacterLevel([bundleWith([revelationChoice])], 2);
+    expect(out[0].grants).toHaveLength(0);
+  });
+
+  it('keeps a minCharacterLevel:3 grant at character level 3 and above', () => {
+    expect(gateGrantsByMinCharacterLevel([bundleWith([revelationChoice])], 3)[0].grants).toHaveLength(1);
+    expect(gateGrantsByMinCharacterLevel([bundleWith([revelationChoice])], 5)[0].grants).toHaveLength(1);
+  });
+
+  it('leaves grants without minCharacterLevel untouched (identity-preserving)', () => {
+    const bundles = [bundleWith([{ type: 'feature', feature: { id: 'aasimar-darkvision' } }])];
+    expect(gateGrantsByMinCharacterLevel(bundles, 1)[0]).toBe(bundles[0]);
+  });
+});
+
+describe('Aasimar Celestial Revelation surfacing by character level (#289)', () => {
+  const aasimarFighterBuild = (numLevels: number): CharacterBuild => ({
+    ...humanFighterL1Build,
+    speciesId: 'aasimar' as SpeciesId,
+    levels: Array.from({ length: numLevels }, () => ({ classId: 'fighter' as ClassId, classLevel: 1, hpRoll: null })),
+  });
+
+  const revelationKey = createChoiceKey('feature-choice', 'species', 'aasimar', 0);
+
+  const hasRevelationChoice = (build: CharacterBuild): boolean =>
+    collectBundles(build).bundles.some((b) =>
+      b.grants.some((g) => g.type === 'feature-choice' && g.key === revelationKey)
+    );
+
+  it('does not offer Celestial Revelation at character level 1 or 2', () => {
+    expect(hasRevelationChoice(aasimarFighterBuild(1))).toBe(false);
+    expect(hasRevelationChoice(aasimarFighterBuild(2))).toBe(false);
+  });
+
+  it('offers Celestial Revelation as a pending choice at character level 3', () => {
+    const build = aasimarFighterBuild(3);
+    expect(hasRevelationChoice(build)).toBe(true);
+    const { bundles, expandedFeats } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: build.levels.length,
+      bundles,
+      choices: build.choices,
+      levels: build.levels,
+      expandedFeats,
+    });
+    const pending = result.pendingChoices.find((c) => c.type === 'feature-choice' && c.choiceKey === revelationKey);
+    expect(pending).toBeDefined();
+    if (pending?.type === 'feature-choice') {
+      expect(pending.options).toHaveLength(3);
+    }
   });
 });

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -443,10 +443,23 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
   }
 
   for (const { grant, source } of allFeatureChoiceGrants) {
-    // ClassStep handles 'class' and 'subclass' origins; OriginStep handles 'feat'.
-    // Any other origin (e.g. 'item') would produce an invisible pending choice;
-    // surface as a warning so the CharacterBuilder amber banner shows it instead of failing silently.
-    if (source.origin !== 'class' && source.origin !== 'feat' && source.origin !== 'subclass') {
+    // Suppress feature-choices gated above the character's current level (#289) before both the
+    // visibility warning and expansion. This prevents a chosen option's expanded feature from
+    // leaking below its unlock level after a level-down, and avoids a spurious warning at levels
+    // where the choice is not yet offered. The top-level grant is separately removed from the
+    // returned bundles by gateGrantsByMinCharacterLevel below.
+    if (grant.minCharacterLevel != null && build.levels.length < grant.minCharacterLevel) continue;
+
+    // ClassStep handles 'class' and 'subclass' origins; OriginStep handles 'feat'; the character
+    // sheet's PendingChoicesPanel renders 'species' origins generically via ChoicePicker.
+    // Any other origin (e.g. 'item') would produce an invisible pending choice; surface as a warning
+    // so the CharacterBuilder amber banner shows it instead of failing silently.
+    if (
+      source.origin !== 'class' &&
+      source.origin !== 'feat' &&
+      source.origin !== 'subclass' &&
+      source.origin !== 'species'
+    ) {
       const msg = `feature-choice "${grant.key}" has non-class origin "${source.origin}" — no builder UI exists for this origin, choice will be invisible`;
       warnings.push(msg);
       logger.warn(msg);

--- a/src/lib/sources/index.ts
+++ b/src/lib/sources/index.ts
@@ -128,6 +128,23 @@ export function gateGrantsByMinClassLevel(
   return { bundles: gated, warnings };
 }
 
+/**
+ * Level-gate grants by their optional `minCharacterLevel` (#289). A grant whose `minCharacterLevel`
+ * exceeds the character's total level is suppressed. Unlike `gateGrantsByMinClassLevel`, this gates
+ * against total character level regardless of source, so it applies to species/background/feat
+ * origins too — e.g. Aasimar Celestial Revelation unlocks at character level 3. Exported for direct
+ * unit testing.
+ */
+export function gateGrantsByMinCharacterLevel(bundles: readonly GrantBundle[], characterLevel: number): GrantBundle[] {
+  return bundles.map((bundle) => {
+    const kept = bundle.grants.filter((g) => {
+      const min = (g as { readonly minCharacterLevel?: number }).minCharacterLevel;
+      return min == null || characterLevel >= min;
+    });
+    return kept.length === bundle.grants.length ? bundle : { source: bundle.source, grants: kept };
+  });
+}
+
 export interface CollectBundlesResult {
   readonly bundles: readonly GrantBundle[];
   readonly warnings: readonly string[];
@@ -459,5 +476,9 @@ export function collectBundles(build: CharacterBuild): CollectBundlesResult {
     logger.warn(msg);
   }
 
-  return { bundles: gateResult.bundles, warnings, expandedFeats };
+  // Level-gate grants by total-character-level `minCharacterLevel` (#289), e.g. Aasimar Celestial
+  // Revelation unlocks at character level 3.
+  const characterGated = gateGrantsByMinCharacterLevel(gateResult.bundles, build.levels.length);
+
+  return { bundles: characterGated, warnings, expandedFeats };
 }

--- a/src/lib/sources/species.test.ts
+++ b/src/lib/sources/species.test.ts
@@ -372,9 +372,9 @@ describe('Aasimar species source (2024 PHB)', () => {
     );
   });
 
-  it('grants darkvision, celestial-resistance, healing-hands, light-bearer, celestial-revelation features', () => {
+  it('grants darkvision, celestial-resistance, healing-hands, light-bearer features', () => {
     const features = source?.grants.filter((g) => g.type === 'feature');
-    expect(features).toHaveLength(5);
+    expect(features).toHaveLength(4);
     const featureIds = features?.map((g) => g.type === 'feature' && g.feature.id);
     expect(featureIds).toEqual(
       expect.arrayContaining([
@@ -382,9 +382,30 @@ describe('Aasimar species source (2024 PHB)', () => {
         'aasimar-celestial-resistance',
         'aasimar-healing-hands',
         'aasimar-light-bearer',
-        'aasimar-celestial-revelation',
       ])
     );
+  });
+
+  // Regression for #289: Celestial Revelation is a level-3 choice of three transformations,
+  // not a flat feature granted at level 1.
+  it('offers Celestial Revelation as a level-3 feature-choice with three options', () => {
+    const choice = source?.grants.find((g) => g.type === 'feature-choice');
+    expect(choice).toBeDefined();
+    if (choice?.type === 'feature-choice') {
+      expect(choice.minCharacterLevel).toBe(3);
+      expect(choice.key).toBe(createChoiceKey('feature-choice', 'species', 'aasimar', 0));
+      expect(choice.options.map((o) => o.optionId).sort()).toEqual([
+        'heavenly-wings',
+        'inner-radiance',
+        'necrotic-shroud',
+      ]);
+    }
+  });
+
+  it('does not grant Celestial Revelation as a flat feature', () => {
+    const features = source?.grants.filter((g) => g.type === 'feature');
+    const ids = features?.map((g) => (g.type === 'feature' ? g.feature.id : ''));
+    expect(ids).not.toContain('aasimar-celestial-revelation');
   });
 });
 

--- a/src/lib/sources/species.ts
+++ b/src/lib/sources/species.ts
@@ -284,7 +284,31 @@ export const SPECIES_SOURCES: readonly SpeciesSource[] = [
       { type: 'resistance', damageType: 'radiant' },
       { type: 'feature', feature: { id: 'aasimar-healing-hands' } },
       { type: 'feature', feature: { id: 'aasimar-light-bearer' } },
-      { type: 'feature', feature: { id: 'aasimar-celestial-revelation' } },
+      // Celestial Revelation: at character level 3, choose one transformation (2024 PHB). #289
+      {
+        type: 'feature-choice',
+        key: createChoiceKey('feature-choice', 'species', 'aasimar', 0),
+        minCharacterLevel: 3,
+        options: [
+          {
+            optionId: 'heavenly-wings',
+            featureId: 'aasimar-celestial-revelation-heavenly-wings',
+            // Transformation-only fly speed (1 min, Bonus Action); the engine does not model
+            // transient activated speeds, so the mechanics live in the feature description.
+            grants: [],
+          },
+          {
+            optionId: 'inner-radiance',
+            featureId: 'aasimar-celestial-revelation-inner-radiance',
+            grants: [],
+          },
+          {
+            optionId: 'necrotic-shroud',
+            featureId: 'aasimar-celestial-revelation-necrotic-shroud',
+            grants: [],
+          },
+        ],
+      },
     ],
   },
   // Dragonborn (2024 PHB) — lineage choice from 10 options (5 chromatic, 5 metallic)

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -889,7 +889,19 @@
     },
     "aasimar-celestial-revelation": {
       "name": "Celestial Revelation",
-      "description": "When you reach character level 3, you can transform as a Bonus Action. Your transformation lasts for 1 minute or until you end it as a Bonus Action."
+      "description": "When you reach character level 3, choose one Celestial Revelation. You can transform as a Bonus Action, and the transformation lasts for 1 minute or until you end it (no action required). Once you transform, you can't do so again until you finish a Long Rest."
+    },
+    "aasimar-celestial-revelation-heavenly-wings": {
+      "name": "Celestial Revelation: Heavenly Wings",
+      "description": "While transformed, wings sprout from your back and you gain a Fly Speed equal to your Speed. The transformation lasts 1 minute or until you end it (no action required), starts with a Bonus Action, and can be used once per Long Rest."
+    },
+    "aasimar-celestial-revelation-inner-radiance": {
+      "name": "Celestial Revelation: Inner Radiance",
+      "description": "While transformed, you shed Bright Light in a 10-foot radius and Dim Light for an additional 10 feet, and any creature that ends its turn within 10 feet of you takes Radiant damage equal to your Proficiency Bonus. The transformation lasts 1 minute or until you end it (no action required), starts with a Bonus Action, and can be used once per Long Rest."
+    },
+    "aasimar-celestial-revelation-necrotic-shroud": {
+      "name": "Celestial Revelation: Necrotic Shroud",
+      "description": "While transformed, creatures other than your allies within 10 feet of you must succeed on a Charisma saving throw (DC 8 + your Charisma modifier + your Proficiency Bonus) or be Frightened of you until the end of your next turn. The transformation lasts 1 minute or until you end it (no action required), starts with a Bonus Action, and can be used once per Long Rest."
     },
     "dragonborn-darkvision": {
       "name": "Darkvision (60 ft.)",

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -281,6 +281,11 @@ export interface FeatureChoiceGrant {
   readonly type: 'feature-choice';
   readonly key: ChoiceKey;
   readonly options: readonly [FeatureChoiceOption, ...FeatureChoiceOption[]];
+  // Optional total-character-level gate: the choice is suppressed until the character reaches this
+  // level. Unlike `minClassLevel` (gated against a single class's level), this gates against total
+  // character level — used for species traits that unlock at a character level, e.g. Aasimar
+  // Celestial Revelation at character level 3 (#289). Gated generically in collectBundles.
+  readonly minCharacterLevel?: number;
 }
 
 export interface LineageChoiceGrant {


### PR DESCRIPTION
Closes #289.

## Problem
An Aasimar reaching character level 3 should choose a Celestial Revelation (Heavenly Wings / Inner Radiance / Necrotic Shroud). Instead, Celestial Revelation was a flat `feature` granted at creation — no choice, and no level gate. The engine also had no mechanism to gate a species trait to a *total character level* (only `minClassLevel`, which gates against a single class).

## Fix
- Added `minCharacterLevel` to `FeatureChoiceGrant` and a general `gateGrantsByMinCharacterLevel` gate in `collectBundles` (applies to species/origin sources, complementing `minClassLevel`).
- Converted Aasimar Celestial Revelation into a level-3 `feature-choice` with three options, each with a full 2024-PHB description. It surfaces in the Pending Choices panel at character level 3+ and not before.

## Scope note
The transformation is an activated, transient effect (Bonus Action, 1 min, once per Long Rest). The engine doesn't model activated/temporary speeds or per-turn damage, so the option grants are feature-only and the mechanics live in the descriptions — consistent with other unmodeled activated traits.

## Verification
typecheck ✅ · lint ✅ · test ✅ (2350) · test:bdd ✅ (82/82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)