### PR TITLE
fix(engine): Epic Boon feat-choice at level 19 for all classes (#302)

### DIFF
--- a/docs/coverage-matrix.md
+++ b/docs/coverage-matrix.md
@@ -20,17 +20,17 @@ missing: 0 · stub: 0 · partial: 2 · complete: 10 · golden-verified: 0/12
 | id | status | detail | golden |
 | --- | --- | --- | --- |
 | barbarian | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
-| bard | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
-| cleric | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
-| druid | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
-| fighter | partial | missing ASI at level(s) 12, 16; missing ASI or Epic Boon at level 19 | — |
-| monk | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
-| paladin | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
-| ranger | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
-| rogue | partial | missing ASI at level(s) 12, 16; missing ASI or Epic Boon at level 19 | — |
-| sorcerer | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
-| warlock | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
-| wizard | complete | 20 levels, subclass@3, ASI@4/8/12/16, ASI@19 | — |
+| bard | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| cleric | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| druid | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| fighter | partial | missing ASI at level(s) 12, 16 | — |
+| monk | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| paladin | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| ranger | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| rogue | partial | missing ASI at level(s) 12, 16 | — |
+| sorcerer | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| warlock | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
+| wizard | complete | 20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19 | — |
 
 ### subclasses — 20/48 structurally complete (42%)
 

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -571,6 +571,30 @@ describe('Resolver either-or ASI ↔ feat-choice suppression', () => {
     const featPending = result.pendingChoices.find((c) => c.type === 'feat-choice');
     expect(featPending).toBeDefined();
   });
+
+  // Regression for #302: cleric/druid/sorcerer/warlock/wizard's L19 Epic Boon
+  // feat-choice reuses the index-4 key that used to belong to a paired ASI
+  // grant. A character persisted before the fix could still carry a satisfied
+  // 'asi:class:cleric:4' decision even though the bundle no longer grants an
+  // ASI at that key — the either-or suppression must not key off a stale
+  // choices-map entry when there is no companion asi *grant* in the bundle.
+  it('does NOT suppress a solo epicBoon feat-choice via a stale companion ASI decision', () => {
+    const soloFeatKey = createChoiceKey('feat-choice', 'class', 'cleric', 4);
+    const staleAsiKey = createChoiceKey('asi', 'class', 'cleric', 4);
+    const bundlesWithSoloFeatChoice: readonly GrantBundle[] = [
+      {
+        source: { origin: 'class', id: 'cleric', level: 19 },
+        grants: [{ type: 'feat-choice', key: soloFeatKey, from: null, category: 'epicBoon' }],
+      },
+    ];
+    const result = resolveCharacter({
+      ...baseInput,
+      bundles: bundlesWithSoloFeatChoice,
+      choices: { [staleAsiKey]: { type: 'asi', allocation: { str: 2 } } as const },
+    });
+    const featPending = result.pendingChoices.find((c) => c.type === 'feat-choice' && c.choiceKey === soloFeatKey);
+    expect(featPending).toMatchObject({ category: 'epicBoon' });
+  });
 });
 
 describe('Human Fighter L1 equipment integration', () => {

--- a/src/lib/resolver/index.test.ts
+++ b/src/lib/resolver/index.test.ts
@@ -1768,7 +1768,7 @@ describe('Weapon mastery resolver', () => {
     expect(ragePool).toMatchObject({ max: 3, regen: 'long-rest' });
   });
 
-  it('L19 Barbarian gains an Epic Boon feature and only four ASIs (no spurious 5th)', () => {
+  it('L19 Barbarian gains an Epic Boon feat-choice and only four ASIs (no spurious 5th)', () => {
     const levels = Array.from({ length: 19 }, (_, i) => ({
       classId: 'barbarian' as ClassId,
       classLevel: i + 1,
@@ -1792,7 +1792,10 @@ describe('Weapon mastery resolver', () => {
       choices: barbarianL19Build.choices,
       levels: barbarianL19Build.levels,
     });
-    expect(result.features.map((f) => f.feature.id)).toContain('barbarian-epic-boon');
+    const epicBoonChoice = result.pendingChoices.find(
+      (c) => c.type === 'feat-choice' && c.choiceKey === 'feat-choice:class:barbarian:4'
+    );
+    expect(epicBoonChoice).toMatchObject({ category: 'epicBoon' });
     const asiKeys = result.pendingChoices.filter((c) => c.type === 'asi').map((c) => c.choiceKey);
     // Four class ASIs (L4/8/12/16) — the old L19 ASI is now the Epic Boon.
     expect(asiKeys).toContain('asi:class:barbarian:3');

--- a/src/lib/resolver/index.ts
+++ b/src/lib/resolver/index.ts
@@ -168,7 +168,10 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
   }
 
   // Unresolved or invalid ASI grants
-  for (const { grant, source } of collectGrantsByType(bundles, 'asi')) {
+  const asiGrants = collectGrantsByType(bundles, 'asi');
+  const asiGrantKeys = new Set(asiGrants.map(({ grant }) => grant.key));
+  const featChoiceGrantKeys = new Set(collectGrantsByType(bundles, 'feat-choice').map(({ grant }) => grant.key));
+  for (const { grant, source } of asiGrants) {
     const decision = choices[grant.key];
     const totalAllocated =
       decision?.type === 'asi' ? Object.values(decision.allocation).reduce((sum, v) => sum + (v ?? 0), 0) : 0;
@@ -183,11 +186,18 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
       return true;
     })();
     if (!isValid) {
-      // Either-or suppression: if the companion feat-choice is satisfied, skip ASI pending
+      // Either-or suppression: if the companion feat-choice grant exists AND is satisfied,
+      // skip ASI pending. Guard on the grant's presence, not just the choices map — a
+      // persisted decision at this key may be stale from before a source data change that
+      // removed the companion grant (#302), so a satisfied-looking decision without a live
+      // companion grant must never suppress this pending choice.
       const parsed = parseChoiceKey(grant.key);
       const companionFeatKey = createChoiceKey('feat-choice', parsed.origin, parsed.id, parsed.index);
       const companionFeatDecision = choices[companionFeatKey];
-      const featSatisfied = companionFeatDecision?.type === 'feat-choice' && companionFeatDecision.featId.length > 0;
+      const featSatisfied =
+        featChoiceGrantKeys.has(companionFeatKey) &&
+        companionFeatDecision?.type === 'feat-choice' &&
+        companionFeatDecision.featId.length > 0;
       if (!featSatisfied) {
         pendingChoices.push({
           type: 'asi',
@@ -204,7 +214,9 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
       const companionFeatKey = createChoiceKey('feat-choice', parsed.origin, parsed.id, parsed.index);
       const companionFeatDecision = choices[companionFeatKey];
       const featAlsoSatisfied =
-        companionFeatDecision?.type === 'feat-choice' && companionFeatDecision.featId.length > 0;
+        featChoiceGrantKeys.has(companionFeatKey) &&
+        companionFeatDecision?.type === 'feat-choice' &&
+        companionFeatDecision.featId.length > 0;
       if (featAlsoSatisfied) {
         logger.warn(
           `BUG: both ASI "${grant.key}" and feat-choice "${companionFeatKey}" are satisfied for the same origin — this should never happen`
@@ -358,11 +370,16 @@ export function resolveCharacter(input: ResolverInput): ResolvedCharacter {
     const decision = choices[grant.key];
     const resolvedFeat = decision?.type === 'feat-choice' ? getFeatSource(decision.featId) : undefined;
     if (!decision || decision.type !== 'feat-choice' || !resolvedFeat) {
-      // Either-or suppression: if the companion ASI is satisfied, skip feat-choice pending
+      // Either-or suppression: if the companion ASI grant exists AND is satisfied, skip
+      // feat-choice pending. Guard on the grant's presence, not just the choices map — a
+      // persisted decision at this key may be stale from before a source data change that
+      // removed the companion grant (#302), so a satisfied-looking decision without a live
+      // companion grant must never suppress this pending choice.
       const parsed = parseChoiceKey(grant.key);
       const companionAsiKey = createChoiceKey('asi', parsed.origin, parsed.id, parsed.index);
       const companionAsiDecision = choices[companionAsiKey];
       const asiSatisfied =
+        asiGrantKeys.has(companionAsiKey) &&
         companionAsiDecision?.type === 'asi' &&
         Object.values(companionAsiDecision.allocation).reduce((sum, v) => sum + (v ?? 0), 0) > 0;
       if (!asiSatisfied) {

--- a/src/lib/sources/classes.test.ts
+++ b/src/lib/sources/classes.test.ts
@@ -143,6 +143,22 @@ describe('Fighter class levels 2–10 grant structures', () => {
     }
   });
 
+  it('level 19 grants a solo Epic Boon feat-choice (index 3)', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'fighter', 3));
+      expect(grant.category).toBe('epicBoon');
+    }
+  });
+
+  it('level 20 has no grants (empty stub)', () => {
+    const level20 = source?.levels[19];
+    expect(level20?.grants).toHaveLength(0);
+  });
+
   it('still has 20 levels total', () => {
     expect(source?.levels).toHaveLength(20);
   });
@@ -274,9 +290,21 @@ describe('Rogue class grant structures', () => {
     }
   });
 
-  it('levels 11–20 are EMPTY_LEVEL', () => {
+  it('levels 11–18 and 20 are EMPTY_LEVEL', () => {
     for (let i = 10; i < 20; i++) {
+      if (i === 18) continue;
       expect(source?.levels[i].grants).toHaveLength(0);
+    }
+  });
+
+  it('level 19 grants a solo Epic Boon feat-choice (index 3)', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'rogue', 3));
+      expect(grant.category).toBe('epicBoon');
     }
   });
 
@@ -462,6 +490,17 @@ describe('Barbarian class grant structures', () => {
     }
   });
 
+  it('level 19 grants a solo Epic Boon feat-choice (index 4)', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'barbarian', 4));
+      expect(grant.category).toBe('epicBoon');
+    }
+  });
+
   it('level 20 has primal-champion feature', () => {
     const grant = source?.levels[19].grants.find((g) => g.type === 'feature');
     expect(grant?.type).toBe('feature');
@@ -561,6 +600,21 @@ describe('Bard class grant structures', () => {
       }
     });
   });
+
+  it('level 19 grants a solo Epic Boon feat-choice (index 4)', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'bard', 4));
+      expect(grant.category).toBe('epicBoon');
+    }
+  });
+
+  it('level 20 has no grants (empty stub)', () => {
+    expect(source?.levels[19].grants).toHaveLength(0);
+  });
 });
 
 describe('Cleric class grant structures', () => {
@@ -626,6 +680,18 @@ describe('Cleric class grant structures', () => {
       expect(grant.key).toBe(createChoiceKey('asi', 'class', 'cleric', 0));
       expect(grant.points).toBe(2);
     }
+  });
+
+  it('level 19 grants a solo Epic Boon feat-choice (index 4) and no ASI', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'cleric', 4));
+      expect(grant.category).toBe('epicBoon');
+    }
+    expect(level19?.grants.find((g) => g.type === 'asi')).toBeUndefined();
   });
 
   it('level 20 has greater-divine-intervention feature', () => {
@@ -741,6 +807,18 @@ describe('Druid class grant structures', () => {
     expect(featureIds).toContain('druid-improved-elemental-fury');
   });
 
+  it('level 19 grants a solo Epic Boon feat-choice (index 4) and no ASI', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'druid', 4));
+      expect(grant.category).toBe('epicBoon');
+    }
+    expect(level19?.grants.find((g) => g.type === 'asi')).toBeUndefined();
+  });
+
   it('level 20 has archdruid feature', () => {
     const featureIds = source?.levels[19].grants
       .filter((g) => g.type === 'feature')
@@ -814,11 +892,20 @@ describe('Monk class grant structures', () => {
     expect(featureIds).toContain('monk-slow-fall');
   });
 
-  it('level 20 has epic-boon feature', () => {
-    const featureIds = source?.levels[19].grants
-      .filter((g) => g.type === 'feature')
-      .map((g) => (g.type === 'feature' ? g.feature.id : ''));
-    expect(featureIds).toContain('monk-epic-boon');
+  it('level 19 grants a solo Epic Boon feat-choice (index 4) and no ASI', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'monk', 4));
+      expect(grant.category).toBe('epicBoon');
+    }
+    expect(level19?.grants.find((g) => g.type === 'asi')).toBeUndefined();
+  });
+
+  it('level 20 has no grants (empty stub)', () => {
+    expect(source?.levels[19].grants).toHaveLength(0);
   });
 });
 
@@ -887,11 +974,20 @@ describe('Paladin class grant structures', () => {
     expect(featureIds).toContain('paladin-aura-of-protection');
   });
 
-  it('level 20 has epic-boon feature', () => {
-    const featureIds = source?.levels[19].grants
-      .filter((g) => g.type === 'feature')
-      .map((g) => (g.type === 'feature' ? g.feature.id : ''));
-    expect(featureIds).toContain('paladin-epic-boon');
+  it('level 19 grants a solo Epic Boon feat-choice (index 4) and no ASI', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'paladin', 4));
+      expect(grant.category).toBe('epicBoon');
+    }
+    expect(level19?.grants.find((g) => g.type === 'asi')).toBeUndefined();
+  });
+
+  it('level 20 has no grants (empty stub)', () => {
+    expect(source?.levels[19].grants).toHaveLength(0);
   });
 });
 
@@ -981,6 +1077,22 @@ describe('Ranger class grant structures', () => {
       ])
     );
   });
+
+  it('level 19 grants a solo Epic Boon feat-choice (index 4) and no ASI', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'ranger', 4));
+      expect(grant.category).toBe('epicBoon');
+    }
+    expect(level19?.grants.find((g) => g.type === 'asi')).toBeUndefined();
+  });
+
+  it('level 20 has no grants (empty stub)', () => {
+    expect(source?.levels[19].grants).toHaveLength(0);
+  });
 });
 
 describe('Sorcerer class grant structures', () => {
@@ -1029,6 +1141,18 @@ describe('Sorcerer class grant structures', () => {
       expect(grant.key).toBe(createChoiceKey('asi', 'class', 'sorcerer', 0));
       expect(grant.points).toBe(2);
     }
+  });
+
+  it('level 19 grants a solo Epic Boon feat-choice (index 4) and no ASI', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'sorcerer', 4));
+      expect(grant.category).toBe('epicBoon');
+    }
+    expect(level19?.grants.find((g) => g.type === 'asi')).toBeUndefined();
   });
 
   it('level 20 has sorcerous-restoration feature', () => {
@@ -1109,6 +1233,18 @@ describe('Warlock class grant structures', () => {
     expect(featureIds).toContain('warlock-mystic-arcanum-6');
   });
 
+  it('level 19 grants a solo Epic Boon feat-choice (index 4) and no ASI', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'warlock', 4));
+      expect(grant.category).toBe('epicBoon');
+    }
+    expect(level19?.grants.find((g) => g.type === 'asi')).toBeUndefined();
+  });
+
   it('level 20 has eldritch-master feature', () => {
     const featureIds = source?.levels[19].grants
       .filter((g) => g.type === 'feature')
@@ -1170,6 +1306,18 @@ describe('Wizard class grant structures', () => {
       .filter((g) => g.type === 'feature')
       .map((g) => (g.type === 'feature' ? g.feature.id : ''));
     expect(featureIds).toContain('wizard-spell-mastery');
+  });
+
+  it('level 19 grants a solo Epic Boon feat-choice (index 4) and no ASI', () => {
+    const level19 = source?.levels[18];
+    expect(level19?.grants).toHaveLength(1);
+    const grant = level19?.grants[0];
+    expect(grant?.type).toBe('feat-choice');
+    if (grant?.type === 'feat-choice') {
+      expect(grant.key).toBe(createChoiceKey('feat-choice', 'class', 'wizard', 4));
+      expect(grant.category).toBe('epicBoon');
+    }
+    expect(level19?.grants.find((g) => g.type === 'asi')).toBeUndefined();
   });
 
   it('level 20 has signature-spells feature', () => {

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -147,7 +147,16 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'barbarian', 3), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'barbarian', 3), from: null, category: 'general' }] },
       { grants: [{ type: 'feature', feature: { id: 'barbarian-improved-brutal-strike-2' } }] },
       { grants: [{ type: 'feature', feature: { id: 'barbarian-indomitable-might' } }] },
-      { grants: [{ type: 'feature', feature: { id: 'barbarian-epic-boon' } }] },
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'barbarian', 4),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
       { grants: [{ type: 'feature', feature: { id: 'barbarian-primal-champion' } }] },
     ],
   },
@@ -431,8 +440,17 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
           },
         ],
       },
-      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'bard', 4), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'bard', 4), from: null, category: 'general' }] },
-      { grants: [{ type: 'feature', feature: { id: 'bard-epic-boon' } }] },
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'bard', 4),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
+      EMPTY_LEVEL,
     ],
   },
 
@@ -544,7 +562,16 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'cleric', 3), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'cleric', 3), from: null, category: 'general' }] },
       EMPTY_LEVEL,
       { grants: [{ type: 'feature', feature: { id: 'cleric-channel-divinity-3' } }] },
-      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'cleric', 4), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'cleric', 4), from: null, category: 'general' }] },
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'cleric', 4),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
       { grants: [{ type: 'feature', feature: { id: 'cleric-greater-divine-intervention' } }] },
     ],
   },
@@ -689,7 +716,16 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'druid', 3), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'druid', 3), from: null, category: 'general' }] },
       EMPTY_LEVEL,
       { grants: [{ type: 'feature', feature: { id: 'druid-beast-spells' } }] },
-      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'druid', 4), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'druid', 4), from: null, category: 'general' }] },
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'druid', 4),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
       { grants: [{ type: 'feature', feature: { id: 'druid-archdruid' } }] },
     ],
   },
@@ -813,7 +849,16 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       },
       EMPTY_LEVEL,
       EMPTY_LEVEL,
-      EMPTY_LEVEL,
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'fighter', 3),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
       EMPTY_LEVEL,
     ],
   },
@@ -908,8 +953,17 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'monk', 3), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'monk', 3), from: null, category: 'general' }] },
       EMPTY_LEVEL,
       { grants: [{ type: 'feature', feature: { id: 'monk-body-and-mind' } }] },
-      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'monk', 4), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'monk', 4), from: null, category: 'general' }] },
-      { grants: [{ type: 'feature', feature: { id: 'monk-epic-boon' } }] },
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'monk', 4),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
+      EMPTY_LEVEL,
     ],
   },
 
@@ -986,8 +1040,17 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'paladin', 3), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'paladin', 3), from: null, category: 'general' }] },
       EMPTY_LEVEL,
       { grants: [{ type: 'feature', feature: { id: 'paladin-aura-expansion' } }] },
-      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'paladin', 4), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'paladin', 4), from: null, category: 'general' }] },
-      { grants: [{ type: 'feature', feature: { id: 'paladin-epic-boon' } }] },
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'paladin', 4),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
+      EMPTY_LEVEL,
     ],
   },
 
@@ -1086,8 +1149,17 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'ranger', 3), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'ranger', 3), from: null, category: 'general' }] },
       { grants: [{ type: 'feature', feature: { id: 'ranger-conjure-volley' } }] },
       { grants: [{ type: 'feature', feature: { id: 'ranger-swift-quiver' } }] },
-      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'ranger', 4), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'ranger', 4), from: null, category: 'general' }] },
-      { grants: [{ type: 'feature', feature: { id: 'ranger-epic-boon' } }] },
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'ranger', 4),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
+      EMPTY_LEVEL,
     ],
   },
 
@@ -1188,7 +1260,16 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       EMPTY_LEVEL,
       EMPTY_LEVEL,
       EMPTY_LEVEL,
-      EMPTY_LEVEL,
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'rogue', 3),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
       EMPTY_LEVEL,
     ],
   },
@@ -1253,7 +1334,16 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'sorcerer', 3), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'sorcerer', 3), from: null, category: 'general' }] },
       EMPTY_LEVEL,
       { grants: [{ type: 'feature', feature: { id: 'sorcerer-arcane-apotheosis' } }] },
-      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'sorcerer', 4), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'sorcerer', 4), from: null, category: 'general' }] },
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'sorcerer', 4),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
       { grants: [{ type: 'feature', feature: { id: 'sorcerer-sorcerous-restoration' } }] },
     ],
   },
@@ -1310,7 +1400,16 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'warlock', 3), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'warlock', 3), from: null, category: 'general' }] },
       { grants: [{ type: 'feature', feature: { id: 'warlock-mystic-arcanum-9' } }] },
       EMPTY_LEVEL,
-      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'warlock', 4), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'warlock', 4), from: null, category: 'general' }] },
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'warlock', 4),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
       { grants: [{ type: 'feature', feature: { id: 'warlock-eldritch-master' } }] },
     ],
   },
@@ -1364,7 +1463,16 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
       { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'wizard', 3), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'wizard', 3), from: null, category: 'general' }] },
       EMPTY_LEVEL,
       { grants: [{ type: 'feature', feature: { id: 'wizard-spell-mastery' } }] },
-      { grants: [{ type: 'asi', key: createChoiceKey('asi', 'class', 'wizard', 4), points: 2, from: null }, { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'wizard', 4), from: null, category: 'general' }] },
+      {
+        grants: [
+          {
+            type: 'feat-choice',
+            key: createChoiceKey('feat-choice', 'class', 'wizard', 4),
+            from: null,
+            category: 'epicBoon',
+          },
+        ],
+      },
       { grants: [{ type: 'feature', feature: { id: 'wizard-signature-spells' } }] },
     ],
   },

--- a/src/lib/sources/coverage-matrix.test.ts
+++ b/src/lib/sources/coverage-matrix.test.ts
@@ -1,7 +1,14 @@
 import { describe, it, expect } from 'vitest';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { resolve } from 'node:path';
-import { computeCoverageMatrix, renderCoverageMarkdown, type ForkCoverage } from '@/lib/sources/coverage-matrix';
+import {
+  computeCoverageMatrix,
+  renderCoverageMarkdown,
+  hasL19EpicBoonGrant,
+  type ForkCoverage,
+} from '@/lib/sources/coverage-matrix';
+import { createChoiceKey } from '@/types/choices';
+import type { LevelUp } from '@/types/sources';
 
 /**
  * Coverage gate for the 2024 PHB source data.
@@ -75,5 +82,41 @@ describe('2024 PHB coverage matrix', () => {
       }
       expect(committed, 'docs/coverage-matrix.md is stale — run `npm run coverage:matrix`').toBe(rendered);
     });
+  });
+});
+
+describe('hasL19EpicBoonGrant', () => {
+  // Synthetic level array: 18 empty levels (indices 0-17) followed by the level-19 slot
+  // (index 18) under test — computeClassCoverage isn't parameterizable with a synthetic
+  // ClassSource, so this exercises the extracted detector directly against a minimal
+  // LevelUp array instead of the full CLASS_SOURCES data.
+  function levelsWithL19(l19Grants: LevelUp['grants']): readonly LevelUp[] {
+    const emptyLevels: LevelUp[] = Array.from({ length: 18 }, () => ({ grants: [] }));
+    return [...emptyLevels, { grants: l19Grants }];
+  }
+
+  it('returns false when level 19 has only an ASI grant', () => {
+    const levels = levelsWithL19([
+      { type: 'asi', key: createChoiceKey('asi', 'class', 'cleric', 4), points: 2, from: null },
+    ]);
+    expect(hasL19EpicBoonGrant(levels)).toBe(false);
+  });
+
+  it('returns false when level 19 has a feat-choice grant with category "general"', () => {
+    const levels = levelsWithL19([
+      { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'cleric', 4), from: null, category: 'general' },
+    ]);
+    expect(hasL19EpicBoonGrant(levels)).toBe(false);
+  });
+
+  it('returns false when level 19 has no grants', () => {
+    expect(hasL19EpicBoonGrant(levelsWithL19([]))).toBe(false);
+  });
+
+  it('returns true when level 19 has a solo feat-choice grant with category "epicBoon"', () => {
+    const levels = levelsWithL19([
+      { type: 'feat-choice', key: createChoiceKey('feat-choice', 'class', 'cleric', 4), from: null, category: 'epicBoon' },
+    ]);
+    expect(hasL19EpicBoonGrant(levels)).toBe(true);
   });
 });

--- a/src/lib/sources/coverage-matrix.ts
+++ b/src/lib/sources/coverage-matrix.ts
@@ -79,11 +79,12 @@ export const SUBCLASS_MILESTONES_BY_CLASS: Readonly<Record<string, readonly numb
  * 2024 PHB Ability Score Improvement levels common to every class. Level 19 is
  * NOT here: in the 2024 rules every class gains an Epic Boon at level 19 instead
  * of a regular ASI ({@link EPIC_BOON_LEVEL}), so that slot is checked separately
- * and accepts either grant shape.
+ * and requires a `feat-choice` grant with `category: 'epicBoon'` — there is no
+ * ASI alternative.
  */
 export const EXPECTED_ASI_LEVELS: readonly number[] = [4, 8, 12, 16] as const;
 
-/** 2024 PHB level at which every class gains an Epic Boon feat in place of an ASI. */
+/** 2024 PHB level at which every class gains an Epic Boon feat-choice in place of an ASI. */
 export const EPIC_BOON_LEVEL = 19 as const;
 
 /**
@@ -137,25 +138,18 @@ export function computeClassCoverage(): ForkCoverage {
     const missingAsi = missingLevels(asiLevels, EXPECTED_ASI_LEVELS);
     if (missingAsi.length > 0) problems.push(`missing ASI at level(s) ${missingAsi.join(', ')}`);
 
-    // Level 19 is the Epic Boon slot in 2024: accept either an ASI grant or an
-    // Epic Boon feature (id ending `-epic-boon`) / epic-boon feat grant. Most class
-    // tables still model it as a plain ASI; only those carrying an actual epic-boon
-    // grant are reported as "Epic Boon@19" so the matrix doesn't overstate coverage.
+    // Level 19 is the Epic Boon slot in 2024: every class must carry a solo
+    // feat-choice grant with category 'epicBoon' there — there is no ASI alternative.
     const hasL19EpicBoon = (src.levels[EPIC_BOON_LEVEL - 1]?.grants ?? []).some(
-      (g) =>
-        (g.type === 'feature' && g.feature.id.endsWith('-epic-boon')) ||
-        (g.type === 'feat' && g.featId.endsWith('-epic-boon'))
+      (g) => g.type === 'feat-choice' && g.category === 'epicBoon'
     );
-    // Reuse the asiLevels scan above rather than re-detecting an ASI grant at level 19.
-    const hasL19Asi = asiLevels.includes(EPIC_BOON_LEVEL);
-    if (!hasL19EpicBoon && !hasL19Asi) problems.push(`missing ASI or Epic Boon at level ${EPIC_BOON_LEVEL}`);
-    const l19Label = hasL19EpicBoon ? 'Epic Boon@19' : 'ASI@19';
+    if (!hasL19EpicBoon) problems.push(`missing Epic Boon feat-choice at level ${EPIC_BOON_LEVEL}`);
 
     const status: EntryStatus = problems.length === 0 ? 'complete' : 'partial';
     return {
       id: c.id,
       status,
-      detail: problems.length === 0 ? `20 levels, subclass@3, ASI@4/8/12/16, ${l19Label}` : problems.join('; '),
+      detail: problems.length === 0 ? '20 levels, subclass@3, ASI@4/8/12/16, Epic Boon@19' : problems.join('; '),
       goldenVerified: GOLDEN_VERIFIED.has(c.id),
     };
   });

--- a/src/lib/sources/coverage-matrix.ts
+++ b/src/lib/sources/coverage-matrix.ts
@@ -22,6 +22,7 @@
 import { CLASS_SOURCES, SPECIES_SOURCES, BACKGROUND_SOURCES, SUBCLASS_SOURCES } from '@/lib/sources';
 import { SUBCLASS_IDS_BY_CLASS } from '@/lib/sources/subclasses';
 import { DND_CLASSES, DND_SPECIES, DND_BACKGROUNDS } from '@/lib/dnd-helpers';
+import type { LevelUp } from '@/types/sources';
 
 export type EntryStatus = 'missing' | 'stub' | 'partial' | 'complete';
 
@@ -120,6 +121,19 @@ function missingLevels(have: readonly number[], expected: readonly number[]): nu
   return expected.filter((lv) => !set.has(lv));
 }
 
+/**
+ * True when the class's level-19 slot ({@link EPIC_BOON_LEVEL}) carries a solo
+ * feat-choice grant with category 'epicBoon' — the only shape the 2024 rules
+ * allow there. Exported standalone (rather than inlined in
+ * {@link computeClassCoverage}) so the detector can be unit-tested directly
+ * against synthetic level arrays, independent of the real CLASS_SOURCES data.
+ */
+export function hasL19EpicBoonGrant(levels: readonly LevelUp[]): boolean {
+  return (levels[EPIC_BOON_LEVEL - 1]?.grants ?? []).some(
+    (g) => g.type === 'feat-choice' && g.category === 'epicBoon'
+  );
+}
+
 export function computeClassCoverage(): ForkCoverage {
   const sourceById = new Map(CLASS_SOURCES.map((c) => [c.id, c]));
   const entries: CoverageEntry[] = DND_CLASSES.map((c) => {
@@ -140,10 +154,7 @@ export function computeClassCoverage(): ForkCoverage {
 
     // Level 19 is the Epic Boon slot in 2024: every class must carry a solo
     // feat-choice grant with category 'epicBoon' there — there is no ASI alternative.
-    const hasL19EpicBoon = (src.levels[EPIC_BOON_LEVEL - 1]?.grants ?? []).some(
-      (g) => g.type === 'feat-choice' && g.category === 'epicBoon'
-    );
-    if (!hasL19EpicBoon) problems.push(`missing Epic Boon feat-choice at level ${EPIC_BOON_LEVEL}`);
+    if (!hasL19EpicBoonGrant(src.levels)) problems.push(`missing Epic Boon feat-choice at level ${EPIC_BOON_LEVEL}`);
 
     const status: EntryStatus = problems.length === 0 ? 'complete' : 'partial';
     return {


### PR DESCRIPTION
Closes #302

## Summary
Level 19 now grants an Epic Boon selection (`feat-choice` of category `epicBoon`) for all 12 classes, replacing the previous inconsistent handling. Investigation revealed the issue's premise held only for Barbarian; the real fix addressed two distinct bugs.

## What Changed
- **Barbarian**: replaced flat `barbarian-epic-boon` feature at L19 with an `epicBoon` feat-choice; L20 capstone untouched.
- **Cleric, Druid, Sorcerer, Warlock, Wizard**: removed a phantom 5th ASI (`asi` grant) at L19 and retargeted the paired `feat-choice` from `general` to `epicBoon`; L20 capstones untouched.
- **Bard, Monk, Paladin, Ranger**: same L19 fix, plus removed a *misplaced* `*-epic-boon` flat feature at L20 (→ `EMPTY_LEVEL`).
- **Fighter, Rogue**: added a new solo `epicBoon` feat-choice at L19 (previously empty).
- `coverage-matrix.ts`: L19 detector now recognizes `feat-choice` w/ `category: 'epicBoon'`; regenerated `docs/coverage-matrix.md`.
- Updated resolver + classes tests.

## Data-shape note
Reused the existing `feat-choice:class:<id>:4` key while dropping its sibling `asi` grant. Any previously-persisted general-feat choice under that key would now be re-interpreted against the `epicBoon` pool. Low-risk (no production users/auth yet), noted for completeness.

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run test` — 2416 tests pass
- [x] `npm run lint` clean
- [x] `npm run coverage:matrix` regenerated; ratchet baseline unchanged (partial: 2, complete: 10)
- [x] Every class `levels` array remains length 20

🤖 Generated with [Claude Code](https://claude.com/claude-code)