### PR TITLE
feat(builder): Dragonborn lineage table (color, damage type, kind) (#292)

### DIFF
--- a/src/components/character-builder/ChoicePicker.test.tsx
+++ b/src/components/character-builder/ChoicePicker.test.tsx
@@ -778,3 +778,54 @@ describe('ChoicePicker saving-throw-choice', () => {
     expect(onClear).toHaveBeenCalledWith(SAVE_CHOICE.choiceKey);
   });
 });
+
+// ---------------------------------------------------------------------------
+// ChoicePicker — lineage-choice branch (Dragonborn table, #292)
+// ---------------------------------------------------------------------------
+
+const DRAGONBORN_LINEAGE_CHOICE: PendingChoice & { type: 'lineage-choice' } = {
+  type: 'lineage-choice',
+  choiceKey: 'lineage-choice:species:dragonborn:0' as ChoiceKey,
+  source: { origin: 'species', id: 'dragonborn' },
+  speciesId: 'dragonborn',
+  from: ['chromatic-black', 'metallic-gold'],
+};
+
+describe('ChoicePicker lineage-choice (Dragonborn table)', () => {
+  it('renders a table (not a flat radio list) for Dragonborn', () => {
+    render(
+      <ChoicePicker choice={DRAGONBORN_LINEAGE_CHOICE} currentDecision={undefined} onDecide={vi.fn()} onClear={vi.fn()} />
+    );
+    expect(screen.getByRole('table')).toBeTruthy();
+    // damage-type cells present (segment-returning mock yields the damageTypes.<id> tail)
+    expect(screen.getByText('acid')).toBeTruthy(); // chromatic-black
+    expect(screen.getByText('fire')).toBeTruthy(); // metallic-gold
+  });
+
+  it('selecting a row calls onDecide with the lineageId', () => {
+    const onDecide = vi.fn();
+    render(
+      <ChoicePicker choice={DRAGONBORN_LINEAGE_CHOICE} currentDecision={undefined} onDecide={onDecide} onClear={vi.fn()} />
+    );
+    fireEvent.click(screen.getAllByRole('radio')[0]);
+    expect(onDecide).toHaveBeenCalledWith(DRAGONBORN_LINEAGE_CHOICE.choiceKey, {
+      type: 'lineage-choice',
+      lineageId: 'chromatic-black',
+    });
+  });
+
+  it('offers a clear button once a lineage is selected', () => {
+    const onClear = vi.fn();
+    const currentDecision: ChoiceDecision = { type: 'lineage-choice', lineageId: 'metallic-gold' };
+    render(
+      <ChoicePicker
+        choice={DRAGONBORN_LINEAGE_CHOICE}
+        currentDecision={currentDecision}
+        onDecide={vi.fn()}
+        onClear={onClear}
+      />
+    );
+    fireEvent.click(screen.getByText('clearSelection'));
+    expect(onClear).toHaveBeenCalledWith(DRAGONBORN_LINEAGE_CHOICE.choiceKey);
+  });
+});

--- a/src/components/character-builder/ChoicePicker.tsx
+++ b/src/components/character-builder/ChoicePicker.tsx
@@ -25,6 +25,7 @@ import type { ChoiceDecision, ChoiceKey } from '@/types/choices';
 import type { BundleSlot, ItemDef, SlotFilter } from '@/types/items';
 import type { PendingChoice } from '@/types/resolved';
 import { getGrantIcon } from '@/lib/class-icons';
+import { DragonbornLineageTable } from './DragonbornLineageTable';
 import type { TFunction } from 'i18next';
 import type { LucideIcon } from 'lucide-react';
 import { useTranslation } from 'react-i18next';
@@ -279,6 +280,25 @@ export function ChoicePicker({
   if (choice.type === 'lineage-choice') {
     const { speciesId, from } = choice;
     const currentLineageId = currentDecision?.type === 'lineage-choice' ? currentDecision.lineageId : undefined;
+
+    // Dragonborn: render the color / damage type / kind table (#292), consistent with the builder.
+    if (speciesId === 'dragonborn') {
+      return (
+        <div className="space-y-2">
+          <DragonbornLineageTable
+            choiceKey={choice.choiceKey}
+            from={from}
+            currentLineageId={currentLineageId}
+            onSelect={(lineageId) => onDecide(choice.choiceKey, { type: 'lineage-choice', lineageId })}
+          />
+          {currentLineageId !== undefined && (
+            <Button variant="ghost" size="sm" onClick={() => onClear(choice.choiceKey)}>
+              {tc('characterBuilder.equipment.clearSelection')}
+            </Button>
+          )}
+        </div>
+      );
+    }
 
     return (
       <div className="space-y-2">

--- a/src/components/character-builder/DragonbornLineageTable.tsx
+++ b/src/components/character-builder/DragonbornLineageTable.tsx
@@ -1,0 +1,88 @@
+import { DRAGONBORN_LINEAGE_DAMAGE } from '@/lib/sources/species';
+import type { ChoiceKey } from '@/types/choices';
+import { useTranslation } from 'react-i18next';
+
+interface DragonbornLineageTableProps {
+  readonly choiceKey: ChoiceKey;
+  readonly from: readonly string[];
+  readonly currentLineageId: string | undefined;
+  readonly onSelect: (lineageId: string) => void;
+}
+
+/**
+ * Renders the Dragonborn lineage choice as a table (dragon color, damage type, and
+ * chromatic-vs-metallic kind) rather than a flat radio list (#292). Each row is selectable.
+ * Shared by the builder's LineagePicker and the character sheet's ChoicePicker so the
+ * layout is consistent wherever a Dragonborn lineage is chosen.
+ */
+export function DragonbornLineageTable({ choiceKey, from, currentLineageId, onSelect }: DragonbornLineageTableProps) {
+  const { t: tc } = useTranslation('common');
+  const { t: tg } = useTranslation('gamedata');
+
+  return (
+    <div className="mt-2 space-y-2">
+      <p className="text-sm text-muted-foreground">{tc('characterBuilder.pendingChoices.lineageChoice')}</p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-muted-foreground">
+              <th className="w-8 py-1.5" scope="col">
+                <span className="sr-only">{tc('characterBuilder.pendingChoices.lineageChoice')}</span>
+              </th>
+              <th className="py-1.5 pr-3 font-medium" scope="col">
+                {tc('characterBuilder.pendingChoices.lineageTable.dragon')}
+              </th>
+              <th className="py-1.5 pr-3 font-medium" scope="col">
+                {tc('characterBuilder.pendingChoices.lineageTable.damageType')}
+              </th>
+              <th className="py-1.5 pr-3 font-medium" scope="col">
+                {tc('characterBuilder.pendingChoices.lineageTable.kind')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {from.map((lineageId) => {
+              const radioId = `choice-lineage-${choiceKey}-${lineageId}`;
+              const kind = lineageId.split('-')[0];
+              const colorLabel = tg(`lineages.dragonborn.${lineageId}` as `lineages.dragonborn.${string}`, {
+                defaultValue: lineageId,
+              });
+              const damageId = DRAGONBORN_LINEAGE_DAMAGE[lineageId];
+              const damageLabel = damageId ? tg(`damageTypes.${damageId}` as `damageTypes.${typeof damageId}`) : '—';
+              const kindLabel = tg(`dragonKinds.${kind}` as `dragonKinds.chromatic` | `dragonKinds.metallic`, {
+                defaultValue: kind,
+              });
+              const selected = currentLineageId === lineageId;
+              return (
+                <tr
+                  key={lineageId}
+                  className={`border-b border-border/50 transition-colors hover:bg-muted/50 ${
+                    selected ? 'bg-muted/50' : ''
+                  }`}
+                >
+                  <td className="py-1.5">
+                    <input
+                      type="radio"
+                      id={radioId}
+                      name={`choice-lineage-${choiceKey}`}
+                      checked={selected}
+                      onChange={() => onSelect(lineageId)}
+                      className="size-4 text-primary"
+                    />
+                  </td>
+                  <td className="py-1.5 pr-3">
+                    <label htmlFor={radioId} className="block cursor-pointer font-medium">
+                      {colorLabel}
+                    </label>
+                  </td>
+                  <td className="py-1.5 pr-3 text-muted-foreground">{damageLabel}</td>
+                  <td className="py-1.5 pr-3 text-muted-foreground">{kindLabel}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
+}

--- a/src/components/character-builder/LineagePicker.test.tsx
+++ b/src/components/character-builder/LineagePicker.test.tsx
@@ -1,0 +1,155 @@
+import { describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { LineagePicker } from '@/components/character-builder/LineagePicker';
+import type { GrantBundle } from '@/types/sources';
+import { createChoiceKey } from '@/types/choices';
+import type { ChoiceDecision } from '@/types/choices';
+
+// Segment-returning i18n mock (matches the other character-builder component tests):
+// t('a.b.c') -> 'c', unless a defaultValue is provided.
+vi.mock('react-i18next', () => ({
+  useTranslation: () => ({
+    t: (key: string, opts?: Record<string, unknown>) => {
+      if (opts && typeof opts.defaultValue === 'string') return opts.defaultValue;
+      const segs = key.split('.');
+      return segs[segs.length - 1];
+    },
+    i18n: { language: 'en' },
+  }),
+}));
+
+const DRAGONBORN_LINEAGE_KEY = createChoiceKey('lineage-choice', 'species', 'dragonborn', 0);
+
+function dragonbornBundles(): GrantBundle[] {
+  return [
+    {
+      source: { origin: 'species', id: 'dragonborn' },
+      grants: [
+        {
+          type: 'lineage-choice',
+          key: DRAGONBORN_LINEAGE_KEY,
+          speciesId: 'dragonborn',
+          from: [
+            'chromatic-black',
+            'chromatic-blue',
+            'chromatic-green',
+            'chromatic-red',
+            'chromatic-white',
+            'metallic-brass',
+            'metallic-bronze',
+            'metallic-copper',
+            'metallic-gold',
+            'metallic-silver',
+          ],
+        },
+      ],
+    },
+  ];
+}
+
+describe('LineagePicker — Dragonborn table (#292)', () => {
+  it('renders a table with Dragon / Damage Type / Kind columns', () => {
+    render(
+      <LineagePicker
+        race="dragonborn"
+        bundles={dragonbornBundles()}
+        build={{ choices: {} }}
+        makeChoice={vi.fn()}
+        clearChoice={vi.fn()}
+      />
+    );
+    const table = screen.getByRole('table');
+    expect(table).toBeTruthy();
+    // Column headers (segment-returning mock yields the last key segment).
+    expect(within(table).getByText('dragon')).toBeTruthy();
+    expect(within(table).getByText('damageType')).toBeTruthy();
+    expect(within(table).getByText('kind')).toBeTruthy();
+  });
+
+  it('renders one selectable row per lineage (10) with damage type and kind cells', () => {
+    render(
+      <LineagePicker
+        race="dragonborn"
+        bundles={dragonbornBundles()}
+        build={{ choices: {} }}
+        makeChoice={vi.fn()}
+        clearChoice={vi.fn()}
+      />
+    );
+    const radios = screen.getAllByRole('radio');
+    expect(radios).toHaveLength(10);
+    // Damage types present (mock returns the damageTypes.<id> segment, e.g. "acid", "poison").
+    expect(screen.getAllByText('acid').length).toBeGreaterThan(0); // black + copper
+    expect(screen.getByText('poison')).toBeTruthy(); // green
+    // Kind labels present.
+    expect(screen.getAllByText('chromatic').length).toBe(5);
+    expect(screen.getAllByText('metallic').length).toBe(5);
+  });
+
+  it('calls makeChoice with the selected lineage when a row radio is clicked', () => {
+    const makeChoice = vi.fn();
+    render(
+      <LineagePicker
+        race="dragonborn"
+        bundles={dragonbornBundles()}
+        build={{ choices: {} }}
+        makeChoice={makeChoice}
+        clearChoice={vi.fn()}
+      />
+    );
+    const redRadio = document.getElementById(`choice-lineage-${DRAGONBORN_LINEAGE_KEY}-chromatic-red`);
+    expect(redRadio).toBeTruthy();
+    fireEvent.click(redRadio!);
+    expect(makeChoice).toHaveBeenCalledWith(DRAGONBORN_LINEAGE_KEY, {
+      type: 'lineage-choice',
+      lineageId: 'chromatic-red',
+    });
+  });
+
+  it('reflects the current selection as checked', () => {
+    render(
+      <LineagePicker
+        race="dragonborn"
+        bundles={dragonbornBundles()}
+        build={{
+          choices: {
+            [DRAGONBORN_LINEAGE_KEY]: { type: 'lineage-choice', lineageId: 'metallic-gold' } as ChoiceDecision,
+          },
+        }}
+        makeChoice={vi.fn()}
+        clearChoice={vi.fn()}
+      />
+    );
+    const goldRadio = document.getElementById(
+      `choice-lineage-${DRAGONBORN_LINEAGE_KEY}-metallic-gold`
+    ) as HTMLInputElement | null;
+    expect(goldRadio?.checked).toBe(true);
+  });
+
+  it('does not render a table for a non-dragonborn species (falls back to radio list)', () => {
+    const elfBundles: GrantBundle[] = [
+      {
+        source: { origin: 'species', id: 'elf' },
+        grants: [
+          {
+            type: 'lineage-choice',
+            key: createChoiceKey('lineage-choice', 'species', 'elf', 0),
+            speciesId: 'elf',
+            from: ['drow', 'high-elf', 'wood-elf'],
+          },
+        ],
+      },
+    ];
+    render(
+      <LineagePicker
+        race="elf"
+        bundles={elfBundles}
+        build={{ choices: {} }}
+        makeChoice={vi.fn()}
+        clearChoice={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole('table')).toBeNull();
+    expect(screen.getAllByRole('radio')).toHaveLength(3);
+  });
+});

--- a/src/components/character-builder/LineagePicker.test.tsx
+++ b/src/components/character-builder/LineagePicker.test.tsx
@@ -126,6 +126,25 @@ describe('LineagePicker — Dragonborn table (#292)', () => {
     expect(goldRadio?.checked).toBe(true);
   });
 
+  it('offers a clear button once a lineage is selected and wires it to clearChoice', () => {
+    const clearChoice = vi.fn();
+    render(
+      <LineagePicker
+        race="dragonborn"
+        bundles={dragonbornBundles()}
+        build={{
+          choices: {
+            [DRAGONBORN_LINEAGE_KEY]: { type: 'lineage-choice', lineageId: 'chromatic-red' } as ChoiceDecision,
+          },
+        }}
+        makeChoice={vi.fn()}
+        clearChoice={clearChoice}
+      />
+    );
+    fireEvent.click(screen.getByText('clearSelection'));
+    expect(clearChoice).toHaveBeenCalledWith(DRAGONBORN_LINEAGE_KEY);
+  });
+
   it('does not render a table for a non-dragonborn species (falls back to radio list)', () => {
     const elfBundles: GrantBundle[] = [
       {

--- a/src/components/character-builder/LineagePicker.tsx
+++ b/src/components/character-builder/LineagePicker.tsx
@@ -1,11 +1,12 @@
 import { collectGrantsByType } from '@/lib/resolver/helpers';
-import { DRAGONBORN_LINEAGE_DAMAGE, LINEAGE_GRANTS_REGISTRY } from '@/lib/sources/species';
+import { LINEAGE_GRANTS_REGISTRY } from '@/lib/sources/species';
 import type { SpeciesId } from '@/lib/dnd-helpers';
 import type { ChoiceDecision, ChoiceKey } from '@/types/choices';
 import type { PendingChoice } from '@/types/resolved';
 import type { GrantBundle } from '@/types/sources';
 import { useTranslation } from 'react-i18next';
 import { ChoicePicker } from './ChoicePicker';
+import { DragonbornLineageTable } from './DragonbornLineageTable';
 
 interface LineagePickerProps {
   readonly race: SpeciesId;
@@ -13,92 +14,6 @@ interface LineagePickerProps {
   readonly build: { choices: Record<ChoiceKey, ChoiceDecision> } | null;
   readonly makeChoice: (key: ChoiceKey, decision: ChoiceDecision) => void;
   readonly clearChoice: (key: ChoiceKey) => void;
-}
-
-/**
- * Renders the Dragonborn lineage choice as a table (dragon color, damage type, and
- * chromatic-vs-metallic kind) rather than a flat radio list (#292). Each row is selectable.
- */
-function DragonbornLineageTable({
-  choiceKey,
-  from,
-  currentLineageId,
-  onSelect,
-}: {
-  readonly choiceKey: ChoiceKey;
-  readonly from: readonly string[];
-  readonly currentLineageId: string | undefined;
-  readonly onSelect: (lineageId: string) => void;
-}) {
-  const { t: tc } = useTranslation('common');
-  const { t: tg } = useTranslation('gamedata');
-
-  return (
-    <div className="mt-2 space-y-2">
-      <p className="text-sm text-muted-foreground">{tc('characterBuilder.pendingChoices.lineageChoice')}</p>
-      <div className="overflow-x-auto">
-        <table className="w-full text-sm">
-          <thead>
-            <tr className="border-b text-left text-muted-foreground">
-              <th className="w-8 py-1.5" scope="col">
-                <span className="sr-only">{tc('characterBuilder.pendingChoices.lineageChoice')}</span>
-              </th>
-              <th className="py-1.5 pr-3 font-medium" scope="col">
-                {tc('characterBuilder.pendingChoices.lineageTable.dragon')}
-              </th>
-              <th className="py-1.5 pr-3 font-medium" scope="col">
-                {tc('characterBuilder.pendingChoices.lineageTable.damageType')}
-              </th>
-              <th className="py-1.5 pr-3 font-medium" scope="col">
-                {tc('characterBuilder.pendingChoices.lineageTable.kind')}
-              </th>
-            </tr>
-          </thead>
-          <tbody>
-            {from.map((lineageId) => {
-              const radioId = `choice-lineage-${choiceKey}-${lineageId}`;
-              const kind = lineageId.split('-')[0];
-              const colorLabel = tg(`lineages.dragonborn.${lineageId}` as `lineages.dragonborn.${string}`, {
-                defaultValue: lineageId,
-              });
-              const damageId = DRAGONBORN_LINEAGE_DAMAGE[lineageId];
-              const damageLabel = damageId ? tg(`damageTypes.${damageId}` as `damageTypes.${typeof damageId}`) : '—';
-              const kindLabel = tg(`dragonKinds.${kind}` as `dragonKinds.chromatic` | `dragonKinds.metallic`, {
-                defaultValue: kind,
-              });
-              const selected = currentLineageId === lineageId;
-              return (
-                <tr
-                  key={lineageId}
-                  className={`border-b border-border/50 transition-colors hover:bg-muted/50 ${
-                    selected ? 'bg-muted/50' : ''
-                  }`}
-                >
-                  <td className="py-1.5">
-                    <input
-                      type="radio"
-                      id={radioId}
-                      name={`choice-lineage-${choiceKey}`}
-                      checked={selected}
-                      onChange={() => onSelect(lineageId)}
-                      className="size-4 text-primary"
-                    />
-                  </td>
-                  <td className="py-1.5 pr-3">
-                    <label htmlFor={radioId} className="block cursor-pointer font-medium">
-                      {colorLabel}
-                    </label>
-                  </td>
-                  <td className="py-1.5 pr-3 text-muted-foreground">{damageLabel}</td>
-                  <td className="py-1.5 pr-3 text-muted-foreground">{kindLabel}</td>
-                </tr>
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
 }
 
 export function LineagePicker({ race, bundles, build, makeChoice, clearChoice }: LineagePickerProps) {

--- a/src/components/character-builder/LineagePicker.tsx
+++ b/src/components/character-builder/LineagePicker.tsx
@@ -1,5 +1,5 @@
 import { collectGrantsByType } from '@/lib/resolver/helpers';
-import { LINEAGE_GRANTS_REGISTRY } from '@/lib/sources/species';
+import { DRAGONBORN_LINEAGE_DAMAGE, LINEAGE_GRANTS_REGISTRY } from '@/lib/sources/species';
 import type { SpeciesId } from '@/lib/dnd-helpers';
 import type { ChoiceDecision, ChoiceKey } from '@/types/choices';
 import type { PendingChoice } from '@/types/resolved';
@@ -13,6 +13,92 @@ interface LineagePickerProps {
   readonly build: { choices: Record<ChoiceKey, ChoiceDecision> } | null;
   readonly makeChoice: (key: ChoiceKey, decision: ChoiceDecision) => void;
   readonly clearChoice: (key: ChoiceKey) => void;
+}
+
+/**
+ * Renders the Dragonborn lineage choice as a table (dragon color, damage type, and
+ * chromatic-vs-metallic kind) rather than a flat radio list (#292). Each row is selectable.
+ */
+function DragonbornLineageTable({
+  choiceKey,
+  from,
+  currentLineageId,
+  onSelect,
+}: {
+  readonly choiceKey: ChoiceKey;
+  readonly from: readonly string[];
+  readonly currentLineageId: string | undefined;
+  readonly onSelect: (lineageId: string) => void;
+}) {
+  const { t: tc } = useTranslation('common');
+  const { t: tg } = useTranslation('gamedata');
+
+  return (
+    <div className="mt-2 space-y-2">
+      <p className="text-sm text-muted-foreground">{tc('characterBuilder.pendingChoices.lineageChoice')}</p>
+      <div className="overflow-x-auto">
+        <table className="w-full text-sm">
+          <thead>
+            <tr className="border-b text-left text-muted-foreground">
+              <th className="w-8 py-1.5" scope="col">
+                <span className="sr-only">{tc('characterBuilder.pendingChoices.lineageChoice')}</span>
+              </th>
+              <th className="py-1.5 pr-3 font-medium" scope="col">
+                {tc('characterBuilder.pendingChoices.lineageTable.dragon')}
+              </th>
+              <th className="py-1.5 pr-3 font-medium" scope="col">
+                {tc('characterBuilder.pendingChoices.lineageTable.damageType')}
+              </th>
+              <th className="py-1.5 pr-3 font-medium" scope="col">
+                {tc('characterBuilder.pendingChoices.lineageTable.kind')}
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {from.map((lineageId) => {
+              const radioId = `choice-lineage-${choiceKey}-${lineageId}`;
+              const kind = lineageId.split('-')[0];
+              const colorLabel = tg(`lineages.dragonborn.${lineageId}` as `lineages.dragonborn.${string}`, {
+                defaultValue: lineageId,
+              });
+              const damageId = DRAGONBORN_LINEAGE_DAMAGE[lineageId];
+              const damageLabel = damageId ? tg(`damageTypes.${damageId}` as `damageTypes.${typeof damageId}`) : '—';
+              const kindLabel = tg(`dragonKinds.${kind}` as `dragonKinds.chromatic` | `dragonKinds.metallic`, {
+                defaultValue: kind,
+              });
+              const selected = currentLineageId === lineageId;
+              return (
+                <tr
+                  key={lineageId}
+                  className={`border-b border-border/50 transition-colors hover:bg-muted/50 ${
+                    selected ? 'bg-muted/50' : ''
+                  }`}
+                >
+                  <td className="py-1.5">
+                    <input
+                      type="radio"
+                      id={radioId}
+                      name={`choice-lineage-${choiceKey}`}
+                      checked={selected}
+                      onChange={() => onSelect(lineageId)}
+                      className="size-4 text-primary"
+                    />
+                  </td>
+                  <td className="py-1.5 pr-3">
+                    <label htmlFor={radioId} className="block cursor-pointer font-medium">
+                      {colorLabel}
+                    </label>
+                  </td>
+                  <td className="py-1.5 pr-3 text-muted-foreground">{damageLabel}</td>
+                  <td className="py-1.5 pr-3 text-muted-foreground">{kindLabel}</td>
+                </tr>
+              );
+            })}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  );
 }
 
 export function LineagePicker({ race, bundles, build, makeChoice, clearChoice }: LineagePickerProps) {
@@ -29,6 +115,22 @@ export function LineagePicker({ race, bundles, build, makeChoice, clearChoice }:
     return <p className="text-sm text-muted-foreground">{tc('characterBuilder.hints.loadingLineage')}</p>;
   }
 
+  const decision = build?.choices[lineageTag.grant.key];
+  const currentLineageId = decision?.type === 'lineage-choice' ? decision.lineageId : undefined;
+
+  // Dragonborn: render a table of dragon color / damage type / kind (#292).
+  if (race === 'dragonborn') {
+    return (
+      <DragonbornLineageTable
+        choiceKey={lineageTag.grant.key}
+        from={lineageTag.grant.from}
+        currentLineageId={currentLineageId}
+        onSelect={(lineageId) => makeChoice(lineageTag.grant.key, { type: 'lineage-choice', lineageId })}
+      />
+    );
+  }
+
+  // Other species: flat radio list via the shared ChoicePicker.
   const lineageChoice: PendingChoice & { type: 'lineage-choice' } = {
     type: 'lineage-choice',
     choiceKey: lineageTag.grant.key,
@@ -36,7 +138,6 @@ export function LineagePicker({ race, bundles, build, makeChoice, clearChoice }:
     speciesId: race,
     from: lineageTag.grant.from,
   };
-  const decision = build?.choices[lineageTag.grant.key];
 
   return (
     <div className="mt-2">

--- a/src/components/character-builder/LineagePicker.tsx
+++ b/src/components/character-builder/LineagePicker.tsx
@@ -5,6 +5,7 @@ import type { ChoiceDecision, ChoiceKey } from '@/types/choices';
 import type { PendingChoice } from '@/types/resolved';
 import type { GrantBundle } from '@/types/sources';
 import { useTranslation } from 'react-i18next';
+import { Button } from '@/components/ui/button';
 import { ChoicePicker } from './ChoicePicker';
 import { DragonbornLineageTable } from './DragonbornLineageTable';
 
@@ -36,12 +37,19 @@ export function LineagePicker({ race, bundles, build, makeChoice, clearChoice }:
   // Dragonborn: render a table of dragon color / damage type / kind (#292).
   if (race === 'dragonborn') {
     return (
-      <DragonbornLineageTable
-        choiceKey={lineageTag.grant.key}
-        from={lineageTag.grant.from}
-        currentLineageId={currentLineageId}
-        onSelect={(lineageId) => makeChoice(lineageTag.grant.key, { type: 'lineage-choice', lineageId })}
-      />
+      <div className="space-y-2">
+        <DragonbornLineageTable
+          choiceKey={lineageTag.grant.key}
+          from={lineageTag.grant.from}
+          currentLineageId={currentLineageId}
+          onSelect={(lineageId) => makeChoice(lineageTag.grant.key, { type: 'lineage-choice', lineageId })}
+        />
+        {currentLineageId !== undefined && (
+          <Button variant="ghost" size="sm" onClick={() => clearChoice(lineageTag.grant.key)}>
+            {tc('characterBuilder.equipment.clearSelection')}
+          </Button>
+        )}
+      </div>
     );
   }
 

--- a/src/components/character-sheet/CharacterSheetHeader.tsx
+++ b/src/components/character-sheet/CharacterSheetHeader.tsx
@@ -45,6 +45,22 @@ export function CharacterSheetHeader({
     return decision.type === 'lineage-choice' ? decision.lineageId : null;
   })();
 
+  // Display label for the lineage. For Dragonborn the label is just the dragon color
+  // (e.g. "Black"), so append the chromatic/metallic kind to keep that context on the
+  // sheet — the builder shows it as a separate column (#292).
+  const lineageLabel: string | null = (() => {
+    if (!lineageId || !character.species) return null;
+    const base = t(`lineages.${character.species}.${lineageId}`, { defaultValue: lineageId });
+    if (character.species === 'dragonborn') {
+      const kind = lineageId.split('-')[0];
+      const kindLabel = t(`dragonKinds.${kind}` as 'dragonKinds.chromatic' | 'dragonKinds.metallic', {
+        defaultValue: '',
+      });
+      return kindLabel ? `${base} (${kindLabel})` : base;
+    }
+    return base;
+  })();
+
   // Origin feat: derive badge info from the background source's grants.
   // deriveOriginFeatInfo handles both shapes (feat grant and direct feat-magic-initiate-* feature).
   const originFeatInfo = (() => {
@@ -125,11 +141,7 @@ export function CharacterSheetHeader({
           <p className="text-foreground font-semibold">
             {character.species ? t(`species.${character.species}`, { defaultValue: character.species }) : ''}
           </p>
-          {lineageId && character.species && (
-            <p className="text-xs text-muted-foreground mt-0.5">
-              {t(`lineages.${character.species}.${lineageId}`, { defaultValue: lineageId })}
-            </p>
-          )}
+          {lineageLabel && <p className="text-xs text-muted-foreground mt-0.5">{lineageLabel}</p>}
         </div>
         <div>
           <span className="text-muted-foreground">{tc('characterSheet.fields.background')}</span>

--- a/src/lib/sources/species.test.ts
+++ b/src/lib/sources/species.test.ts
@@ -3,6 +3,7 @@ import { getSpeciesSource } from '@/lib/sources';
 import {
   SPECIES_SOURCES,
   DRAGONBORN_LINEAGE_GRANTS,
+  DRAGONBORN_LINEAGE_DAMAGE,
   GOLIATH_ANCESTRY_GRANTS,
   TIEFLING_LINEAGE_GRANTS,
   ELF_LINEAGE_GRANTS,
@@ -473,6 +474,30 @@ describe('Dragonborn species source (2024 PHB)', () => {
       expect(features).toHaveLength(2);
       const featureIds = features.map((g) => g.type === 'feature' && g.feature.id);
       expect(featureIds).toContain(`dragonborn-breath-${lineageId}`);
+    }
+  });
+
+  // #292: damage-type map used by the lineage table, derived from each lineage's resistance grant.
+  it('DRAGONBORN_LINEAGE_DAMAGE maps every lineage to its 2024 PHB damage type', () => {
+    expect(DRAGONBORN_LINEAGE_DAMAGE).toEqual({
+      'chromatic-black': 'acid',
+      'chromatic-blue': 'lightning',
+      'chromatic-green': 'poison',
+      'chromatic-red': 'fire',
+      'chromatic-white': 'cold',
+      'metallic-brass': 'fire',
+      'metallic-bronze': 'lightning',
+      'metallic-copper': 'acid',
+      'metallic-gold': 'fire',
+      'metallic-silver': 'cold',
+    });
+  });
+
+  it('DRAGONBORN_LINEAGE_DAMAGE damage type matches each lineage resistance grant', () => {
+    for (const [lineageId, grants] of Object.entries(DRAGONBORN_LINEAGE_GRANTS)) {
+      const resistance = grants!.find((g) => g.type === 'resistance');
+      const damageType = resistance?.type === 'resistance' ? resistance.damageType : undefined;
+      expect(DRAGONBORN_LINEAGE_DAMAGE[lineageId]).toBe(damageType);
     }
   });
 

--- a/src/lib/sources/species.ts
+++ b/src/lib/sources/species.ts
@@ -1,5 +1,5 @@
 import type { SpeciesSource } from '@/types/sources';
-import type { Grant } from '@/types/grants';
+import type { DamageTypeId, Grant } from '@/types/grants';
 import type { SpeciesId } from '@/lib/dnd-helpers';
 import { createChoiceKey } from '@/types/choices';
 
@@ -57,6 +57,16 @@ export const DRAGONBORN_LINEAGE_GRANTS: Readonly<Partial<Record<string, readonly
     { type: 'feature', feature: { id: 'dragonborn-breath-metallic-silver' } },
   ],
 } as const;
+
+// Damage type per Dragonborn lineage, derived from each lineage's `resistance` grant — the
+// single source of truth (in the 2024 PHB, a Dragonborn's Breath Weapon and Damage Resistance
+// share the ancestry's damage type). Used to render the lineage table (#292).
+export const DRAGONBORN_LINEAGE_DAMAGE: Readonly<Record<string, DamageTypeId>> = Object.fromEntries(
+  Object.entries(DRAGONBORN_LINEAGE_GRANTS).flatMap(([id, grants]) => {
+    const resistance = grants?.find((g) => g.type === 'resistance');
+    return resistance && resistance.type === 'resistance' ? [[id, resistance.damageType] as const] : [];
+  })
+);
 
 // Per-ancestry sub-grants for Goliath. Keyed by giant ancestry ID.
 export const GOLIATH_ANCESTRY_GRANTS: Readonly<Partial<Record<string, readonly Grant[]>>> = {

--- a/src/locales/en/common.json
+++ b/src/locales/en/common.json
@@ -169,7 +169,12 @@
       "featureChoice": "Choose an option",
       "unsupported": "Choice not yet supported: {{type}}",
       "remaining": "remaining",
-      "fromSource": "from {{source}}"
+      "fromSource": "from {{source}}",
+      "lineageTable": {
+        "dragon": "Dragon",
+        "damageType": "Damage Type",
+        "kind": "Kind"
+      }
     },
     "finalizeBlockers": {
       "title": "Before you can finalize:",

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -2271,18 +2271,22 @@
     "pack": "Pack",
     "gear": "Gear"
   },
+  "dragonKinds": {
+    "chromatic": "Chromatic",
+    "metallic": "Metallic"
+  },
   "lineages": {
     "dragonborn": {
-      "chromatic-black": "Chromatic (Black)",
-      "chromatic-blue": "Chromatic (Blue)",
-      "chromatic-green": "Chromatic (Green)",
-      "chromatic-red": "Chromatic (Red)",
-      "chromatic-white": "Chromatic (White)",
-      "metallic-brass": "Metallic (Brass)",
-      "metallic-bronze": "Metallic (Bronze)",
-      "metallic-copper": "Metallic (Copper)",
-      "metallic-gold": "Metallic (Gold)",
-      "metallic-silver": "Metallic (Silver)"
+      "chromatic-black": "Black",
+      "chromatic-blue": "Blue",
+      "chromatic-green": "Green",
+      "chromatic-red": "Red",
+      "chromatic-white": "White",
+      "metallic-brass": "Brass",
+      "metallic-bronze": "Bronze",
+      "metallic-copper": "Copper",
+      "metallic-gold": "Gold",
+      "metallic-silver": "Silver"
     },
     "tiefling": {
       "abyssal": "Abyssal",


### PR DESCRIPTION
Closes #292.

Per arovani's direction: "Change the layout to a table to display the dragon color, damage type, and flavor grouping of chromatic vs metallic."

## Changes
- `LineagePicker` now renders the Dragonborn lineage choice as a **table** with columns **Dragon** (color), **Damage Type**, and **Kind** (Chromatic/Metallic); each row is a selectable radio. Other species keep the existing radio list.
- Damage type is derived from each lineage's existing `resistance` grant (single source of truth) via a new `DRAGONBORN_LINEAGE_DAMAGE` map — no duplicated data.
- Simplified the `lineages.dragonborn.*` labels to plain dragon colors ("Black", "Blue", …) to match the 2024 PHB table; added `dragonKinds` (Chromatic/Metallic) and table-header i18n keys.

## Tests
- Data: `DRAGONBORN_LINEAGE_DAMAGE` maps every lineage to its PHB damage type and matches each lineage's resistance grant.
- Component: table renders 10 selectable rows with damage/kind cells, selection calls `makeChoice`, current selection reflected, non-dragonborn species fall back to the radio list.

## Verification
typecheck ✅ · lint ✅ · test ✅ (2378) · test:bdd ✅ (82/82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)