### PR TITLE
fix(barbarian): restrict weapon mastery choices to melee weapons (#290)

### DIFF
--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -11,7 +11,7 @@ import type { ChoiceKey, ChoiceDecision } from '@/types/choices';
 import type { ResolvedCharacter, PendingChoice, ResolvedSkill } from '@/types/resolved';
 import type { HitDie, ExpertiseChoiceGrant } from '@/types/grants';
 import { mapNonEmpty } from '@/lib/non-empty';
-import type { WeaponMasteryId } from '@/types/items';
+import type { WeaponMasteryId, WeaponRange } from '@/types/items';
 import { collectGrantsByType, getClassLevel } from '@/lib/resolver/helpers';
 import { resolveAbilities } from '@/lib/resolver/abilities';
 import { resolveSavingThrows, resolveSkills, resolveProficiencies } from '@/lib/resolver/proficiencies';
@@ -270,9 +270,12 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
 
   // Aggregate weapon mastery choices — eligible weapons are those the character is proficient with that have a mastery
   const weaponProfSet = new Set(proficiencies.weapon.map((p) => p.value));
-  const eligibleMasteryWeapons = WEAPON_CATALOG.filter(
+  const eligibleMasteryDefs = WEAPON_CATALOG.filter(
     (w) => w.mastery !== undefined && (weaponProfSet.has(w.category) || weaponProfSet.has(w.weaponProficiencyId))
-  ).map((w) => w.id);
+  );
+  // A grant may restrict eligibility by weapon range (#290: Barbarian is melee-only).
+  const eligibleWeaponsForGrant = (range: WeaponRange | undefined): string[] =>
+    eligibleMasteryDefs.filter((w) => range === undefined || w.range === range).map((w) => w.id);
 
   // Emit pending choices for underfilled grants; build resolved weaponMasteries.
   // Iterate grants in stable order (collectGrantsByType preserves bundle/level order from collectBundles).
@@ -283,6 +286,7 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
   for (const { grant, source } of weaponMasteryGrants) {
     const decision = choices[grant.key];
     const rawIds = decision?.type === 'weapon-mastery-choice' ? decision.weaponIds : [];
+    const eligibleMasteryWeapons = eligibleWeaponsForGrant(grant.range);
 
     // Dedupe within the decision, filter to eligible, exclude already claimed by earlier grants
     const seenInDecision = new Set<string>();

--- a/src/lib/sources/classes.test.ts
+++ b/src/lib/sources/classes.test.ts
@@ -415,6 +415,18 @@ describe('Barbarian class grant structures', () => {
     }
   });
 
+  // Regression for #290: Barbarian weapon masteries are restricted to melee weapons.
+  it('every barbarian weapon-mastery-choice grant restricts range to melee', () => {
+    const masteryGrants =
+      source?.levels.flatMap((lvl) => lvl.grants.filter((g) => g.type === 'weapon-mastery-choice')) ?? [];
+    expect(masteryGrants.length).toBeGreaterThan(0);
+    for (const grant of masteryGrants) {
+      if (grant.type === 'weapon-mastery-choice') {
+        expect(grant.range, `grant ${grant.key} should be melee-only`).toBe('melee');
+      }
+    }
+  });
+
   it('level 4 has an ASI (index 0)', () => {
     const grant = source?.levels[3].grants.find((g) => g.type === 'asi');
     expect(grant?.type).toBe('asi');

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -69,6 +69,8 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
           {
             type: 'weapon-mastery-choice',
             key: createChoiceKey('weapon-mastery-choice', 'class', 'barbarian', 0),
+            // 2024 PHB: Barbarian may only master Simple or Martial melee weapons (#290).
+            range: 'melee',
             count: 2,
           },
           {
@@ -105,6 +107,8 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
           {
             type: 'weapon-mastery-choice',
             key: createChoiceKey('weapon-mastery-choice', 'class', 'barbarian', 1),
+            // 2024 PHB: Barbarian may only master Simple or Martial melee weapons (#290).
+            range: 'melee',
             count: 1,
           },
         ],
@@ -129,6 +133,8 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
           {
             type: 'weapon-mastery-choice',
             key: createChoiceKey('weapon-mastery-choice', 'class', 'barbarian', 2),
+            // 2024 PHB: Barbarian may only master Simple or Martial melee weapons (#290).
+            range: 'melee',
             count: 1,
           },
         ],

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -1377,6 +1377,45 @@ describe('gateGrantsByMinClassLevel (issue #189)', () => {
   });
 });
 
+describe('Barbarian weapon masteries are melee-only (#290)', () => {
+  const RANGED_MASTERY_WEAPONS = ['shortbow', 'longbow', 'light-crossbow', 'heavy-crossbow', 'hand-crossbow'];
+
+  const masteryChoiceFrom = (build: CharacterBuild, choiceKey: ChoiceKey): readonly string[] => {
+    const { bundles, expandedFeats } = collectBundles(build);
+    const result = resolveCharacter({
+      baseAbilities: build.baseAbilities,
+      level: build.levels.length,
+      bundles,
+      choices: build.choices,
+      levels: build.levels,
+      expandedFeats,
+    });
+    const pending = result.pendingChoices.find((c) => c.type === 'weapon-mastery-choice' && c.choiceKey === choiceKey);
+    return pending?.type === 'weapon-mastery-choice' ? pending.from : [];
+  };
+
+  it('excludes ranged weapons from a Barbarian mastery choice but keeps melee ones', () => {
+    const barbarianBuild: CharacterBuild = {
+      ...humanFighterL1Build,
+      levels: [{ classId: 'barbarian' as ClassId, classLevel: 1, hpRoll: null }],
+    };
+    const from = masteryChoiceFrom(barbarianBuild, createChoiceKey('weapon-mastery-choice', 'class', 'barbarian', 0));
+    expect(from.length).toBeGreaterThan(0);
+    for (const ranged of RANGED_MASTERY_WEAPONS) {
+      expect(from, `barbarian must not be able to master ranged weapon "${ranged}"`).not.toContain(ranged);
+    }
+    expect(from).toContain('greataxe'); // a martial melee weapon with a mastery
+  });
+
+  it('still allows ranged weapons for a Fighter mastery choice (no range restriction)', () => {
+    const from = masteryChoiceFrom(
+      humanFighterL1Build,
+      createChoiceKey('weapon-mastery-choice', 'class', 'fighter', 0)
+    );
+    expect(from).toContain('longbow');
+  });
+});
+
 describe('gateGrantsByMinCharacterLevel (#289)', () => {
   const speciesSource = { origin: 'species', id: 'aasimar' } as const;
   const bundleWith = (grants: GrantBundle['grants']): GrantBundle => ({ source: speciesSource, grants });

--- a/src/lib/use-all-choice-grants.ts
+++ b/src/lib/use-all-choice-grants.ts
@@ -96,9 +96,12 @@ export function collectChoiceGrantsFromGrants(
       case 'weapon-mastery-choice': {
         if (alreadyClaimedMasteries !== undefined) {
           const weaponProfSet = new Set<string>(resolvedWeaponProficiencies?.map((p) => p.value) ?? []);
+          // A grant may restrict eligibility by weapon range (#290: Barbarian is melee-only).
           const eligibleMasteryWeapons = WEAPON_CATALOG.filter(
             (w) =>
-              w.mastery !== undefined && (weaponProfSet.has(w.category) || weaponProfSet.has(w.weaponProficiencyId))
+              w.mastery !== undefined &&
+              (weaponProfSet.has(w.category) || weaponProfSet.has(w.weaponProficiencyId)) &&
+              (grant.range === undefined || w.range === grant.range)
           ).map((w) => w.id);
 
           const decision = choices[grant.key];

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -11,7 +11,7 @@ import type {
   SpeciesId,
 } from '@/lib/dnd-helpers';
 import type { ChoiceKey } from '@/types/choices';
-import type { BundleCategory } from '@/types/items';
+import type { BundleCategory, WeaponRange } from '@/types/items';
 import type { FeatCategory } from '@/types/sources';
 import type { SpellDef } from '@/types/spells';
 
@@ -248,6 +248,10 @@ export interface WeaponMasteryChoiceGrant {
   readonly type: 'weapon-mastery-choice';
   readonly key: ChoiceKey;
   readonly count: number;
+  // Optional weapon-range restriction. When set, eligible weapons are limited to those with the
+  // given range. The Barbarian may only choose masteries of Simple or Martial *melee* weapons
+  // (`range: 'melee'`), #290. When omitted, weapons of any range are eligible (e.g. Fighter).
+  readonly range?: WeaponRange;
 }
 
 export interface DamageTypeChoiceGrant {


### PR DESCRIPTION
Closes #290.

## Problem
When selecting weapon masteries, a Barbarian could choose ranged weapons. Per the 2024 PHB, a Barbarian may only master **Simple or Martial melee** weapons. The `weapon-mastery-choice` grant carried only a `count`, so the resolver offered every proficient weapon with a mastery — including ranged ones.

## Fix
- Added an optional `range` filter to `WeaponMasteryChoiceGrant`; eligibility is computed per-grant in both the resolver and `use-all-choice-grants` (unset = any range).
- Set `range: 'melee'` on the Barbarian's L1/L4/L10 mastery grants. Fighter/Paladin/Ranger/Rogue are unchanged.

## Tests
- Barbarian eligible masteries exclude ranged (shortbow/longbow/crossbows), keep melee (greataxe).
- Fighter masteries still include ranged (longbow).
- Grant-shape test: every Barbarian mastery grant is `range: 'melee'`.

## Verification
typecheck ✅ · lint ✅ · test ✅ (2355) · test:bdd ✅ (82/82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)