### PR TITLE
fix(species): Aasimar gains all three Celestial Revelations, chosen per use (#301)

### DIFF
--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -1419,21 +1419,20 @@ describe('Barbarian weapon masteries are melee-only (#290)', () => {
 describe('gateGrantsByMinCharacterLevel (#289)', () => {
   const speciesSource = { origin: 'species', id: 'aasimar' } as const;
   const bundleWith = (grants: GrantBundle['grants']): GrantBundle => ({ source: speciesSource, grants });
-  const revelationChoice: Grant = {
-    type: 'feature-choice',
-    key: createChoiceKey('feature-choice', 'species', 'aasimar', 0),
+  const revelationFeature: Grant = {
+    type: 'feature',
     minCharacterLevel: 3,
-    options: [{ optionId: 'inner-radiance', featureId: 'aasimar-celestial-revelation-inner-radiance', grants: [] }],
+    feature: { id: 'aasimar-celestial-revelation-inner-radiance' },
   };
 
   it('drops a minCharacterLevel:3 grant below character level 3', () => {
-    const out = gateGrantsByMinCharacterLevel([bundleWith([revelationChoice])], 2);
+    const out = gateGrantsByMinCharacterLevel([bundleWith([revelationFeature])], 2);
     expect(out[0].grants).toHaveLength(0);
   });
 
   it('keeps a minCharacterLevel:3 grant at character level 3 and above', () => {
-    expect(gateGrantsByMinCharacterLevel([bundleWith([revelationChoice])], 3)[0].grants).toHaveLength(1);
-    expect(gateGrantsByMinCharacterLevel([bundleWith([revelationChoice])], 5)[0].grants).toHaveLength(1);
+    expect(gateGrantsByMinCharacterLevel([bundleWith([revelationFeature])], 3)[0].grants).toHaveLength(1);
+    expect(gateGrantsByMinCharacterLevel([bundleWith([revelationFeature])], 5)[0].grants).toHaveLength(1);
   });
 
   it('leaves grants without minCharacterLevel untouched (identity-preserving)', () => {
@@ -1442,28 +1441,47 @@ describe('gateGrantsByMinCharacterLevel (#289)', () => {
   });
 });
 
-describe('Aasimar Celestial Revelation surfacing by character level (#289)', () => {
+describe('Aasimar Celestial Revelation by character level (#289, #301)', () => {
   const aasimarFighterBuild = (numLevels: number): CharacterBuild => ({
     ...humanFighterL1Build,
     speciesId: 'aasimar' as SpeciesId,
     levels: Array.from({ length: numLevels }, () => ({ classId: 'fighter' as ClassId, classLevel: 1, hpRoll: null })),
   });
 
-  const revelationKey = createChoiceKey('feature-choice', 'species', 'aasimar', 0);
+  // #301: Celestial Revelation grants ALL THREE transformations (chosen per use), not a
+  // one-time build choice — so there is no pending feature-choice; the features are simply
+  // granted at character level 3.
+  const CELESTIAL_IDS = [
+    'aasimar-celestial-revelation',
+    'aasimar-celestial-revelation-heavenly-wings',
+    'aasimar-celestial-revelation-inner-radiance',
+    'aasimar-celestial-revelation-necrotic-shroud',
+  ];
 
-  const hasRevelationChoice = (build: CharacterBuild): boolean =>
-    collectBundles(build).bundles.some((b) =>
-      b.grants.some((g) => g.type === 'feature-choice' && g.key === revelationKey)
-    );
+  const featureIdsAt = (numLevels: number): string[] =>
+    collectBundles(aasimarFighterBuild(numLevels))
+      .bundles.flatMap((b) => b.grants)
+      .filter((g) => g.type === 'feature')
+      .map((g) => (g.type === 'feature' ? g.feature.id : ''));
 
-  it('does not offer Celestial Revelation at character level 1 or 2', () => {
-    expect(hasRevelationChoice(aasimarFighterBuild(1))).toBe(false);
-    expect(hasRevelationChoice(aasimarFighterBuild(2))).toBe(false);
+  it('grants none of the Celestial Revelation features below character level 3', () => {
+    for (const numLevels of [1, 2]) {
+      const ids = featureIdsAt(numLevels);
+      for (const cid of CELESTIAL_IDS) {
+        expect(ids, `${cid} should be absent at level ${numLevels}`).not.toContain(cid);
+      }
+    }
   });
 
-  it('offers Celestial Revelation as a pending choice at character level 3', () => {
+  it('grants all three transformations plus the overview at character level 3', () => {
+    const ids = featureIdsAt(3);
+    for (const cid of CELESTIAL_IDS) {
+      expect(ids, `${cid} should be granted at level 3`).toContain(cid);
+    }
+  });
+
+  it('does not surface a species feature-choice pending choice (chosen per use, not at build time)', () => {
     const build = aasimarFighterBuild(3);
-    expect(hasRevelationChoice(build)).toBe(true);
     const { bundles, expandedFeats } = collectBundles(build);
     const result = resolveCharacter({
       baseAbilities: build.baseAbilities,
@@ -1473,37 +1491,15 @@ describe('Aasimar Celestial Revelation surfacing by character level (#289)', () 
       levels: build.levels,
       expandedFeats,
     });
-    const pending = result.pendingChoices.find((c) => c.type === 'feature-choice' && c.choiceKey === revelationKey);
-    expect(pending).toBeDefined();
-    if (pending?.type === 'feature-choice') {
-      expect(pending.options).toHaveLength(3);
-    }
+    const pending = result.pendingChoices.find((c) => c.type === 'feature-choice' && c.source.origin === 'species');
+    expect(pending).toBeUndefined();
   });
 
-  it('emits no warnings for a plain Aasimar build (species feature-choice is a known origin)', () => {
+  it('emits no warnings for a plain Aasimar build', () => {
     for (const numLevels of [1, 2, 3]) {
       const { warnings } = collectBundles(aasimarFighterBuild(numLevels));
-      const revelationWarnings = warnings.filter((w) => w.includes('feature-choice:species:aasimar:0'));
-      expect(revelationWarnings, `unexpected warning at level ${numLevels}: ${revelationWarnings.join('; ')}`).toEqual(
-        []
-      );
+      const aasimarWarnings = warnings.filter((w) => w.toLowerCase().includes('aasimar'));
+      expect(aasimarWarnings, `unexpected warning at level ${numLevels}: ${aasimarWarnings.join('; ')}`).toEqual([]);
     }
-  });
-
-  it('does not grant the chosen revelation feature below level 3 (e.g. after a level-down)', () => {
-    const buildWithChoice = (numLevels: number): CharacterBuild => ({
-      ...aasimarFighterBuild(numLevels),
-      choices: {
-        [revelationKey]: { type: 'feature-choice', optionId: 'inner-radiance' } as ChoiceDecision,
-      },
-    });
-    const featureIdsAt = (numLevels: number): string[] =>
-      collectBundles(buildWithChoice(numLevels))
-        .bundles.flatMap((b) => b.grants)
-        .filter((g) => g.type === 'feature')
-        .map((g) => (g.type === 'feature' ? g.feature.id : ''));
-
-    expect(featureIdsAt(2)).not.toContain('aasimar-celestial-revelation-inner-radiance');
-    expect(featureIdsAt(3)).toContain('aasimar-celestial-revelation-inner-radiance');
   });
 });

--- a/src/lib/sources/species.test.ts
+++ b/src/lib/sources/species.test.ts
@@ -373,40 +373,41 @@ describe('Aasimar species source (2024 PHB)', () => {
     );
   });
 
-  it('grants darkvision, celestial-resistance, healing-hands, light-bearer features', () => {
-    const features = source?.grants.filter((g) => g.type === 'feature');
-    expect(features).toHaveLength(4);
-    const featureIds = features?.map((g) => g.type === 'feature' && g.feature.id);
-    expect(featureIds).toEqual(
-      expect.arrayContaining([
-        'aasimar-darkvision',
-        'aasimar-celestial-resistance',
-        'aasimar-healing-hands',
-        'aasimar-light-bearer',
-      ])
-    );
-  });
-
-  // Regression for #289: Celestial Revelation is a level-3 choice of three transformations,
-  // not a flat feature granted at level 1.
-  it('offers Celestial Revelation as a level-3 feature-choice with three options', () => {
-    const choice = source?.grants.find((g) => g.type === 'feature-choice');
-    expect(choice).toBeDefined();
-    if (choice?.type === 'feature-choice') {
-      expect(choice.minCharacterLevel).toBe(3);
-      expect(choice.key).toBe(createChoiceKey('feature-choice', 'species', 'aasimar', 0));
-      expect(choice.options.map((o) => o.optionId).sort()).toEqual([
-        'heavenly-wings',
-        'inner-radiance',
-        'necrotic-shroud',
-      ]);
+  it('grants the four base features ungated at level 1', () => {
+    const base = [
+      'aasimar-darkvision',
+      'aasimar-celestial-resistance',
+      'aasimar-healing-hands',
+      'aasimar-light-bearer',
+    ];
+    for (const id of base) {
+      const grant = source?.grants.find((g) => g.type === 'feature' && g.feature.id === id);
+      expect(grant, `missing base feature ${id}`).toBeDefined();
+      if (grant?.type === 'feature') {
+        expect(grant.minCharacterLevel, `${id} should not be level-gated`).toBeUndefined();
+      }
     }
   });
 
-  it('does not grant Celestial Revelation as a flat feature', () => {
-    const features = source?.grants.filter((g) => g.type === 'feature');
-    const ids = features?.map((g) => (g.type === 'feature' ? g.feature.id : ''));
-    expect(ids).not.toContain('aasimar-celestial-revelation');
+  // Regression for #289 + #301: Celestial Revelation grants ALL THREE transformations (chosen per
+  // use, not a one-time build choice), as informational features gated to character level 3 — NOT
+  // a feature-choice.
+  it('does not model Celestial Revelation as a feature-choice', () => {
+    const choice = source?.grants.find((g) => g.type === 'feature-choice');
+    expect(choice).toBeUndefined();
+  });
+
+  it('grants all three Celestial Revelation transformations (plus overview) gated at character level 3', () => {
+    const celestial = ['heavenly-wings', 'inner-radiance', 'necrotic-shroud'].map(
+      (o) => `aasimar-celestial-revelation-${o}`
+    );
+    for (const id of [...celestial, 'aasimar-celestial-revelation']) {
+      const grant = source?.grants.find((g) => g.type === 'feature' && g.feature.id === id);
+      expect(grant, `missing celestial feature ${id}`).toBeDefined();
+      if (grant?.type === 'feature') {
+        expect(grant.minCharacterLevel, `${id} should be gated to level 3`).toBe(3);
+      }
+    }
   });
 });
 

--- a/src/lib/sources/species.ts
+++ b/src/lib/sources/species.ts
@@ -294,31 +294,14 @@ export const SPECIES_SOURCES: readonly SpeciesSource[] = [
       { type: 'resistance', damageType: 'radiant' },
       { type: 'feature', feature: { id: 'aasimar-healing-hands' } },
       { type: 'feature', feature: { id: 'aasimar-light-bearer' } },
-      // Celestial Revelation: at character level 3, choose one transformation (2024 PHB). #289
-      {
-        type: 'feature-choice',
-        key: createChoiceKey('feature-choice', 'species', 'aasimar', 0),
-        minCharacterLevel: 3,
-        options: [
-          {
-            optionId: 'heavenly-wings',
-            featureId: 'aasimar-celestial-revelation-heavenly-wings',
-            // Transformation-only fly speed (1 min, Bonus Action); the engine does not model
-            // transient activated speeds, so the mechanics live in the feature description.
-            grants: [],
-          },
-          {
-            optionId: 'inner-radiance',
-            featureId: 'aasimar-celestial-revelation-inner-radiance',
-            grants: [],
-          },
-          {
-            optionId: 'necrotic-shroud',
-            featureId: 'aasimar-celestial-revelation-necrotic-shroud',
-            grants: [],
-          },
-        ],
-      },
+      // Celestial Revelation (2024 PHB): at character level 3 you gain ALL THREE transformations and
+      // choose which to use each time you activate the feature (once per Long Rest) — not a one-time
+      // build choice (#301). Granted as informational features gated to character level 3 (#289);
+      // the transformations are transient/activated effects the engine does not otherwise model.
+      { type: 'feature', minCharacterLevel: 3, feature: { id: 'aasimar-celestial-revelation' } },
+      { type: 'feature', minCharacterLevel: 3, feature: { id: 'aasimar-celestial-revelation-heavenly-wings' } },
+      { type: 'feature', minCharacterLevel: 3, feature: { id: 'aasimar-celestial-revelation-inner-radiance' } },
+      { type: 'feature', minCharacterLevel: 3, feature: { id: 'aasimar-celestial-revelation-necrotic-shroud' } },
     ],
   },
   // Dragonborn (2024 PHB) — lineage choice from 10 options (5 chromatic, 5 metallic)

--- a/src/locales/en/gamedata.json
+++ b/src/locales/en/gamedata.json
@@ -889,7 +889,7 @@
     },
     "aasimar-celestial-revelation": {
       "name": "Celestial Revelation",
-      "description": "When you reach character level 3, choose one Celestial Revelation. You can transform as a Bonus Action, and the transformation lasts for 1 minute or until you end it (no action required). Once you transform, you can't do so again until you finish a Long Rest."
+      "description": "When you reach character level 3, you gain all three Celestial Revelation transformations below. As a Bonus Action you can transform, choosing which revelation to use each time you do so. A transformation lasts 1 minute or until you end it (no action required). Once you transform, you can't do so again until you finish a Long Rest."
     },
     "aasimar-celestial-revelation-heavenly-wings": {
       "name": "Celestial Revelation: Heavenly Wings",

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -139,6 +139,10 @@ export interface ExpertiseChoiceGrant {
 export interface FeatureGrant {
   readonly type: 'feature';
   readonly feature: FeatureDef;
+  // Optional total-character-level gate (see FeatureChoiceGrant.minCharacterLevel). Suppresses the
+  // feature until the character reaches this level — e.g. the Aasimar Celestial Revelation options
+  // are all granted at character level 3 (#301). Gated generically in collectBundles.
+  readonly minCharacterLevel?: number;
 }
 
 export type SpeedMode = 'walk' | 'fly' | 'swim' | 'climb' | 'burrow';


### PR DESCRIPTION
Closes #301. Corrects the #289 implementation.

## Problem
#289 modeled Celestial Revelation as a one-time build-level `feature-choice` (pick one of three). Per the 2024 PHB, an Aasimar gains **all three** transformations at character level 3 and chooses which to use **each time** they activate the feature (Bonus Action, once per Long Rest) — a table-time decision, not a build choice.

## Fix
- Replaced the level-3 `feature-choice` with all three transformation features (Heavenly Wings, Inner Radiance, Necrotic Shroud) plus the overview feature, granted as informational features gated to character level 3.
- Added `minCharacterLevel` support to plain `FeatureGrant` (the generic `gateGrantsByMinCharacterLevel` already honors it).
- Updated the overview description; updated the #289 regression tests (all three present at L3, absent below, and no pending species feature-choice).

## Verification
typecheck ✅ · lint ✅ · test ✅ (2401) · test:bdd ✅ (82/82)

🤖 Generated with [Claude Code](https://claude.com/claude-code)