### PR TITLE
feat(engine): fixed level-20 ability-score increases (Barbarian Primal Champion) (#303)

### DIFF
--- a/src/lib/resolver/abilities.test.ts
+++ b/src/lib/resolver/abilities.test.ts
@@ -412,4 +412,127 @@ describe('resolveAbilities', () => {
       expect(result.cha.total).toBe(10); // unaffected
     });
   });
+
+  describe('ability-score-increase grants', () => {
+    it('applies fixed str/con increases', () => {
+      const bundles: GrantBundle[] = [
+        {
+          source: { origin: 'class', id: 'barbarian', level: 20 },
+          grants: [
+            { type: 'ability-score-increase', ability: 'str', amount: 4, max: 24 },
+            { type: 'ability-score-increase', ability: 'con', amount: 4, max: 24 },
+          ],
+        },
+      ];
+      const result = resolveAbilities(BASE, bundles, NO_CHOICES);
+      expect(result.str.total).toBe(14);
+      expect(result.con.total).toBe(14);
+      expect(result.dex.total).toBe(10);
+    });
+
+    it('raises the cap past 20 — base 20 + grant reaches 24, not clamped to 20', () => {
+      const highBase = { ...BASE, str: 20 };
+      const bundles: GrantBundle[] = [
+        {
+          source: { origin: 'class', id: 'barbarian', level: 20 },
+          grants: [{ type: 'ability-score-increase', ability: 'str', amount: 4, max: 24 }],
+        },
+      ];
+      const result = resolveAbilities(highBase, bundles, NO_CHOICES);
+      expect(result.str.total).toBe(24);
+      expect(result.str.modifier).toBe(7);
+    });
+
+    it('caps at the raised max — base 22 + 4 raw 26 clamps to 24', () => {
+      const highBase = { ...BASE, str: 22 };
+      const bundles: GrantBundle[] = [
+        {
+          source: { origin: 'class', id: 'barbarian', level: 20 },
+          grants: [{ type: 'ability-score-increase', ability: 'str', amount: 4, max: 24 }],
+        },
+      ];
+      const result = resolveAbilities(highBase, bundles, NO_CHOICES);
+      expect(result.str.total).toBe(24);
+    });
+
+    it('low base score still gets the full amount', () => {
+      const lowBase = { ...BASE, str: 8 };
+      const bundles: GrantBundle[] = [
+        {
+          source: { origin: 'class', id: 'barbarian', level: 20 },
+          grants: [{ type: 'ability-score-increase', ability: 'str', amount: 4, max: 24 }],
+        },
+      ];
+      const result = resolveAbilities(lowBase, bundles, NO_CHOICES);
+      expect(result.str.total).toBe(12);
+    });
+
+    it('stacks additively with a player ASI on the same ability', () => {
+      const bundles: GrantBundle[] = [
+        {
+          source: { origin: 'class', id: 'fighter', level: 4 },
+          grants: [{ type: 'asi', key: 'asi:class:fighter:0', points: 2, from: null }],
+        },
+        {
+          source: { origin: 'class', id: 'barbarian', level: 20 },
+          grants: [{ type: 'ability-score-increase', ability: 'str', amount: 4, max: 24 }],
+        },
+      ];
+      const choices: Readonly<Record<ChoiceKey, ChoiceDecision>> = {
+        'asi:class:fighter:0': { type: 'asi', allocation: { str: 2 } },
+      };
+      const result = resolveAbilities(BASE, bundles, choices);
+      expect(result.str.total).toBe(16); // 10 + 2 (asi) + 4 (increase)
+    });
+
+    it('stacks with ASI on a high base and clamps at the raised max', () => {
+      const highBase = { ...BASE, str: 18 };
+      const bundles: GrantBundle[] = [
+        {
+          source: { origin: 'class', id: 'fighter', level: 4 },
+          grants: [{ type: 'asi', key: 'asi:class:fighter:0', points: 2, from: null }],
+        },
+        {
+          source: { origin: 'class', id: 'barbarian', level: 20 },
+          grants: [{ type: 'ability-score-increase', ability: 'str', amount: 4, max: 24 }],
+        },
+      ];
+      const choices: Readonly<Record<ChoiceKey, ChoiceDecision>> = {
+        'asi:class:fighter:0': { type: 'asi', allocation: { str: 2 } },
+      };
+      const result = resolveAbilities(highBase, bundles, choices);
+      expect(result.str.total).toBe(24); // raw 18 + 2 + 4 = 24, at cap
+    });
+
+    it('per-ability cap only raises the granted ability — other abilities still clamp at 20', () => {
+      const highBase = { ...BASE, str: 20, dex: 18 };
+      const bundles: GrantBundle[] = [
+        {
+          source: { origin: 'class', id: 'barbarian', level: 20 },
+          grants: [{ type: 'ability-score-increase', ability: 'str', amount: 4, max: 24 }],
+        },
+        {
+          source: { origin: 'species', id: 'human' },
+          grants: [{ type: 'ability-bonus', ability: 'dex', bonus: 5 }],
+        },
+      ];
+      const result = resolveAbilities(highBase, bundles, NO_CHOICES);
+      expect(result.str.total).toBe(24);
+      expect(result.dex.total).toBe(20); // raw 23, no raised cap for dex — clamps at 20
+    });
+
+    it('tracks bonus sources', () => {
+      const source = { origin: 'class' as const, id: 'barbarian' as const, level: 20 };
+      const bundles: GrantBundle[] = [
+        {
+          source,
+          grants: [{ type: 'ability-score-increase', ability: 'str', amount: 4, max: 24 }],
+        },
+      ];
+      const result = resolveAbilities(BASE, bundles, NO_CHOICES);
+      expect(result.str.bonuses).toHaveLength(1);
+      expect(result.str.bonuses[0].value).toBe(4);
+      expect(result.str.bonuses[0].source).toEqual(source);
+    });
+  });
 });

--- a/src/lib/resolver/abilities.test.ts
+++ b/src/lib/resolver/abilities.test.ts
@@ -534,5 +534,22 @@ describe('resolveAbilities', () => {
       expect(result.str.bonuses[0].value).toBe(4);
       expect(result.str.bonuses[0].source).toEqual(source);
     });
+
+    it('two increases on the same ability sum additively and use the higher of the two caps', () => {
+      const highBase = { ...BASE, str: 20 };
+      const bundles: GrantBundle[] = [
+        {
+          source: { origin: 'item', id: 'test-increase-source-1' },
+          grants: [{ type: 'ability-score-increase', ability: 'str', amount: 2, max: 22 }],
+        },
+        {
+          source: { origin: 'item', id: 'test-increase-source-2' },
+          grants: [{ type: 'ability-score-increase', ability: 'str', amount: 4, max: 24 }],
+        },
+      ];
+      const result = resolveAbilities(highBase, bundles, NO_CHOICES);
+      // raw 20 + 2 + 4 = 26, clamped to the higher of the two caps (24), not the lower (22)
+      expect(result.str.total).toBe(24);
+    });
   });
 });

--- a/src/lib/resolver/abilities.ts
+++ b/src/lib/resolver/abilities.ts
@@ -67,12 +67,19 @@ export function resolveAbilities(
     }
   }
 
+  const maxByAbility: Partial<Record<AbilityKey, number>> = {};
+  for (const { grant, source } of collectGrantsByType(bundles, 'ability-score-increase')) {
+    bonusList[grant.ability].push({ value: grant.amount, source });
+    maxByAbility[grant.ability] = Math.max(maxByAbility[grant.ability] ?? 20, grant.max);
+  }
+
   const result = {} as Record<AbilityKey, ResolvedAbility>;
   for (const key of keys) {
     const base = baseAbilities[key];
     const bonuses = bonusList[key];
     const rawTotal = base + bonuses.reduce((sum, b) => sum + b.value, 0);
-    const total = Math.min(rawTotal, 20);
+    const max = maxByAbility[key] ?? 20;
+    const total = Math.min(rawTotal, max);
     result[key] = {
       base,
       bonuses,

--- a/src/lib/sources/classes.test.ts
+++ b/src/lib/sources/classes.test.ts
@@ -508,6 +508,21 @@ describe('Barbarian class grant structures', () => {
       expect(grant.feature.id).toBe('barbarian-primal-champion');
     }
   });
+
+  // Regression for #303: Primal Champion also grants fixed +4 str/+4 con with a raised cap of 24.
+  it('level 20 has exactly two ability-score-increase grants for str and con, max 24', () => {
+    const increaseGrants = source?.levels[19].grants.filter((g) => g.type === 'ability-score-increase') ?? [];
+    expect(increaseGrants).toHaveLength(2);
+    for (const grant of increaseGrants) {
+      if (grant.type === 'ability-score-increase') {
+        expect(grant.amount).toBe(4);
+        expect(grant.max).toBe(24);
+      }
+    }
+    const abilities = increaseGrants.map((g) => (g.type === 'ability-score-increase' ? g.ability : null));
+    expect(abilities).toContain('str');
+    expect(abilities).toContain('con');
+  });
 });
 
 describe('Bard class grant structures', () => {

--- a/src/lib/sources/classes.ts
+++ b/src/lib/sources/classes.ts
@@ -157,7 +157,13 @@ export const CLASS_SOURCES: readonly ClassSource[] = [
           },
         ],
       },
-      { grants: [{ type: 'feature', feature: { id: 'barbarian-primal-champion' } }] },
+      {
+        grants: [
+          { type: 'feature', feature: { id: 'barbarian-primal-champion' } },
+          { type: 'ability-score-increase', ability: 'str', amount: 4, max: 24 },
+          { type: 'ability-score-increase', ability: 'con', amount: 4, max: 24 },
+        ],
+      },
     ],
   },
 

--- a/src/lib/sources/index.test.ts
+++ b/src/lib/sources/index.test.ts
@@ -1503,3 +1503,57 @@ describe('Aasimar Celestial Revelation by character level (#289, #301)', () => {
     }
   });
 });
+
+// Regression for #303: Barbarian Primal Champion's fixed +4 str/+4 con (cap 24) through the real
+// collectBundles → resolveCharacter seam, not just hand-built bundles.
+describe('level-20 Barbarian: Primal Champion fixed ability-score increases (#303)', () => {
+  const level20BarbarianBuild: CharacterBuild = {
+    speciesId: 'human' as SpeciesId,
+    backgroundId: 'soldier' as BackgroundId,
+    // Already at the normal cap so the raised max is the only thing that can move the total further.
+    baseAbilities: { str: 20, dex: 10, con: 20, int: 10, wis: 10, cha: 10 },
+    abilityMethod: 'standard-array',
+    levels: Array.from({ length: 20 }, (_, i) => ({
+      classId: 'barbarian' as ClassId,
+      classLevel: i + 1,
+      hpRoll: i === 0 ? null : 7,
+    })),
+    choices: {},
+    feats: [],
+    activeItems: [],
+  };
+
+  it('collectBundles includes the two ability-score-increase grants sourced from barbarian level 20', () => {
+    const { bundles } = collectBundles(level20BarbarianBuild);
+    const barbarianL20Bundle = bundles.find(
+      (b) => b.source.origin === 'class' && b.source.id === 'barbarian' && b.source.level === 20
+    );
+    expect(barbarianL20Bundle).toBeDefined();
+    const increaseGrants = barbarianL20Bundle?.grants.filter((g) => g.type === 'ability-score-increase') ?? [];
+    expect(increaseGrants).toHaveLength(2);
+    for (const grant of increaseGrants) {
+      if (grant.type === 'ability-score-increase') {
+        expect(grant.amount).toBe(4);
+        expect(grant.max).toBe(24);
+      }
+    }
+    const abilities = increaseGrants.map((g) => (g.type === 'ability-score-increase' ? g.ability : null));
+    expect(abilities).toContain('str');
+    expect(abilities).toContain('con');
+  });
+
+  it('resolveCharacter reflects the raised cap: str/con reach 24, dex stays unaffected', () => {
+    const { bundles, expandedFeats } = collectBundles(level20BarbarianBuild);
+    const result = resolveCharacter({
+      baseAbilities: level20BarbarianBuild.baseAbilities,
+      level: level20BarbarianBuild.levels.length,
+      bundles,
+      choices: level20BarbarianBuild.choices,
+      levels: level20BarbarianBuild.levels,
+      expandedFeats,
+    });
+    expect(result.abilities.str.total).toBe(24); // base 20 + 4, raised cap 24
+    expect(result.abilities.con.total).toBe(24); // base 20 + 4, raised cap 24
+    expect(result.abilities.dex.total).toBe(10); // unaffected
+  });
+});

--- a/src/types/grants.ts
+++ b/src/types/grants.ts
@@ -216,6 +216,14 @@ export interface AsiGrant {
   readonly from: readonly AbilityKey[] | null;
 }
 
+export interface AbilityScoreIncreaseGrant {
+  readonly type: 'ability-score-increase';
+  readonly ability: AbilityKey;
+  readonly amount: number;
+  /** Raised per-ability cap this increase enables (e.g. 24 for Barbarian Primal Champion). */
+  readonly max: number;
+}
+
 export interface FeatGrant {
   readonly type: 'feat';
   readonly featId: FeatId;
@@ -397,6 +405,7 @@ export type Grant =
   | SpellcastingGrant
   | SpellGrant
   | AsiGrant
+  | AbilityScoreIncreaseGrant
   | SubclassGrant
   | AbilityCheckBonusGrant
   | FightingStyleChoiceGrant


### PR DESCRIPTION
Closes #303

## Summary
Adds a new `AbilityScoreIncreaseGrant` grant type for fixed, non-player-allocated ability increases that raise the per-ability cap, and wires it to Barbarian's level-20 capstone **Primal Champion** (+4 Strength, +4 Constitution, max 24). The resolver's final clamp now consults a per-ability max override instead of a hardcoded 20.

## Audit
Verified against in-repo 2024 PHB descriptions: **only** Barbarian Primal Champion grants a fixed L20 ability increase. Druid/Sorcerer/Warlock/Wizard/Cleric L20 capstones and all 12 Epic Boon feats grant no fixed increases — none touched.

## What Changed
- `src/types/grants.ts` — new `AbilityScoreIncreaseGrant` in the `Grant` union.
- `src/lib/resolver/abilities.ts` — collect the new grant into `bonusList`; per-ability `maxByAbility` cap override; final clamp uses it (default 20).
- `src/lib/sources/classes.ts` — Barbarian L20 grants the two fixed increases alongside the feature.
- Tests: 8 new resolver unit tests + 1 data-wiring test.

## Testing
- [x] `npm run typecheck` clean
- [x] `npm run lint` clean
- [x] `npm run test` — 2430 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)